### PR TITLE
Add shortwave radiation parametrization

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,7 @@
 Copyright (c) 2021 Milan Kloewer
 
+Copyright (c) 2022 Fred Kucharski and Franco Molteni
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/docs/src/functions.md
+++ b/docs/src/functions.md
@@ -73,3 +73,12 @@ SpeedyWeather.timestep!
 SpeedyWeather.first_timesteps!
 SpeedyWeather.leapfrog!
 ```
+
+## Shortwave radiation
+```@docs
+SpeedyWeather.shortwave_radiation!
+SpeedyWeather.solar!
+SpeedyWeather.sol_oz!
+SpeedyWeather.cloud!
+SpeedyWeather.radsw!
+```

--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -102,6 +102,7 @@ module SpeedyWeather
     include("tendencies_parametrizations.jl")
     include("convection.jl")
     include("large_scale_condensation.jl")
+    include("shortwave_radiation.jl")
 
     include("time_integration.jl")
     include("pretty_printing.jl")

--- a/src/column_variables.jl
+++ b/src/column_variables.jl
@@ -58,32 +58,32 @@ to iterate over horizontal grid points. Every column vector has `nlev` entries, 
     precip_large_scale::NF = 0  # Precipitation due to large-scale condensation
 
     # Shortwave radiation: solar
-    tyear::NF = NaN
-    csol::NF = NaN
-    topsr::NF = NaN
+    tyear::NF = NF(NaN) # time as fraction of year (0-1, 0 = 1jan.h00)
+    csol::NF = NF(NaN)  # FIXME
+    topsr::NF = NF(NaN) # FIXME
     # Shortwave radiation: solar_oz
-    fsol::NF = NaN
-    ozupp::NF = NaN
-    ozone::NF = NaN
-    zenit::NF = NaN
-    stratz::NF = NaN
+    fsol::NF = NF(NaN)   # Flux of incoming solar radiation
+    ozupp::NF = NF(NaN)  # Flux absorbed by ozone (upper stratos.)
+    ozone::NF = NF(NaN)  # Flux absorbed by ozone (lower stratos.)
+    zenit::NF = NF(NaN)  # Optical depth ratio (function of solar zenith angle)
+    stratz::NF = NF(NaN) # Stratospheric correction for polar night
     # Shortwave radiation: radsw
-    albsfc::NF = NaN
-    ssrd::NF = NaN
-    ssr::NF = NaN
-    tsr::NF = NaN
-    tau2::Matrix{NF} = fill(NaN, nlev, 4)
-    tend_t_rsw::Vector{NF} = fill(NaN, nlev)
-    norm_pres::NF = NaN # Normalized pressure (p/1000 hPa)
+    albsfc::NF = NF(NaN) # Combined surface albedo (land + sea)
+    ssrd::NF = NF(NaN)   # Surface shortwave radiation (downward-only)
+    ssr::NF = NF(NaN)    # Surface shortwave radiation (net downward)
+    tsr::NF = NF(NaN)    # Top-of-atm. shortwave radiation (downward)
+    tau2::Matrix{NF} = fill(NF(NaN), nlev, 4) # Transmissivity of atmospheric layers
+    tend_t_rsw::Vector{NF} = fill(NF(NaN), nlev) # Tempterature tendency
+    norm_pres::NF = NF(NaN) # Normalized pressure (p/1000 hPa)
     # Shortwave radiation: cloud
-    icltop::Int = typemax(Int)
-    cloudc::NF = NaN
-    clstr::NF = NaN
-    qcloud::NF = NaN
-    fmask::NF = NaN
+    icltop::Int = typemax(Int) # Cloud top level (all clouds)
+    cloudc::NF = NF(NaN)       # Total cloud cover (fraction)
+    clstr::NF = NF(NaN)        # Stratiform cloud cover (fraction)
+    qcloud::NF = NF(NaN)       # Equivalent specific humidity of clouds
+    fmask::NF = NF(NaN)        # Fraction of land
     # Shortwave radiation: shortwave_radiation
-    rel_hum::Vector{NF} = fill(NaN, nlev)
-    grad_dry_static_energy::NF = NaN
+    rel_hum::Vector{NF} = fill(NF(NaN), nlev) # Relative humidity
+    grad_dry_static_energy::NF = NF(NaN)      # gradient of dry static energy
 end
 
 # use Float64 if not provided

--- a/src/column_variables.jl
+++ b/src/column_variables.jl
@@ -56,6 +56,34 @@ to iterate over horizontal grid points. Every column vector has `nlev` entries, 
 
     # Large-scale condensation
     precip_large_scale::NF = 0  # Precipitation due to large-scale condensation
+
+    # Shortwave radiation: solar
+    tyear::NF = NaN
+    csol::NF = NaN
+    topsr::NF = NaN
+    # Shortwave radiation: solar_oz
+    fsol::NF = NaN
+    ozupp::NF = NaN
+    ozone::NF = NaN
+    zenit::NF = NaN
+    stratz::NF = NaN
+    # Shortwave radiation: radsw
+    albsfc::NF = NaN
+    ssrd::NF = NaN
+    ssr::NF = NaN
+    tsr::NF = NaN
+    tau2::Matrix{NF} = fill(NaN, nlev, 4)
+    tend_t_rsw::Vector{NF} = fill(NaN, nlev)
+    norm_pres::NF = NaN # Normalized pressure (p/1000 hPa)
+    # Shortwave radiation: cloud
+    icltop::Int = typemax(Int)
+    cloudc::NF = NaN
+    clstr::NF = NaN
+    qcloud::NF = NaN
+    fmask::NF = NaN
+    # Shortwave radiation: shortwave_radiation
+    rel_hum::Vector{NF} = fill(NaN, nlev)
+    grad_dry_static_energy::NF = NaN
 end
 
 # use Float64 if not provided

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -35,6 +35,7 @@ The default values of the keywords define the default model setup.
                                         # specific humidity [g/Kg]
     alhs::Real=2801                     # latent heat of sublimation [?]
     sbc::Real=5.67e-8                   # stefan-Boltzmann constant [W/m^2/K^4]
+    p0::Real=1.e+5                      # Reference pressure (Pa)
 
     # STANDARD ATMOSPHERE
     lapse_rate::Real=6                  # reference temperature lapse rate -dT/dz [K/km]
@@ -86,6 +87,42 @@ The default values of the keywords define the default model setup.
     humid_relax_time_cnv::Real = 6.0        # Relaxation time for PBL humidity (hours)
     max_entrainment::Real = 0.5             # Maximum entrainment as a fraction of cloud-base mass flux
     ratio_secondary_mass_flux::Real = 0.8   # Ratio between secondary and primary mass flux at cloud-base
+
+    # Shortwave radiation: sol_oz
+    solc::Real = 342.0 ## Solar constant (area averaged) in W / m^2
+    epssw::Real = 0.020 ## Fraction of incoming solar radiation absorbed by ozone
+
+    # Shortwave radiation: cloud
+    rhcl1::Real = 0.30 # Relative humidity threshold corresponding to cloud cover = 0
+    rhcl2::Real = 1.00 # Relative humidity correponding to cloud cover = 1
+    rrcl::Real = 1.0 / (rhcl2 - rhcl1)
+    qcl::Real = 0.20 # Specific humidity threshold for cloud cover
+    pmaxcl::Real = 10.0 # Maximum value of precipitation (mm/day) contributing to cloud cover
+    wpcl::Real = 0.2  # Cloud cover weight for the square-root of precipitation (for p = 1 mm/day)
+    gse_s1::Real = 0.40 # Gradient of dry static energy corresponding to stratiform cloud cover = 1
+    gse_s0::Real = 0.25 # Gradient of dry static energy corresponding to stratiform cloud cover = 0
+    clsmax::Real = 0.60 # Maximum stratiform cloud cover
+    clsminl::Real = 0.15 # Minimum stratiform cloud cover over land (for RH = 1)
+
+    # Shortwave radiation: radsw
+    albcl::Real = 0.43  # Cloud albedo (for cloud cover = 1)
+    albcls::Real = 0.50  # Stratiform cloud albedo (for st. cloud cover = 1)
+    abscl1::Real = 0.015 # Absorptivity of clouds (visible band, maximum value)
+    abscl2::Real = 0.15  # Absorptivity of clouds (visible band, for dq_base = 1 g/kg)
+
+    absdry::Real = 0.033 # Absorptivity of dry air (visible band)
+    absaer::Real = 0.033 # Absorptivity of aerosols (visible band)
+    abswv1::Real = 0.022 # Absorptivity of water vapour (visible band, for dq = 1 g/kg)
+    abswv2::Real = 15.0  # Absorptivity of water vapour (near IR band, for dq = 1 g/kg)
+
+    ablwin::Real = 0.3   # Absorptivity of air in "window" band
+    ablco2::Real = 6.0   # Absorptivity of air in CO2 band
+    ablwv1::Real = 0.7   # Absorptivity of water vapour in H2O band 1 (weak), (for dq = 1 g/kg)
+    ablwv2::Real = 50.0   # Absorptivity of water vapour in H2O band 2 (strong), (for dq = 1 g/kg)
+    ablcl2::Real = 0.6   # Absorptivity of "thin" upper clouds in window and H2O bands
+    ablcl1::Real = 12.0   # Absorptivity of "thick" clouds in window band (below cloud top)
+    epslw::Real = 0.05    # Fraction of blackbody spectrum absorbed/emitted by PBL only
+
 
     # TIME STEPPING
     startdate::DateTime = DateTime(2000,1,1)# time at which the integration starts

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -35,7 +35,6 @@ The default values of the keywords define the default model setup.
                                         # specific humidity [g/Kg]
     alhs::Real=2801                     # latent heat of sublimation [?]
     sbc::Real=5.67e-8                   # stefan-Boltzmann constant [W/m^2/K^4]
-    p0::Real=1.e+5                      # Reference pressure (Pa)
 
     # STANDARD ATMOSPHERE
     lapse_rate::Real=6                  # reference temperature lapse rate -dT/dz [K/km]

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -88,41 +88,8 @@ The default values of the keywords define the default model setup.
     max_entrainment::Real = 0.5             # Maximum entrainment as a fraction of cloud-base mass flux
     ratio_secondary_mass_flux::Real = 0.8   # Ratio between secondary and primary mass flux at cloud-base
 
-    # Shortwave radiation: sol_oz
-    solc::Real = 342.0 # Solar constant (area averaged) in W / m^2
-    epssw::Real = 0.020 # Fraction of incoming solar radiation absorbed by ozone
-
-    # Shortwave radiation: cloud
-    rhcl1::Real = 0.30 # Relative humidity threshold corresponding to cloud cover = 0
-    rhcl2::Real = 1.00 # Relative humidity correponding to cloud cover = 1
-    rrcl::Real = 1 / (rhcl2 - rhcl1)
-    qcl::Real = 0.20 # Specific humidity threshold for cloud cover
-    pmaxcl::Real = 10.0 # Maximum value of precipitation (mm/day) contributing to cloud cover
-    wpcl::Real = 0.2  # Cloud cover weight for the square-root of precipitation (for p = 1 mm/day)
-    gse_s1::Real = 0.40 # Gradient of dry static energy corresponding to stratiform cloud cover = 1
-    gse_s0::Real = 0.25 # Gradient of dry static energy corresponding to stratiform cloud cover = 0
-    clsmax::Real = 0.60 # Maximum stratiform cloud cover
-    clsminl::Real = 0.15 # Minimum stratiform cloud cover over land (for RH = 1)
-
-    # Shortwave radiation: radsw
-    albcl::Real = 0.43  # Cloud albedo (for cloud cover = 1)
-    albcls::Real = 0.50  # Stratiform cloud albedo (for st. cloud cover = 1)
-    abscl1::Real = 0.015 # Absorptivity of clouds (visible band, maximum value)
-    abscl2::Real = 0.15  # Absorptivity of clouds (visible band, for dq_base = 1 g/kg)
-
-    absdry::Real = 0.033 # Absorptivity of dry air (visible band)
-    absaer::Real = 0.033 # Absorptivity of aerosols (visible band)
-    abswv1::Real = 0.022 # Absorptivity of water vapour (visible band, for dq = 1 g/kg)
-    abswv2::Real = 15.0  # Absorptivity of water vapour (near IR band, for dq = 1 g/kg)
-
-    ablwin::Real = 0.3   # Absorptivity of air in "window" band
-    ablco2::Real = 6.0   # Absorptivity of air in CO2 band
-    ablwv1::Real = 0.7   # Absorptivity of water vapour in H2O band 1 (weak), (for dq = 1 g/kg)
-    ablwv2::Real = 50.0   # Absorptivity of water vapour in H2O band 2 (strong), (for dq = 1 g/kg)
-    ablcl2::Real = 0.6   # Absorptivity of "thin" upper clouds in window and H2O bands
-    ablcl1::Real = 12.0   # Absorptivity of "thick" clouds in window band (below cloud top)
-    epslw::Real = 0.05    # Fraction of blackbody spectrum absorbed/emitted by PBL only
-
+    # Radiation
+    radiation_coefs::RadiationCoefs = RadiationCoefs{NF}()
 
     # TIME STEPPING
     startdate::DateTime = DateTime(2000,1,1)# time at which the integration starts

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -89,13 +89,13 @@ The default values of the keywords define the default model setup.
     ratio_secondary_mass_flux::Real = 0.8   # Ratio between secondary and primary mass flux at cloud-base
 
     # Shortwave radiation: sol_oz
-    solc::Real = 342.0 ## Solar constant (area averaged) in W / m^2
-    epssw::Real = 0.020 ## Fraction of incoming solar radiation absorbed by ozone
+    solc::Real = 342.0 # Solar constant (area averaged) in W / m^2
+    epssw::Real = 0.020 # Fraction of incoming solar radiation absorbed by ozone
 
     # Shortwave radiation: cloud
     rhcl1::Real = 0.30 # Relative humidity threshold corresponding to cloud cover = 0
     rhcl2::Real = 1.00 # Relative humidity correponding to cloud cover = 1
-    rrcl::Real = 1.0 / (rhcl2 - rhcl1)
+    rrcl::Real = 1 / (rhcl2 - rhcl1)
     qcl::Real = 0.20 # Specific humidity threshold for cloud cover
     pmaxcl::Real = 10.0 # Maximum value of precipitation (mm/day) contributing to cloud cover
     wpcl::Real = 0.2  # Cloud cover weight for the square-root of precipitation (for p = 1 mm/day)

--- a/src/parameter_structs.jl
+++ b/src/parameter_structs.jl
@@ -33,3 +33,43 @@ Parameters for computing saturation vapour pressure using the August-Roche-Magnu
     C₁::NF = 17.269
     C₂::NF = 21.875
 end
+
+"""
+Parameters for radiation parameterizations.
+"""
+@with_kw struct RadiationCoefs{NF<:Real} <: Coefficients
+        # Shortwave radiation: sol_oz
+        solc::NF = 342.0    # Solar constant (area averaged) [W/m^2]
+        epssw::NF = 0.020   # Fraction of incoming solar radiation absorbed by ozone
+    
+        # Shortwave radiation: cloud
+        rhcl1::NF = 0.30    # Relative humidity threshold corresponding to cloud cover = 0
+        rhcl2::NF = 1.00    # Relative humidity correponding to cloud cover = 1
+        rrcl::NF = 1 / (rhcl2 - rhcl1)
+        qcl::NF = 0.20      # Specific humidity threshold for cloud cover
+        pmaxcl::NF = 10.0   # Maximum value of precipitation (mm/day) contributing to cloud cover
+        wpcl::NF = 0.2      # Cloud cover weight for the square-root of precipitation (for p = 1 mm/day)
+        gse_s1::NF = 0.40   # Gradient of dry static energy corresponding to stratiform cloud cover = 1
+        gse_s0::NF = 0.25   # Gradient of dry static energy corresponding to stratiform cloud cover = 0
+        clsmax::NF = 0.60   # Maximum stratiform cloud cover
+        clsminl::NF = 0.15  # Minimum stratiform cloud cover over land (for RH = 1)
+    
+        # Shortwave radiation: radsw
+        albcl::NF = 0.43    # Cloud albedo (for cloud cover = 1)
+        albcls::NF = 0.50   # Stratiform cloud albedo (for st. cloud cover = 1)
+        abscl1::NF = 0.015  # Absorptivity of clouds (visible band, maximum value)
+        abscl2::NF = 0.15   # Absorptivity of clouds (visible band, for dq_base = 1 g/kg)
+    
+        absdry::NF = 0.033  # Absorptivity of dry air (visible band)
+        absaer::NF = 0.033  # Absorptivity of aerosols (visible band)
+        abswv1::NF = 0.022  # Absorptivity of water vapour (visible band, for dq = 1 g/kg)
+        abswv2::NF = 15.0   # Absorptivity of water vapour (near IR band, for dq = 1 g/kg)
+    
+        ablwin::NF = 0.3    # Absorptivity of air in "window" band
+        ablco2::NF = 6.0    # Absorptivity of air in CO2 band
+        ablwv1::NF = 0.7    # Absorptivity of water vapour in H2O band 1 (weak), (for dq = 1 g/kg)
+        ablwv2::NF = 50.0   # Absorptivity of water vapour in H2O band 2 (strong), (for dq = 1 g/kg)
+        ablcl2::NF = 0.6    # Absorptivity of "thin" upper clouds in window and H2O bands
+        ablcl1::NF = 12.0   # Absorptivity of "thick" clouds in window band (below cloud top)
+        epslw::NF = 0.05    # Fraction of blackbody spectrum absorbed/emitted by PBL only
+end    

--- a/src/parameter_structs.jl
+++ b/src/parameter_structs.jl
@@ -38,6 +38,9 @@ end
 Parameters for radiation parameterizations.
 """
 @with_kw struct RadiationCoefs{NF<:Real} <: Coefficients
+
+        p0::Real = 1e5      # Reference pressure (Pa)
+
         # Shortwave radiation: sol_oz
         solc::NF = 342.0    # Solar constant (area averaged) [W/m^2]
         epssw::NF = 0.020   # Fraction of incoming solar radiation absorbed by ozone

--- a/src/shortwave_radiation.jl
+++ b/src/shortwave_radiation.jl
@@ -200,7 +200,7 @@ Compute shortwave radiation fluxes for an atmospheric column.
 function radsw!(
     column::ColumnVariables{NF}, model::PrimitiveEquationModel
 ) where {NF<:AbstractFloat}
-    @unpack norm_pres, humid, icltop, cloudc, clstr, ozupp, ozone
+    @unpack norm_pres, humid, icltop, cloudc, clstr, ozupp, ozone = column
     @unpack zenit, stratz, fsol, qcloud, albsfc, nlev = column
     @unpack σ_levels_full, σ_levels_thick, n_stratosphere_levels = model.geometry
     @unpack albcl, albcls, abscl1, abscl2, absdry, absaer = model.parameters.radiation_coefs

--- a/src/shortwave_radiation.jl
+++ b/src/shortwave_radiation.jl
@@ -10,7 +10,8 @@ function shortwave_radiation!(
     column::ColumnVariables{NF}, model::PrimitiveEquationModel
 ) where {NF<:AbstractFloat}
     @unpack humid, sat_vap_pres, dry_static_energy, geopot, norm_pres = column
-    @unpack cp, p0 = model.parameters.radiation_coefs
+    @unpack cp = model.parameters
+    @unpack p0 = model.parameters.radiation_coefs
     @unpack σ_levels_thick = model.geometry
     @unpack gravity = model.constants
 

--- a/src/shortwave_radiation.jl
+++ b/src/shortwave_radiation.jl
@@ -16,19 +16,19 @@ function shortwave_radiation!(
 
     sol_oz!(column, model)
 
-    column.rel_hum = humid ./ sat_vap_pres
-    column.grad_dry_static_energy =
-        (dry_static_energy[end - 1] - dry_static_energy[end]) ./
+    column.rel_hum .= humid ./ sat_vap_pres
+    column.grad_dry_static_energy = 
+        (dry_static_energy[end - 1] - dry_static_energy[end]) /
         (geopot[end - 1] - geopot[end])
     cloud!(column, model)
 
     radsw!(column, model)
 
-    prog_sp_inv = 1.0 / norm_pres
-    grdsig = gravity ./ (σ_levels_thick .* p0)
-
     for k in eachlayer(column)
-        column.temp_tend[k] += column.tend_t_rsw[k] * prog_sp_inv * grdsig[k] / cp
+        column.temp_tend[k] += 
+            column.tend_t_rsw[k] * inv(norm_pres) *
+            (gravity / (σ_levels_thick[k] * p0)) /
+            cp
     end
 end
 
@@ -42,25 +42,25 @@ function solar!(column::ColumnVariables{NF}) where {NF<:AbstractFloat}
     @unpack tyear, csol, lat = column
 
     # Compute cosine and sine of latitude
-    clat = cos(lat * π / 180.0)
-    slat = sin(lat * π / 180.0)
+    clat = cos(lat * π / 180)
+    slat = sin(lat * π / 180)
 
     # 1.0 Compute declination angle and Earth - Sun distance factor
-    pigr = 2.0 * asin(1.0)
-    α = 2.0 * pigr * tyear
+    pigr = 2 * asin(1)
+    α = 2 * pigr * tyear
 
     ca1 = cos(α)
     sa1 = sin(α)
     ca2 = ca1 * ca1 - sa1 * sa1
-    sa2 = 2.0 * sa1 * ca1
+    sa2 = 2 * sa1 * ca1
     ca3 = ca1 * ca2 - sa1 * sa2
     sa3 = sa1 * ca2 + sa2 * ca1
 
     decl =
-        0.006918 - 0.399912 * ca1 + 0.070257 * sa1 - 0.006758 * ca2 + 0.000907 * sa2 -
-        0.002697 * ca3 + 0.001480 * sa3
+        NF(0.006918) - NF(0.399912) * ca1 + NF(0.070257) * sa1 - NF(0.006758) * ca2 + NF(0.000907) * sa2 -
+        NF(0.002697) * ca3 + NF(0.001480) * sa3
 
-    fdis = 1.000110 + 0.034221 * ca1 + 0.001280 * sa1 + 0.000719 * ca2 + 0.000077 * sa2
+    fdis = NF(1.000110) + NF(0.034221) * ca1 + NF(0.001280) * sa1 + NF(0.000719) * ca2 + NF(0.000077) * sa2
 
     cdecl = cos(decl)
     sdecl = sin(decl)
@@ -69,7 +69,7 @@ function solar!(column::ColumnVariables{NF}) where {NF<:AbstractFloat}
     # 2.0 Compute daily - average insolation at the atm. top
     csolp = csol / pigr
 
-    ch0 = min(1.0, max(-1.0, -tdecl * slat / clat))
+    ch0 = min(1, max(-1, -tdecl * slat / clat))
     h0 = acos(ch0)
     sh0 = sin(h0)
 
@@ -87,47 +87,47 @@ function sol_oz!(
     column::ColumnVariables{NF}, model::PrimitiveEquationModel
 ) where {NF<:AbstractFloat}
     @unpack tyear, lat = column
-    @unpack solc, epssw = model.parameters
+    @unpack solc, epssw, tropic_cancer = model.parameters
 
     # Compute cosine and sine of latitude
-    clat = cos(lat * π / 180.0)
-    slat = sin(lat * π / 180.0)
+    clat = cos(lat * π / 180)
+    slat = sin(lat * π / 180)
 
     # α = year phase ( 0 - 2pi, 0 = winter solstice = 22dec.h00 )
-    α = 4.0 * asin(1.0) * (tyear + 10.0 / 365.0)
-    dα = 0.0
+    α = 4 * asin(1) * (tyear + 10 / 365)
+    dα = NF(0.)
 
-    coz1 = 1.0 * max(0.0, cos(α - dα))
-    coz2 = 1.8
-    azen = 1.0
+    coz1 = 1 * max(0, cos(α - dα))
+    coz2 = NF(1.8)
+    azen = 1
     nzen = 2
 
-    rzen = -cos(α) * 23.45 * asin(1.0) / 90.0
+    rzen = -cos(α) * NF(23.45) * asin(1.0) / 90
     czen = cos(rzen)
     szen = sin(rzen)
 
-    fs0 = 6.0
+    fs0 = 6
 
     # Solar radiation at the top
-    column.csol = 4.0 * solc
+    column.csol = 4 * solc
     column.topsr = solar!(column)
     column.fsol = column.topsr
 
-    flat2 = 1.5 * slat^2 - 0.5
+    flat2 = NF(1.5) * slat^2 - NF(0.5)
 
     # Ozone depth in upper and lower stratosphere
-    column.ozupp = 0.5 * epssw
-    column.ozone = 0.4 * epssw * (1.0 + coz1 * slat + coz2 * flat2)
+    column.ozupp = NF(0.5) * epssw
+    column.ozone = NF(0.4) * epssw * (1 + coz1 * slat + coz2 * flat2)
 
     # Zenith angle correction to (downward) absorptivity
-    column.zenit = 1.0 + azen * (1.0 - (clat * czen + slat * szen))^nzen
+    column.zenit = 1 + azen * (1 - (clat * czen + slat * szen))^nzen
 
     # Ozone absorption in upper and lower stratosphere
     column.ozupp = column.fsol * column.ozupp * column.zenit
     column.ozone = column.fsol * column.ozone * column.zenit
 
     # Polar night cooling in the stratosphere
-    column.stratz = max(fs0 - column.fsol, 0.0)
+    column.stratz = max(fs0 - column.fsol, 0)
 end
 
 """
@@ -157,7 +157,7 @@ function cloud!(
         column.cloudc = rel_hum[nlev - 1] - rhcl1
         column.icltop = nlev - 1
     else
-        column.cloudc = 0.0
+        column.cloudc = NF(0.)
         column.icltop = nlev + 1
     end
 
@@ -169,20 +169,20 @@ function cloud!(
         end
     end
 
-    pr1 = min(pmaxcl, 86.4 * (precip_convection + precip_large_scale))
-    column.cloudc = min(1.0, wpcl * sqrt(pr1) + min(1.0, column.cloudc * rrcl)^2.0)
+    pr1 = min(pmaxcl, NF(86.4) * (precip_convection + precip_large_scale))
+    column.cloudc = min(1, wpcl * sqrt(pr1) + min(1, column.cloudc * rrcl)^2)
     column.icltop = min(cloud_top, column.icltop)
 
     # 2.0  Equivalent specific humidity of clouds
     column.qcloud = humid[nlev - 1]
 
     # 3.0 Stratiform clouds at the top of pbl
-    clfact = 1.2
-    rgse = 1.0 / (gse_s1 - gse_s0)
+    clfact = NF(1.2)
+    rgse = 1 / (gse_s1 - gse_s0)
 
     # Stratocumulus clouds over sea
-    fstab = max(0.0, min(1.0, rgse * (grad_dry_static_energy - gse_s0)))
-    column.clstr = fstab * max(clsmax - clfact * column.cloudc, 0.0)
+    fstab = max(0, min(1, rgse * (grad_dry_static_energy - gse_s0)))
+    column.clstr = fstab * max(clsmax - clfact * column.cloudc, 0)
 
     # Stratocumulus clouds over land
     clstrl = max(column.clstr, clsminl) * rel_hum[nlev]
@@ -202,19 +202,20 @@ function radsw!(
     @unpack norm_pres,
     humid, icltop, cloudc, clstr, ozupp, ozone, zenit, stratz, fsol, qcloud, albsfc,
         nlev = column
-    @unpack σ_levels_full, σ_levels_thick = model.geometry
+    @unpack σ_levels_full, σ_levels_thick, n_stratosphere_levels = model.geometry
 
     @unpack albcl, albcls, abscl1, abscl2, absdry, absaer, abswv1, abswv2, ablwin, ablco2, ablwv1,
         ablwv2, ablcl2, ablcl1, epslw = model.parameters
 
     # Locals variables
-    flux::Vector{NF} = fill(NaN, 2)
-    stratc::Vector{NF} = fill(NaN, 2)
+    sbands_flux = 2
+    flux::Vector{NF} = fill(NaN, sbands_flux)
+    stratc::Vector{NF} = fill(NaN, n_stratosphere_levels)
 
     nl1 = nlev - 1
 
-    fband2 = 0.05
-    fband1 = 1.0 - fband2
+    fband2 = NF(0.05)
+    fband1 = 1 - fband2
 
     # 1.0 Initialization
     column.tau2 = fill!(column.tau2, 0)
@@ -234,7 +235,7 @@ function radsw!(
     deltap = psaz * σ_levels_thick[1]
     column.tau2[1, 1] = exp(-deltap * absdry)
 
-    for k in 2:nl1
+    for k in n_stratosphere_levels:nl1
         abs1 = absdry + absaer * σ_levels_full[k]^2
         deltap = psaz * σ_levels_thick[k]
         if (k >= icltop)
@@ -248,7 +249,7 @@ function radsw!(
     deltap = psaz * σ_levels_thick[nlev]
     column.tau2[nlev, 1] = exp(-deltap * (abs1 + abswv1 * humid[nlev]))
 
-    for k in 2:nlev
+    for k in n_stratosphere_levels:nlev
         deltap = psaz * σ_levels_thick[k]
         column.tau2[k, 2] = exp(-deltap * abswv2 * humid[k])
     end
@@ -260,18 +261,15 @@ function radsw!(
     flux[2] = fsol * fband2
 
     # 3.2 Ozone and dry - air absorption in the stratosphere
-    k = 1
-    column.tend_t_rsw[k] = flux[1]
-    flux[1] = column.tau2[k, 1] * (flux[1] - ozupp * norm_pres)
-    column.tend_t_rsw[k] = column.tend_t_rsw[k] - flux[1]
-
-    k = 2
-    column.tend_t_rsw[k] = flux[1]
-    flux[1] = column.tau2[k, 1] * (flux[1] - ozone * norm_pres)
-    column.tend_t_rsw[k] = column.tend_t_rsw[k] - flux[1]
-
+    for k in 1:n_stratosphere_levels
+        if k == 1 ozone_tmp = ozupp else ozone_tmp = ozone end
+        column.tend_t_rsw[k] = flux[1]
+        flux[1] = column.tau2[k, 1] * (flux[1] - ozone_tmp * norm_pres)
+        column.tend_t_rsw[k] = column.tend_t_rsw[k] - flux[1]
+    end
+    
     # 3.3  Absorption and reflection in the troposphere
-    for k in 3:nlev
+    for k in n_stratosphere_levels+1:nlev
         column.tau2[k, 3] = flux[1] * column.tau2[k, 3]
         flux[1] = flux[1] - column.tau2[k, 3]
         column.tend_t_rsw[k] = flux[1]
@@ -279,7 +277,7 @@ function radsw!(
         column.tend_t_rsw[k] = column.tend_t_rsw[k] - flux[1]
     end
 
-    for k in 2:nlev
+    for k in n_stratosphere_levels:nlev
         column.tend_t_rsw[k] = column.tend_t_rsw[k] + flux[2]
         flux[2] = column.tau2[k, 2] * flux[2]
         column.tend_t_rsw[k] = column.tend_t_rsw[k] - flux[2]
@@ -311,10 +309,10 @@ function radsw!(
     deltap = norm_pres * σ_levels_thick[k]
     column.tau2[k, 1] = exp(-deltap * ablwin)
     column.tau2[k, 2] = exp(-deltap * ablco2)
-    column.tau2[k, 3] = 1.0
-    column.tau2[k, 4] = 1.0
+    column.tau2[k, 3] = 1.
+    column.tau2[k, 4] = 1.
 
-    for k in 2:(nlev - 2):nlev
+    for k in n_stratosphere_levels:(nlev - n_stratosphere_levels):nlev
         deltap = norm_pres * σ_levels_thick[k]
         column.tau2[k, 1] = exp(-deltap * ablwin)
         column.tau2[k, 2] = exp(-deltap * ablco2)
@@ -325,7 +323,7 @@ function radsw!(
     # Cloudy layers (free troposphere)
     acloud = cloudc * ablcl2
 
-    for k in 3:nl1
+    for k in n_stratosphere_levels+1:nl1
         deltap = norm_pres * σ_levels_thick[k]
         if (k < icltop)
             acloud1 = acloud
@@ -339,7 +337,9 @@ function radsw!(
     end
 
     # 5.2  Stratospheric correction terms
-    eps1 = epslw / (σ_levels_thick[1] + σ_levels_thick[2])
     stratc[1] = stratz * norm_pres
-    stratc[2] = eps1 * norm_pres
+    for k in 2:n_stratosphere_levels
+        eps1 = epslw / (σ_levels_thick[k-1] + σ_levels_thick[k])
+        stratc[k] = eps1 * norm_pres
+    end
 end

--- a/src/shortwave_radiation.jl
+++ b/src/shortwave_radiation.jl
@@ -146,6 +146,7 @@ function cloud!(
     @unpack wpcl, gse_s1, gse_s0, clsmax, clsminl = model.parameters.radiation_coefs
     @unpack humid, rel_hum, grad_dry_static_energy, precip_convection = column
     @unpack precip_large_scale, cloud_top, nlev, fmask = column
+    @unpack n_stratosphere_levels = model.geometry
 
     # 1.0 Cloud cover, defined as the sum of:
     # - a term proportional to the square - root of precip. rate
@@ -163,7 +164,7 @@ function cloud!(
         column.icltop = nlev + 1
     end
 
-    for k in 3:(nlev - 2)   # TODO use n_stratospheric_levels
+    for k in n_stratosphere_levels+1:(nlev - n_stratosphere_levels)
         drh = rel_hum[k] - rhcl1
         if (drh > column.cloudc) & (humid[k] > qcl)
             column.cloudc = drh

--- a/src/shortwave_radiation.jl
+++ b/src/shortwave_radiation.jl
@@ -1,0 +1,345 @@
+"""
+    function shortwave_radiation!(
+        column::ColumnVariables{NF}, model::PrimitiveEquationModel
+    )
+
+Compute air temperature tendencies from shortwave radiation for an atmospheric column.
+For more details see http://users.ictp.it/~kucharsk/speedy_description/km_ver41_appendixA.pdf
+"""
+function shortwave_radiation!(
+    column::ColumnVariables{NF}, model::PrimitiveEquationModel
+) where {NF<:AbstractFloat}
+    @unpack humid, sat_vap_pres, dry_static_energy, geopot, norm_pres = column
+    @unpack cp, p0, = model.parameters
+    @unpack σ_levels_thick = model.geometry
+    @unpack gravity = model.constants
+
+    sol_oz!(column, model)
+
+    column.rel_hum = humid ./ sat_vap_pres
+    column.grad_dry_static_energy =
+        (dry_static_energy[end - 1] - dry_static_energy[end]) ./
+        (geopot[end - 1] - geopot[end])
+    cloud!(column, model)
+
+    radsw!(column, model)
+
+    prog_sp_inv = 1.0 / norm_pres
+    grdsig = gravity ./ (σ_levels_thick .* p0)
+
+    for k in eachlayer(column)
+        column.temp_tend[k] += column.tend_t_rsw[k] * prog_sp_inv * grdsig[k] / cp
+    end
+end
+
+"""
+    function solar!(column::ColumnVariables{NF})
+
+Compute average daily flux of solar radiation for an atmospheric column,
+from Hartmann (1994).
+"""
+function solar!(column::ColumnVariables{NF}) where {NF<:AbstractFloat}
+    @unpack tyear, csol, lat = column
+
+    # Compute cosine and sine of latitude
+    clat = cos(lat * π / 180.0)
+    slat = sin(lat * π / 180.0)
+
+    # 1.0 Compute declination angle and Earth - Sun distance factor
+    pigr = 2.0 * asin(1.0)
+    α = 2.0 * pigr * tyear
+
+    ca1 = cos(α)
+    sa1 = sin(α)
+    ca2 = ca1 * ca1 - sa1 * sa1
+    sa2 = 2.0 * sa1 * ca1
+    ca3 = ca1 * ca2 - sa1 * sa2
+    sa3 = sa1 * ca2 + sa2 * ca1
+
+    decl =
+        0.006918 - 0.399912 * ca1 + 0.070257 * sa1 - 0.006758 * ca2 + 0.000907 * sa2 -
+        0.002697 * ca3 + 0.001480 * sa3
+
+    fdis = 1.000110 + 0.034221 * ca1 + 0.001280 * sa1 + 0.000719 * ca2 + 0.000077 * sa2
+
+    cdecl = cos(decl)
+    sdecl = sin(decl)
+    tdecl = sdecl / cdecl
+
+    # 2.0 Compute daily - average insolation at the atm. top
+    csolp = csol / pigr
+
+    ch0 = min(1.0, max(-1.0, -tdecl * slat / clat))
+    h0 = acos(ch0)
+    sh0 = sin(h0)
+
+    column.topsr = csolp * fdis * (h0 * slat * sdecl + sh0 * clat * cdecl)
+end
+
+"""
+    function sol_oz!(
+        column::ColumnVariables{NF}, model::PrimitiveEquationModel
+    )
+
+Compute solar radiation parametres for an atmospheric column.
+"""
+function sol_oz!(
+    column::ColumnVariables{NF}, model::PrimitiveEquationModel
+) where {NF<:AbstractFloat}
+    @unpack tyear, lat = column
+    @unpack solc, epssw = model.parameters
+
+    # Compute cosine and sine of latitude
+    clat = cos(lat * π / 180.0)
+    slat = sin(lat * π / 180.0)
+
+    # α = year phase ( 0 - 2pi, 0 = winter solstice = 22dec.h00 )
+    α = 4.0 * asin(1.0) * (tyear + 10.0 / 365.0)
+    dα = 0.0
+
+    coz1 = 1.0 * max(0.0, cos(α - dα))
+    coz2 = 1.8
+    azen = 1.0
+    nzen = 2
+
+    rzen = -cos(α) * 23.45 * asin(1.0) / 90.0
+    czen = cos(rzen)
+    szen = sin(rzen)
+
+    fs0 = 6.0
+
+    # Solar radiation at the top
+    column.csol = 4.0 * solc
+    column.topsr = solar!(column)
+    column.fsol = column.topsr
+
+    flat2 = 1.5 * slat^2 - 0.5
+
+    # Ozone depth in upper and lower stratosphere
+    column.ozupp = 0.5 * epssw
+    column.ozone = 0.4 * epssw * (1.0 + coz1 * slat + coz2 * flat2)
+
+    # Zenith angle correction to (downward) absorptivity
+    column.zenit = 1.0 + azen * (1.0 - (clat * czen + slat * szen))^nzen
+
+    # Ozone absorption in upper and lower stratosphere
+    column.ozupp = column.fsol * column.ozupp * column.zenit
+    column.ozone = column.fsol * column.ozone * column.zenit
+
+    # Polar night cooling in the stratosphere
+    column.stratz = max(fs0 - column.fsol, 0.0)
+end
+
+"""
+    function cloud!(
+        column::ColumnVariables{NF}, model::PrimitiveEquationModel
+    )
+
+Compute shortwave radiation cloud contibutions for an atmospheric column.
+"""
+function cloud!(
+    column::ColumnVariables{NF}, model::PrimitiveEquationModel
+) where {NF<:AbstractFloat}
+    @unpack rhcl1, rhcl2, rrcl, qcl, pmaxcl, wpcl, gse_s1, gse_s0, clsmax, clsminl =
+        model.parameters
+    @unpack humid, rel_hum, grad_dry_static_energy, precip_convection, precip_large_scale,
+        cloud_top, nlev, fmask = column
+
+    # 1.0 Cloud cover, defined as the sum of:
+    # - a term proportional to the square - root of precip. rate
+    # - a quadratic function of the max. relative humidity
+    #    in tropospheric layers above pbl where q > prog_qcl :
+    #     ( = 0 for rhmax < rhcl1, = 1 for rhmax > rhcl2 )
+    #    Cloud - top level: defined as the highest (i.e. least sigma)
+    #      between the top of convection / condensation and
+    #      the level of maximum relative humidity.
+    if (rel_hum[nlev - 1] > rhcl1)
+        column.cloudc = rel_hum[nlev - 1] - rhcl1
+        column.icltop = nlev - 1
+    else
+        column.cloudc = 0.0
+        column.icltop = nlev + 1
+    end
+
+    for k in 3:(nlev - 2)
+        drh = rel_hum[k] - rhcl1
+        if (drh > column.cloudc) & (humid[k] > qcl)
+            column.cloudc = drh
+            column.icltop = k
+        end
+    end
+
+    pr1 = min(pmaxcl, 86.4 * (precip_convection + precip_large_scale))
+    column.cloudc = min(1.0, wpcl * sqrt(pr1) + min(1.0, column.cloudc * rrcl)^2.0)
+    column.icltop = min(cloud_top, column.icltop)
+
+    # 2.0  Equivalent specific humidity of clouds
+    column.qcloud = humid[nlev - 1]
+
+    # 3.0 Stratiform clouds at the top of pbl
+    clfact = 1.2
+    rgse = 1.0 / (gse_s1 - gse_s0)
+
+    # Stratocumulus clouds over sea
+    fstab = max(0.0, min(1.0, rgse * (grad_dry_static_energy - gse_s0)))
+    column.clstr = fstab * max(clsmax - clfact * column.cloudc, 0.0)
+
+    # Stratocumulus clouds over land
+    clstrl = max(column.clstr, clsminl) * rel_hum[nlev]
+    column.clstr = column.clstr + fmask * (clstrl - column.clstr)
+end
+
+"""
+    function radsw!(
+        column::ColumnVariables{NF}, model::PrimitiveEquationModel
+    )
+
+Compute shortwave radiation fluxes for an atmospheric column.
+"""
+function radsw!(
+    column::ColumnVariables{NF}, model::PrimitiveEquationModel
+) where {NF<:AbstractFloat}
+    @unpack norm_pres,
+    humid, icltop, cloudc, clstr, ozupp, ozone, zenit, stratz, fsol, qcloud, albsfc,
+        nlev = column
+    @unpack σ_levels_full, σ_levels_thick = model.geometry
+
+    @unpack albcl, albcls, abscl1, abscl2, absdry, absaer, abswv1, abswv2, ablwin, ablco2, ablwv1,
+        ablwv2, ablcl2, ablcl1, epslw = model.parameters
+
+    # Locals variables
+    flux::Vector{NF} = fill(NaN, 2)
+    stratc::Vector{NF} = fill(NaN, 2)
+
+    nl1 = nlev - 1
+
+    fband2 = 0.05
+    fband1 = 1.0 - fband2
+
+    # 1.0 Initialization
+    column.tau2 = fill!(column.tau2, 0)
+
+    # Change to ensure only ICLTOP < = NLEV used
+    if (icltop <= nlev)
+        column.tau2[icltop, 3] = albcl * cloudc
+    end
+    column.tau2[nlev, 3] = albcls * clstr
+
+    # 2.0 Shortwave transmissivity:
+    # function of layer mass, ozone (in the statosphere),
+    # abs. humidity and cloud cover (in the troposphere)
+    psaz = norm_pres * zenit
+    acloud = cloudc * min(abscl1 * qcloud, abscl2)
+
+    deltap = psaz * σ_levels_thick[1]
+    column.tau2[1, 1] = exp(-deltap * absdry)
+
+    for k in 2:nl1
+        abs1 = absdry + absaer * σ_levels_full[k]^2
+        deltap = psaz * σ_levels_thick[k]
+        if (k >= icltop)
+            column.tau2[k, 1] = exp(-deltap * (abs1 + abswv1 * humid[k] + acloud))
+        else
+            column.tau2[k, 1] = exp(-deltap * (abs1 + abswv1 * humid[k]))
+        end
+    end
+
+    abs1 = absdry + absaer * σ_levels_full[nlev]^2
+    deltap = psaz * σ_levels_thick[nlev]
+    column.tau2[nlev, 1] = exp(-deltap * (abs1 + abswv1 * humid[nlev]))
+
+    for k in 2:nlev
+        deltap = psaz * σ_levels_thick[k]
+        column.tau2[k, 2] = exp(-deltap * abswv2 * humid[k])
+    end
+
+    # 3.0 Shortwave downward flux
+    # 3.1 Initialization of fluxes
+    column.tsr = fsol
+    flux[1] = fsol * fband1
+    flux[2] = fsol * fband2
+
+    # 3.2 Ozone and dry - air absorption in the stratosphere
+    k = 1
+    column.tend_t_rsw[k] = flux[1]
+    flux[1] = column.tau2[k, 1] * (flux[1] - ozupp * norm_pres)
+    column.tend_t_rsw[k] = column.tend_t_rsw[k] - flux[1]
+
+    k = 2
+    column.tend_t_rsw[k] = flux[1]
+    flux[1] = column.tau2[k, 1] * (flux[1] - ozone * norm_pres)
+    column.tend_t_rsw[k] = column.tend_t_rsw[k] - flux[1]
+
+    # 3.3  Absorption and reflection in the troposphere
+    for k in 3:nlev
+        column.tau2[k, 3] = flux[1] * column.tau2[k, 3]
+        flux[1] = flux[1] - column.tau2[k, 3]
+        column.tend_t_rsw[k] = flux[1]
+        flux[1] = column.tau2[k, 1] * flux[1]
+        column.tend_t_rsw[k] = column.tend_t_rsw[k] - flux[1]
+    end
+
+    for k in 2:nlev
+        column.tend_t_rsw[k] = column.tend_t_rsw[k] + flux[2]
+        flux[2] = column.tau2[k, 2] * flux[2]
+        column.tend_t_rsw[k] = column.tend_t_rsw[k] - flux[2]
+    end
+
+    # 4.0 Shortwave upward flux
+    # 4.1  Absorption and reflection at the surface
+    column.ssrd = flux[1] + flux[2]
+    flux[1] = flux[1] * albsfc
+    column.ssr = column.ssrd - flux[1]
+
+    # 4.2  Absorption of upward flux
+    for k in nlev:-1:1
+        column.tend_t_rsw[k] = column.tend_t_rsw[k] + flux[1]
+        flux[1] = column.tau2[k, 1] * flux[1]
+        column.tend_t_rsw[k] = column.tend_t_rsw[k] - flux[1]
+        flux[1] = flux[1] + column.tau2[k, 3]
+    end
+
+    # 4.3  Net solar radiation = incoming - outgoing
+    column.tsr = column.tsr - flux[1]
+
+    # 5.0  Initialization of longwave radiation model
+    # 5.1  Longwave transmissivity:
+    #      function of layer mass, abs. humidity and cloud cover.
+
+    #    Cloud - free levels (stratosphere + PBL)
+    k = 1
+    deltap = norm_pres * σ_levels_thick[k]
+    column.tau2[k, 1] = exp(-deltap * ablwin)
+    column.tau2[k, 2] = exp(-deltap * ablco2)
+    column.tau2[k, 3] = 1.0
+    column.tau2[k, 4] = 1.0
+
+    for k in 2:(nlev - 2):nlev
+        deltap = norm_pres * σ_levels_thick[k]
+        column.tau2[k, 1] = exp(-deltap * ablwin)
+        column.tau2[k, 2] = exp(-deltap * ablco2)
+        column.tau2[k, 3] = exp(-deltap * ablwv1 * humid[k])
+        column.tau2[k, 4] = exp(-deltap * ablwv2 * humid[k])
+    end
+
+    # Cloudy layers (free troposphere)
+    acloud = cloudc * ablcl2
+
+    for k in 3:nl1
+        deltap = norm_pres * σ_levels_thick[k]
+        if (k < icltop)
+            acloud1 = acloud
+        else
+            acloud1 = ablcl1 * cloudc
+        end
+        column.tau2[k, 1] = exp(-deltap * (ablwin + acloud1))
+        column.tau2[k, 2] = exp(-deltap * ablco2)
+        column.tau2[k, 3] = exp(-deltap * max(ablwv1 * humid[k], acloud))
+        column.tau2[k, 4] = exp(-deltap * max(ablwv2 * humid[k], acloud))
+    end
+
+    # 5.2  Stratospheric correction terms
+    eps1 = epslw / (σ_levels_thick[1] + σ_levels_thick[2])
+    stratc[1] = stratz * norm_pres
+    stratc[2] = eps1 * norm_pres
+end

--- a/src/tendencies_parametrizations.jl
+++ b/src/tendencies_parametrizations.jl
@@ -27,8 +27,8 @@ function parametrization_tendencies!(
         convection!(column, M)
         large_scale_condensation!(column, M)
         # clouds!(column, M)
-        # shortwave_radiation!(column, M)
-        # longwave_radiation!(column, M)
+        shortwave_radiation!(column, M)
+        longwave_radiation!(column, M)
         # surface_fluxes!(column,M)
         # vertical_diffusion!(column,M)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ include("column_variables.jl")
 include("thermodynamics.jl")
 include("large_scale_condensation.jl")
 include("convection.jl")
+include("shortwave_radiation.jl")
 
 # INITIALIZATION AND INTEGRATION
 include("initialize.jl")

--- a/test/shortwave_radiation.jl
+++ b/test/shortwave_radiation.jl
@@ -1,0 +1,149 @@
+@testset "Parametrization: shortwave radiation" begin
+    @testset "solar!" begin
+        @testset for NF in (Float32, Float64)
+            topsr = [0., 283.06, 352.56537, 378.8209880964894]
+            lat = [-89., 0., 45., 89.]
+            @testset for i in 1:4
+                _, diagn, model = SpeedyWeather.initialize_speedy(NF, model = :primitive, nlev = 4)
+                nlev = diagn.nlev
+
+                column = ColumnVariables{NF}(nlev = nlev)
+                column.tyear = 0.5
+                column.csol = 1000.
+                column.lat = lat[i]
+
+                SpeedyWeather.solar!(column)
+
+                @test column.topsr ≈ topsr[i]
+            end
+        end
+    end
+    @testset "sol_oz!" begin
+        @testset for NF in (Float32, Float64)
+            _, diagn, model = SpeedyWeather.initialize_speedy(NF, model = :primitive, nlev = 4)
+            nlev = diagn.nlev
+
+            column = ColumnVariables{NF}(nlev = nlev)
+            column.tyear = 0.5
+            column.lat = 89.
+
+            SpeedyWeather.sol_oz!(column, model)
+
+            @test column.topsr ≈ 518.2271117159975
+            @test column.fsol ≈ 518.2271117159975
+            @test column.ozupp ≈ 6.99611021887365
+            @test column.ozone ≈ 15.666684
+            @test column.zenit ≈ 1.3500085311452612
+            @test column.stratz ≈ 0.
+        end
+    end
+    @testset "cloud!" begin
+        @testset for NF in (Float32, Float64)
+            _, diagn, model = SpeedyWeather.initialize_speedy(NF, model = :primitive, nlev = 4)
+            nlev = diagn.nlev
+
+            column = ColumnVariables{NF}(nlev = nlev)
+            column.humid .= [0., 0.03124937, 0.9748285, 6.7846994] # g/kg
+            column.rel_hum = [0.0, 1., 1., 0.8964701087948754]
+            column.grad_dry_static_energy = 0.4255393541723314
+            column.precip_convection = 1
+            column.precip_large_scale = 1
+            column.cloud_top = 1
+            column.fmask = 1.
+
+            SpeedyWeather.cloud!(column, model)
+
+            @test column.icltop ≈ 1.
+            @test column.cloudc ≈ 1.
+            @test column.clstr ≈ 0.13447051631923132
+            @test column.qcloud ≈ 0.9748285
+        end
+    end
+    @testset "radsw!" begin
+        @testset for NF in (Float32, Float64)
+            _, diagn, model = SpeedyWeather.initialize_speedy(NF, model = :primitive, nlev = 4)
+            nlev = diagn.nlev
+
+            column = ColumnVariables{NF}(nlev = nlev)
+            column.norm_pres = 1.
+            column.humid .= [0., 0.03124937, 0.9748285, 6.7846994] # g/kg
+            column.albsfc = 0.5
+            # Same as returned from sol_oz and cloud
+            column.icltop = 1
+            column.cloudc = 0.90186596
+            column.clstr = 0.1485
+            column.ozupp = 6.99611021887365
+            column.ozone = 15.666684
+            column.zenit = 1.3500085311452612
+            column.stratz = 0.
+            column.fsol = 518.2271117159975
+            column.qcloud = 0.033334
+
+            SpeedyWeather.radsw!(column, model)
+
+            @test column.ssrd ≈ 385.7997293028816
+            @test column.ssr ≈ 192.8998646514408
+            @test column.tsr ≈ 315.10016
+            @test column.tau2 ≈ [0.9526258427031802 0.3788324531779398 1.0 1.0;
+                                 0.9286716429916902 0.2276374390970355 0.994618802250959 0.6801722651144487;
+                                 0.02148265489609933 0.12596241035550795 0.7900788064253661 4.906182803130207e-8;
+                                 0.9287847242363858 0.22819245387064319 0.31050206404533354 5.234705430612321e-37]
+            @test column.tend_t_rsw ≈ [11.947794979452055, 27.611640775148402, 42.565299927060124, 40.46336031165737]
+        end
+    end
+    @testset "shortwave_radiation!" begin
+        @testset for NF in (Float32, Float64)
+            _, diagn, model = SpeedyWeather.initialize_speedy(NF, model = :primitive, nlev = 4)
+            nlev = diagn.nlev
+
+            column = ColumnVariables{NF}(nlev = nlev)
+
+            # 1. Set variables for sol_oz
+            column.tyear = 0.5
+            column.lat = 89.
+
+            # 2. Compute sat_vap_pres and dry_static_energy
+            # and set remainig varables for cloud
+            column.pres = 1. # nomalised
+            column.temp .= [208.40541, 219.8126 , 249.25502, 276.14264]
+            column.humid .= [0., 0.03124937, 0.9748285, 6.7846994] # g/kg
+            column.geopot .= [241932.19, 117422.14, 54618.79, 7626.5884]
+            SpeedyWeather.get_thermodynamics!(column, model)
+
+            # column.sat_vap_pres = [0.005265206274688095, 0.02494611200040165, 0.7012750147882735, 7.56823828640608]
+            # column.dry_static_energy = [451171.22164, 338113.9904, 304870.83008, 284873.79896]
+            # column.rel_hum = [0.0, 1.2526749659224194, 1.3900801817305823, 0.8964701087948754]
+            # column.grad_dry_static_energy = 0.4255393541723314
+
+            column.precip_convection = 1
+            column.precip_large_scale = 1
+            column.cloud_top = 1
+            column.fmask = 1.
+
+            # Set variables for radsw
+            # FIXME: pres is overloaded and will need to be
+            # fixed in other functions
+            column.norm_pres = column.pres
+            column.albsfc = 0.5
+
+            SpeedyWeather.shortwave_radiation!(column, model)
+
+            # Results need to be close to those computed by radsw but
+            # are not the same as precision is maintained between functions
+            @test isapprox(column.ssrd, 385.7997293028816, rtol=0.1)
+            @test isapprox(column.ssr, 192.8998646514408, rtol=0.1)
+            @test isapprox(column.tsr, 315.10016, rtol=0.1)
+            @test isapprox(column.tau2, [
+                0.9526258427031802 0.3788324531779398 1.0 1.0;
+                0.9286716429916902 0.2276374390970355 0.994618802250959 0.6801722651144487;
+                0.02148265489609933 0.12596241035550795 0.7900788064253661 4.906182803130207e-8;
+                0.9287847242363858 0.22819245387064319 0.31050206404533354 5.234705430612321e-37
+                ], rtol=0.1)
+            @test isapprox(column.tend_t_rsw, [
+                11.947794979452055, 27.611640775148402, 42.565299927060124, 40.46336031165737
+                ], rtol=0.1)
+            # Range is generally order 10^-5
+            @test column.temp_tend ≈ [7.189150408440864e-6, 1.2141337616807728e-5, 1.3196339560843619e-5, 1.5994200814647754e-5]
+        end
+    end
+end

--- a/test/shortwave_radiation.jl
+++ b/test/shortwave_radiation.jl
@@ -4,7 +4,7 @@
             topsr = [0., 283.06, 352.56537, 378.8209880964894]
             lat = [-89., 0., 45., 89.]
             @testset for i in 1:4
-                _, diagn, model = SpeedyWeather.initialize_speedy(NF, model = :primitive, nlev = 4)
+                _, diagn, model = SpeedyWeather.initialize_speedy(NF, model=PrimitiveEquation, nlev = 4)
                 nlev = diagn.nlev
 
                 column = ColumnVariables{NF}(nlev = nlev)
@@ -20,7 +20,7 @@
     end
     @testset "sol_oz!" begin
         @testset for NF in (Float32, Float64)
-            _, diagn, model = SpeedyWeather.initialize_speedy(NF, model = :primitive, nlev = 4)
+            _, diagn, model = SpeedyWeather.initialize_speedy(NF, model=PrimitiveEquation, nlev = 4)
             nlev = diagn.nlev
 
             column = ColumnVariables{NF}(nlev = nlev)
@@ -39,7 +39,7 @@
     end
     @testset "cloud!" begin
         @testset for NF in (Float32, Float64)
-            _, diagn, model = SpeedyWeather.initialize_speedy(NF, model = :primitive, nlev = 4)
+            _, diagn, model = SpeedyWeather.initialize_speedy(NF, model=PrimitiveEquation, nlev = 4)
             nlev = diagn.nlev
 
             column = ColumnVariables{NF}(nlev = nlev)
@@ -61,7 +61,7 @@
     end
     @testset "radsw!" begin
         @testset for NF in (Float32, Float64)
-            _, diagn, model = SpeedyWeather.initialize_speedy(NF, model = :primitive, nlev = 4)
+            _, diagn, model = SpeedyWeather.initialize_speedy(NF, model=PrimitiveEquation, nlev = 4)
             nlev = diagn.nlev
 
             column = ColumnVariables{NF}(nlev = nlev)
@@ -93,7 +93,7 @@
     end
     @testset "shortwave_radiation!" begin
         @testset for NF in (Float32, Float64)
-            _, diagn, model = SpeedyWeather.initialize_speedy(NF, model = :primitive, nlev = 4)
+            _, diagn, model = SpeedyWeather.initialize_speedy(NF, model=PrimitiveEquation, nlev = 4)
             nlev = diagn.nlev
 
             column = ColumnVariables{NF}(nlev = nlev)


### PR DESCRIPTION
This PR adds SPEEDY shortwave radiation parametrization. The code is kept as close as possible to [its original](https://github.com/samhatfield/speedy_physics.f90) but will refactor at a later stage after this PR is merged to keep comparison straightforward. I carry out two type of evaluations. First I compare fortran and julia functions with [speedy_physics_compare](https://github.com/dmey/speedy_physics_compare/blob/44ce685c148ff3208ea98f9216c7b88b4ca41266/evaluate_shortwave_radiation.ipynb).  Second, I evaluate each function for ranges in speedy_physics_comapre. All tests pass.

There are also some general questions and issues common to other parametrization schemes (e.g. overloading of physical quantities such as 'pres' for both atmospheric  surface pressure and its normalized counterpart) but we can discuss them somewhere else.