### PR TITLE
Update copyright and licensing information

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,7 @@
 Copyright (c) 2021 Milan Kloewer
 
+Copyright (c) 2022 Fred Kucharski and Franco Molteni
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,6 @@
-Copyright (c) 2022 SpeedyWeather contributors
-Copyright (c) 2022 Fred Kucharski and Franco Molteni
+Copyright (c) 2020 Milan Kloewer for SpeedyWeather.jl
+Copyright (c) 2021 The SpeedyWeather.jl Contributors for SpeedyWeather.jl
+Copyright (c) 2022 Fred Kucharski and Franco Molteni for SPEEDY parametrization schemes
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -62,3 +62,10 @@ which will install the latest release and all dependencies automatically. The ve
 ```
 which pulls directly from the `#main` branch. Please use the current minor version of Julia,
 compatibilities with older versions are not guaranteed.
+
+## Copyright and license
+
+Copyright (c) 2021 Milan Kloewer for SpeedyWeather.jl.
+Copyright (c) 2022 Fred Kucharski and Franco Molteni for parametrization schemes.
+
+Software licensed under the [MIT License](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ compatibilities with older versions are not guaranteed.
 
 ## Copyright and license
 
-Copyright (c) 2022 Milan Kloewer and contributors for SpeedyWeather.jl.
-Copyright (c) 2022 Fred Kucharski and Franco Molteni for parametrization schemes.
+Copyright (c) 2020 Milan Kloewer for SpeedyWeather.jl
+Copyright (c) 2021 The SpeedyWeather.jl Contributors for SpeedyWeather.jl
+Copyright (c) 2022 Fred Kucharski and Franco Molteni for SPEEDY parametrization schemes
 
 Software licensed under the [MIT License](LICENSE.txt).

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -1,0 +1,33 @@
+SpeedyWeather.jl (https://github.com/milankl/SpeedyWeather.jl).
+
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION.
+Do Not Translate or Localize.
+
+This project incorporates components from the projects listed below.
+The original copyright notices and the licenses are included below:
+
+1. SPEEDY fortran routines for physical parametrizations v41 (https://github.com/samhatfield/speedy_physics.f90)
+
+%% SPEEDY fortran routines for physical parametrizations v41 NOTICES AND INFORMATION BEGIN HERE
+=========================================
+Copyright (c) 2022 <Fred Kucharski, Franco Molteni>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, and/or sublicense
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=========================================
+END OF SPEEDY fortran routines for physical parametrizations v41 NOTICES AND INFORMATION


### PR DESCRIPTION
This PR adds copyright and licensing information for parametrization schemes used in SpeedyWeather.jl.