### PR TITLE
In-place and more efficient eachring computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ SpeedyWeather.jl is registered in Julia's registry, so open the package manager 
 ```
 which will install the latest release and all dependencies automatically. The very latest version is installed with
 ```julia
-(@v1.7) pkg> add https://github.com/milankl/SpeedyWeather.jl#main
+(@v1.7) pkg> add https://github.com/SpeedyWeather/SpeedyWeather.jl#main
 ```
 which pulls directly from the `#main` branch. Please use the current minor version of Julia,
 compatibilities with older versions are not guaranteed.

--- a/src/Grids/full_grids.jl
+++ b/src/Grids/full_grids.jl
@@ -71,7 +71,7 @@ function each_index_in_ring!(   rings::Vector{<:UnitRange{<:Integer}},
     index_end = 0                       
     @inbounds for j in 1:nlat
         index_1st = index_end + 1       # 1st index is +1 from prev ring's last index
-        index_end = j*nlon              # only calculate last index per ring
+        index_end += nlon               # only calculate last index per ring
         rings[j] = index_1st:index_end  # write UnitRange to rings vector
     end
 end

--- a/src/Grids/full_grids.jl
+++ b/src/Grids/full_grids.jl
@@ -61,6 +61,22 @@ function each_index_in_ring(Grid::Type{<:AbstractFullGrid},     # function for f
     return index_1st:index_end      # range of js in ring
 end
 
+function each_index_in_ring!(   rings::Vector{<:UnitRange{<:Integer}},
+                                Grid::Type{<:AbstractFullGrid},
+                                nlat_half::Integer)
+    nlat = length(rings)                # number of latitude rings
+    @boundscheck nlat == get_nlat(Grid,nlat_half) || throw(BoundsError)
+
+    nlon = get_nlon(Grid,nlat_half)     # number of longitudes
+    index_end = 0                       
+    @inbounds for j in 1:nlat
+        index_1st = index_end + 1       # 1st index is +1 from prev ring's last index
+        index_end = j*nlon              # only calculate last index per ring
+        rings[j] = index_1st:index_end  # write UnitRange to rings vector
+    end
+end
+
+
 """
     G = FullClenshawGrid{T}
 

--- a/src/Grids/grids_general.jl
+++ b/src/Grids/grids_general.jl
@@ -117,8 +117,9 @@ and then each grid point per ring. To be used like
 eachring(grid::AbstractGrid) = eachring(typeof(grid),grid.nlat_half)
 
 function eachring(Grid::Type{<:AbstractGrid},nlat_half::Integer)
-    rings = [each_index_in_ring(Grid,j,nlat_half) for j in 1:get_nlat(Grid,nlat_half)]
-    return rings    # returns Vector{UnitRange}
+    rings = Vector{UnitRange{Int}}(undef,get_nlat(Grid,nlat_half))
+    each_index_in_ring!(rings,Grid,nlat_half)
+    return rings
 end
 
 """

--- a/src/Grids/healpix.jl
+++ b/src/Grids/healpix.jl
@@ -84,7 +84,7 @@ function each_index_in_ring!(   rings::Vector{<:UnitRange{<:Integer}},
     nside = nside_healpix(nlat_half)                # side length of a basepixel
 
     # North polar cap
-    for j in 1:nside-1
+    @inbounds for j in 1:nside-1
         index_1st = index_end + 1                   # 1st index is +1 from prev ring's last index
         index_end += 4j                             # add number of grid points per ring
         rings[j] = index_1st:index_end              # turn into UnitRange
@@ -92,14 +92,14 @@ function each_index_in_ring!(   rings::Vector{<:UnitRange{<:Integer}},
 
     # Equatorial belt
     nlon_max = get_nlon_max(Grid,nlat_half)         # number of grid points on belt
-    for j in nside:3nside
+    @inbounds for j in nside:3nside
         index_1st = index_end + 1                   # 1st index is +1 from prev ring's last index
         index_end += nlon_max                       # nlon constant in belt
         rings[j] = index_1st:index_end              # turn into UnitRange
     end
 
     # South polar cap
-    for (j,j_mir) in zip( 3nside+1:nlat,  # South only
+    @inbounds for (j,j_mir) in zip( 3nside+1:nlat,  # South only
                                     nside-1:-1:1)   # mirror index
 
         index_1st = index_end + 1                   # 1st index is +1 from prev ring's last index

--- a/src/Grids/healpix.jl
+++ b/src/Grids/healpix.jl
@@ -73,6 +73,41 @@ function each_index_in_ring(::Type{<:AbstractHEALPixGrid},  # function for HEALP
     return index_1st:index_end                              # range of i's in ring
 end
 
+function each_index_in_ring!(   rings::Vector{<:UnitRange{<:Integer}},
+                                Grid::Type{<:AbstractHEALPixGrid},
+                                nlat_half::Integer) # resolution param
+
+    nlat = length(rings)
+    @boundscheck nlat == get_nlat(Grid,nlat_half) || throw(BoundsError)
+
+    index_end = 0
+    nside = nside_healpix(nlat_half)                # side length of a basepixel
+
+    # North polar cap
+    for j in 1:nside-1
+        index_1st = index_end + 1                   # 1st index is +1 from prev ring's last index
+        index_end += 4j                             # add number of grid points per ring
+        rings[j] = index_1st:index_end              # turn into UnitRange
+    end
+
+    # Equatorial belt
+    nlon_max = get_nlon_max(Grid,nlat_half)         # number of grid points on belt
+    for j in nside:3nside
+        index_1st = index_end + 1                   # 1st index is +1 from prev ring's last index
+        index_end += nlon_max                       # nlon constant in belt
+        rings[j] = index_1st:index_end              # turn into UnitRange
+    end
+
+    # South polar cap
+    for (j,j_mir) in zip( 3nside+1:nlat,  # South only
+                                    nside-1:-1:1)   # mirror index
+
+        index_1st = index_end + 1                   # 1st index is +1 from prev ring's last index
+        index_end += 4j_mir                         # add number of grid points per ring
+        rings[j] = index_1st:index_end              # turn into UnitRange
+    end
+end
+
 """
     H = HEALPixGrid{T}
 

--- a/src/Grids/healpix4.jl
+++ b/src/Grids/healpix4.jl
@@ -58,6 +58,28 @@ function each_index_in_ring(::Type{<:AbstractHEALPix4Grid}, # function for HEALP
     return index_1st:index_end                              # range of i's in ring
 end
 
+function each_index_in_ring!(   rings::Vector{<:UnitRange{<:Integer}},
+                                Grid::Type{<:AbstractHEALPix4Grid},
+                                nlat_half::Integer) # resolution param
+
+    nlat = length(rings)
+    @boundscheck nlat == get_nlat(Grid,nlat_half) || throw(BoundsError)
+
+    index_end = 0
+    @inbounds for j in 1:nlat_half                  # North incl Eq only
+        index_1st = index_end + 1                   # 1st index is +1 from prev ring's last index
+        index_end += 4j                             # add number of grid points per ring
+        rings[j] = index_1st:index_end              # turn into UnitRange
+    end
+    @inbounds for (j,j_rev) in zip( nlat_half+1:nlat,       # South only
+                                    nlat-nlat_half:-1:1)    # reverse index
+
+        index_1st = index_end + 1                   # 1st index is +1 from prev ring's last index
+        index_end += 4j_rev                         # add number of grid points per ring
+        rings[j] = index_1st:index_end              # turn into UnitRange
+    end
+end
+
 
 """
     H = HEALPix4Grid{T}

--- a/src/Grids/octahedral.jl
+++ b/src/Grids/octahedral.jl
@@ -58,6 +58,29 @@ function each_index_in_ring(Grid::Type{<:AbstractOctahedralGrid},
     return index_1st:index_end                              # range of i's in ring
 end
 
+function each_index_in_ring!(   rings::Vector{<:UnitRange{<:Integer}},
+                                Grid::Type{<:AbstractOctahedralGrid},
+                                nlat_half::Integer) # resolution param
+
+    nlat = length(rings)
+    @boundscheck nlat == get_nlat(Grid,nlat_half) || throw(BoundsError)
+
+    index_end = 0
+    @inbounds for j in 1:nlat_half                  # North incl Eq only
+        index_1st = index_end + 1                   # 1st index is +1 from prev ring's last index
+        index_end += 16 + 4j                        # add number of grid points per ring
+        rings[j] = index_1st:index_end              # turn into UnitRange
+    end
+    @inbounds for (j,j_rev) in zip(   nlat_half+1:nlat, # South only
+                            nlat-nlat_half:-1:1)        # reverse index
+
+        index_1st = index_end + 1                   # 1st index is +1 from prev ring's last index
+        index_end += 16 + 4j_rev                    # add number of grid points per ring
+        rings[j] = index_1st:index_end              # turn into UnitRange
+    end
+end
+
+
 """
     G = OctahedralGaussianGrid{T}
 

--- a/src/Grids/octahedral.jl
+++ b/src/Grids/octahedral.jl
@@ -45,13 +45,14 @@ function each_index_in_ring(Grid::Type{<:AbstractOctahedralGrid},
                             j::Integer,                     # ring index north to south
                             nlat_half::Integer)             # resolution param
 
-    @boundscheck 0 < j <= (2nlat_half-nlat_odd(Grid)) || throw(BoundsError)  # ring index valid?
+    nlat = get_nlat(Grid,nlat_half)
+    @boundscheck 0 < j <= nlat || throw(BoundsError)        # ring index valid?
     if j <= nlat_half                                       # northern hemisphere incl Equator
         index_1st = 2j*(j+7) - 15                           # first in-ring index i
         index_end = 2j*(j+9)                                # last in-ring index i
     else                                                    # southern hemisphere excl Equator
-        j = 2nlat_half-nlat_odd(Grid) - j + 1               # mirror ring index around Equator
-        n = npoints_octahedral(nlat_half,nlat_odd(Grid))+1  # number of grid points + 1
+        j = nlat - j + 1                                    # mirror ring index around Equator
+        n = get_npoints(Grid,nlat_half) + 1                 # number of grid points + 1
         index_1st = n - 2j*(j+9)                            # count backwards
         index_end = n - (2j*(j+7) - 15)
     end
@@ -71,11 +72,11 @@ function each_index_in_ring!(   rings::Vector{<:UnitRange{<:Integer}},
         index_end += 16 + 4j                        # add number of grid points per ring
         rings[j] = index_1st:index_end              # turn into UnitRange
     end
-    @inbounds for (j,j_rev) in zip(   nlat_half+1:nlat, # South only
-                            nlat-nlat_half:-1:1)        # reverse index
+    @inbounds for (j,j_mir) in zip( nlat_half+1:nlat,       # South only
+                                    nlat-nlat_half:-1:1)    # reverse index
 
         index_1st = index_end + 1                   # 1st index is +1 from prev ring's last index
-        index_end += 16 + 4j_rev                    # add number of grid points per ring
+        index_end += 16 + 4j_mir                    # add number of grid points per ring
         rings[j] = index_1st:index_end              # turn into UnitRange
     end
 end

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -17,7 +17,8 @@ struct Geometry{NF<:AbstractFloat}      # NF: Number format
     nlev::Int           # Number of vertical levels
     nlat_half::Int      # Number of latitudes in one hemisphere (incl Equator)
     npoints::Int        # total number of grid points
-    radius_earth::Real  # Earth's radius [m]
+    rings::Vector{UnitRange}    # indices range on ring
+    radius_earth::Real          # Earth's radius [m]
 
     # LATITUDES (either Gaussian, equi-angle, HEALPix or HEALPix4 lats, depending on grid)
     lat::Vector{NF}         # array of latitudes (π/2...-π/2)
@@ -86,6 +87,7 @@ function Geometry(P::Parameters,Grid::Type{<:AbstractGrid})
     nlon_max = get_nlon_max(Grid,nlat_half)         # number of longitudes around the equator
     nlon = nlon_max                                 # same (used for compatibility)
     npoints = get_npoints(Grid,nlat_half)           # total number of grid points
+    rings = eachring(Grid,nlat_half)                # indices range on ring
 
     # LATITUDE VECTORS (based on Gaussian, equi-angle or HEALPix latitudes)
     colat = get_colat(Grid,nlat_half)               # colatitude in radians
@@ -154,7 +156,7 @@ function Geometry(P::Parameters,Grid::Type{<:AbstractGrid})
 
     # conversion to number format NF happens here
     Geometry{P.NF}( Grid,nresolution,
-                    nlon_max,nlon,nlat,nlev,nlat_half,npoints,radius_earth,
+                    nlon_max,nlon,nlat,nlev,nlat_half,npoints,rings,radius_earth,
                     lat,latd,colat,colatd,lon,lond,lons,lats,
                     sinlat,coslat,coslat⁻¹,coslat²,coslat⁻²,f_coriolis,
                     n_stratosphere_levels,

--- a/src/spectral_transform.jl
+++ b/src/spectral_transform.jl
@@ -121,7 +121,8 @@ function SpectralTransform( ::Type{NF},                     # Number format NF
 
     # LONGITUDE OFFSETS OF FIRST GRID POINT PER RING (0 for full and octahedral grids)
     _, lons = get_colatlons(Grid,nlat_half)
-    lon1s = [lons[each_index_in_ring(Grid,j,nlat_half)[1]] for j in 1:nlat_half]
+    rings = eachring(Grid,nlat_half)                        # compute ring indices
+    lon1s = [lons[rings[j].start] for j in 1:nlat_half]     # pick lons at first index for each ring
     lon_offsets = [cispi(m*lon1/π) for m in 0:mmax, lon1 in lon1s]
 
     # PREALLOCATE LEGENDRE POLYNOMIALS, lmax+2 for one more degree l for meridional gradient recursion

--- a/src/spectral_transform.jl
+++ b/src/spectral_transform.jl
@@ -378,6 +378,8 @@ function gridded!(  map::AbstractGrid{NF},                      # gridded output
     gn = zeros(Complex{NF}, nfreq_max)      # phase factors for northern latitudes
     gs = zeros(Complex{NF}, nfreq_max)      # phase factors for southern latitudes
 
+    rings = eachring(map)                   # precompute ring indices
+
     Λw = Legendre.Work(Legendre.λlm!, Λ, Legendre.Scalar(zero(Float64)))
 
     @inbounds for j_north in 1:nlat_half    # symmetry: loop over northern latitudes only
@@ -436,11 +438,11 @@ function gridded!(  map::AbstractGrid{NF},                      # gridded output
 
         # INVERSE FOURIER TRANSFORM in zonal direction
         brfft_plan = brfft_plans[j_north]       # FFT planned wrt nlon on ring
-        ilons = each_index_in_ring(map,j_north) # in-ring indices northern ring
+        ilons = rings[j_north]                  # in-ring indices northern ring
         LinearAlgebra.mul!(view(map.data,ilons),brfft_plan,view(gn,1:nfreq))  # perform FFT
 
         # southern latitude, don't call redundant 2nd fft if ring is on equator 
-        ilons = each_index_in_ring(map,j_south) # in-ring indices southern ring
+        ilons = rings[j_south]                  # in-ring indices southern ring
         not_equator && LinearAlgebra.mul!(view(map.data,ilons),brfft_plan,view(gs,1:nfreq))  # perform FFT
 
         fill!(gn, zero(Complex{NF}))            # set phase factors back to zero
@@ -483,6 +485,8 @@ function spectral!( alms::LowerTriangularMatrix{Complex{NF}},   # output: spectr
     fn = zeros(Complex{NF},nfreq_max)       # Fourier-transformed northern latitude
     fs = zeros(Complex{NF},nfreq_max)       # Fourier-transformed southern latitude
 
+    rings = eachring(map)                   # precompute ring indices
+
     # partial sums are accumulated in alms, force zeros initially.
     fill!(alms,0)
 
@@ -497,10 +501,10 @@ function spectral!( alms::LowerTriangularMatrix{Complex{NF}},   # output: spectr
 
         # FOURIER TRANSFORM in zonal direction
         rfft_plan = rfft_plans[j_north]         # FFT planned wrt nlon on ring
-        ilons = each_index_in_ring(map,j_north) # in-ring indices northern ring
+        ilons = rings[j_north]                  # in-ring indices northern ring
         LinearAlgebra.mul!(view(fn,1:nfreq),rfft_plan,view(map.data,ilons))   # Northern latitude
 
-        ilons = each_index_in_ring(map,j_south) # in-ring indices southern ring
+        ilons = rings[j_south]                  # in-ring indices southern ring
                                                 # Southern latitude (don't call FFT on Equator)
                                                 # then fill fs with zeros and no changes needed further down
         not_equator ? LinearAlgebra.mul!(view(fs,1:nfreq),rfft_plan,view(map.data,ilons)) : fill!(fs,0)

--- a/src/tendencies.jl
+++ b/src/tendencies.jl
@@ -62,9 +62,9 @@ function get_tendencies!(   diagn::DiagnosticVariables,
     vertical_advection!(diagn,model)                # use σ̇ for the vertical advection of u,v,T,q
 
     for layer in diagn.layers
-        vordiv_tendencies!(layer,surface,model)
-        temperature_tendency!(layer,model)
-        humidity_tendency!(layer,model)
+        vordiv_tendencies!(layer,surface,model)     # vorticity advection
+        temperature_tendency!(layer,model)          # hor. advection + adiabatic term
+        humidity_tendency!(layer,model)             # horizontal advection of humid
         bernoulli_potential!(layer,G,S)             # add -∇²(E+ϕ) term to div tendency
     end
 end

--- a/test/grids.jl
+++ b/test/grids.jl
@@ -112,3 +112,26 @@ end
         @test sum(grid) == SpeedyWeather.get_npoints(G,n)
     end
 end
+
+@testset "Ring indices" begin
+    @testset for G in (  FullClenshawGrid,
+                FullGaussianGrid,
+                OctahedralGaussianGrid,
+                OctahedralClenshawGrid,
+                HEALPixGrid,
+                HEALPix4Grid,
+                FullHEALPixGrid,
+                FullHEALPix4Grid,
+                )
+
+        @testset for n in [8,16,24,32]      # resolution parameter nlat_half
+            grid = zeros(G,n)
+
+            # precompute indices and boundscheck
+            rings = SpeedyWeather.eachring(grid)   
+            rings2 = [SpeedyWeather.each_index_in_ring(grid,j) for j in 1:SpeedyWeather.get_nlat(grid)]
+
+            @test rings == rings2
+        end
+    end
+end

--- a/test/spectral_gradients.jl
+++ b/test/spectral_gradients.jl
@@ -289,7 +289,7 @@ end
     for NF in (Float32,Float64)
         p,d,m = initialize_speedy(NF)
 
-        a = rand(LowerTriangularMatrix{Complex{NF}},33,32)
+        a = randn(LowerTriangularMatrix{Complex{NF}},33,32)
         SpeedyWeather.spectral_truncation!(a,31)
         a[:,1] .= real.(a[:,1])
 
@@ -313,7 +313,7 @@ end
         SpeedyWeather.curl!(∇x∇a,dadx,dady,m.spectral_transform)
 
         for lm in SpeedyWeather.eachharmonic(∇x∇a)
-            @test ∇x∇a[lm] ≈ 0 atol=3*sqrt(eps(NF))
+            @test ∇x∇a[lm] ≈ 0 atol=5*sqrt(eps(NF))
         end
         
         # DIV(GRAD(A)) = LAPLACE(A)
@@ -323,7 +323,7 @@ end
         SpeedyWeather.∇²!(∇²a,a,m.spectral_transform)
 
         for lm in SpeedyWeather.eachharmonic(div_∇a,∇²a)
-            @test div_∇a[lm] ≈ ∇²a[lm] atol=3*sqrt(eps(NF)) rtol=3*sqrt(eps(NF))
+            @test div_∇a[lm] ≈ ∇²a[lm] atol=5*sqrt(eps(NF)) rtol=5*sqrt(eps(NF))
         end
     end
 end


### PR DESCRIPTION
The previous functions caused large allocations in the dynamical core (I don't know why) and therefore performance penalties. Now `rings` is first allocated `Vector{UnitRange{Int}}` and then filled via `each_index_in_ring!`