### PR TITLE
Scaling Prognostic Variables

### DIFF
--- a/src/models.jl
+++ b/src/models.jl
@@ -1,4 +1,4 @@
-abstract type ModelSetup{D} end
+abstract type ModelSetup{NF,D} end
 
 """
     M = BarotropicModel(::Parameters,
@@ -11,7 +11,7 @@ The BarotropicModel struct holds all other structs that contain precalculated co
 whether scalars or arrays that do not change throughout model integration. In contrast to
 `ShallowWaterModel` or `PrimitiveEquationModel` it does not contain a `Boundaries` struct
 as not needed."""
-struct BarotropicModel{NF<:AbstractFloat, D<:AbstractDevice} <: ModelSetup{D}
+struct BarotropicModel{NF<:AbstractFloat, D<:AbstractDevice} <: ModelSetup{NF,D}
     parameters::Parameters
     constants::Constants{NF}
     geometry::Geometry{NF}
@@ -32,7 +32,7 @@ has(::Type{BarotropicModel{NF,D}}, var_name::Symbol) where {NF,D} = var_name in 
 
 The ShallowWaterModel struct holds all other structs that contain precalculated constants, whether scalars or
 arrays that do not change throughout model integration."""
-struct ShallowWaterModel{NF<:AbstractFloat, D<:AbstractDevice} <: ModelSetup{D}
+struct ShallowWaterModel{NF<:AbstractFloat, D<:AbstractDevice} <: ModelSetup{NF,D}
     parameters::Parameters
     constants::Constants{NF}
     geometry::Geometry{NF}
@@ -57,7 +57,7 @@ has(::Type{ShallowWaterModel{NF,D}}, var_name::Symbol) where {NF,D} = var_name i
 
 The PrimitiveEquationModel struct holds all other structs that contain precalculated constants,
 whether scalars or arrays that do not change throughout model integration."""
-struct PrimitiveEquationModel{NF<:AbstractFloat,D<:AbstractDevice} <: ModelSetup{D}
+struct PrimitiveEquationModel{NF<:AbstractFloat,D<:AbstractDevice} <: ModelSetup{NF,D}
     parameters::Parameters
     constants::Constants{NF}
     geometry::Geometry{NF}
@@ -75,5 +75,5 @@ has(::Type{PrimitiveEquationModel{NF,D}}, var_name::Symbol) where {NF,D} = var_n
 
 Returns true if the model `M` has a prognostic variable `var_name`, false otherwise. The default fallback is that all variables are included. 
 """
-has(::Type{ModelSetup{D}}, var_name::Symbol) where D = var_name in [:vor, :div, :temp, :humid, :pres] 
+has(::Type{ModelSetup{NF,D}}, var_name::Symbol) where {NF,D} = var_name in [:vor, :div, :temp, :humid, :pres] 
 has(M::ModelSetup, var_name) = has(typeof(M), var_name)

--- a/src/output.jl
+++ b/src/output.jl
@@ -337,11 +337,6 @@ function write_restart_file(time::DateTime,
     @unpack run_path, write_restart = outputter
     write_restart || return nothing                 # exit immediately if no restart file desired
 
-    # unscale variables
-    #@unpack radius_earth = M.geometry
-    #scale!(progn,:vor,1/radius_earth)
-    #scale!(progn,:div,1/radius_earth)
-
     # COMPRESSION OF RESTART FILE
     @unpack keepbits = M.parameters
     for layer in progn.layers

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -51,3 +51,38 @@ function scale!(progn::PrognosticVariables{NF},
         end
     end
 end
+
+"""
+    scale!(progn::PrognosticVariables{NF}) where NF 
+
+Scales all variables within `progn` with the scale set when initializing it.
+"""
+function scale!(progn::PrognosticVariables{NF}) where NF 
+    for (var,scale) in progn.scale 
+        scale!(progn, var, scale)
+    end 
+end 
+
+"""
+    unscale!(progn::PrognosticVariables{NF}) where NF 
+
+Scales  all variables within `progn` with the inverse of scale set when initializing it.
+"""
+function unscale!(progn::PrognosticVariables{NF}) where NF 
+    for (var,scale) in progn.scale 
+        scale!(progn, var, inv(scale))
+    end
+end  
+
+"""
+    unscale(progn::PrognosticVariables{NF}) where NF 
+
+Scales all variables within `progn` with the inverse of scale set when initializing it.
+"""
+function unscale(progn::PrognosticVariables{NF}) where NF 
+    unscaled_progn = copy(progn)
+    for (var,scale) in progn.scale 
+        scale!(unscaled_progn, var, inv(scale))
+    end
+    return unscaled_progn
+end  

--- a/test/initialize.jl
+++ b/test/initialize.jl
@@ -4,7 +4,7 @@
         G = Geometry(P)
         S = SpectralTransform(P)
         
-        P = zeros(PrognosticVariables{NF},5,5,3)
+        P = zeros(PrognosticVariables{NF},5,5,3,SpeedyWeather.init_scale(NF))
         P = zeros(DiagnosticVariables,G,S)
     end
 end


### PR DESCRIPTION
Initial draft 

* Does only apply to prognostic variables, not diagnostic variables 
* Is not yet applied to the netCDF output 
* Still need to add some tests

* For future Float16, one could just add a similar scale field to the `PrognosticVariablesLayer` if that is needed per layer and this one keeps to be the global scale 