### PR TITLE
add convenience interpolate method, show ring info for grids

### DIFF
--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -1,6 +1,7 @@
 #TODO turn into module?
 
 include("grids_general.jl") # def AbstractGrid
+include("show.jl")
 
 include("full_grids.jl")    # def AbstractFullGrid, Full*Grid, * = Gaussian, Clenshaw, HEALPix, HEALPix4
 include("octahedral.jl")    # def AbstractOctahedralGrid, OctahedralGaussianGrid, OctahedralClenshawGrid

--- a/src/Grids/interpolation.jl
+++ b/src/Grids/interpolation.jl
@@ -266,6 +266,15 @@ function interpolate(   ::Type{Grid},
     return Aout             # returns the grid wrapped around that vector
 end
 
+# if nlat_half not provided use that from input grid
+function interpolate(   ::Type{Grid},
+                        A::AbstractGrid,
+                        I::Type{<:AbstractInterpolator}=DEFAULT_INTERPOLATOR
+                        ) where {Grid<:AbstractGrid}
+
+    interpolate(Grid,A.nlat_half,A,I)
+end
+
 function update_locator!(   I::AbstractInterpolator{NF,Grid},   # GridGeometry and Locator
                             θs::Vector,                         # latitudes to interpolate onto
                             λs::Vector;                         # longitudes to interpolate onto

--- a/src/Grids/show.jl
+++ b/src/Grids/show.jl
@@ -1,0 +1,7 @@
+# For grids, also add info about the number of rings, e.g.
+# julia> A = randn(OctahedralClenshawGrid,24)
+# 3056-element, 47-ring OctahedralClenshawGrid{Float64}:
+function Base.array_summary(io::IO, grid::AbstractGrid, inds::Tuple{Vararg{Base.OneTo}})
+    print(io, Base.dims2string(length.(inds)), ", $(get_nlat(grid))-ring ")
+    Base.showarg(io, grid, true)
+end


### PR DESCRIPTION
We now can omit `nlat_half` and it'll just use the same as from the input grid
```julia
julia> A = randn(OctahedralClenshawGrid,24)             # create data on some grid
julia> SpeedyWeather.interpolate(FullGaussianGrid,A)    # interpolate on another with same nlat_half
4608-element, 48-ring FullGaussianGrid{Float64}:
 -0.6548842797988247
 -0.6404409999872624
  ⋮
```
interpolating onto a lower or higher resolution grid? Still works as before:
```julia
julia> SpeedyWeather.interpolate(HEALPixGrid,256,A)
196608-element, 511-ring HEALPixGrid{Float64}:
  0.032597552308651516
  0.06585833004005627
  ⋮

julia> SpeedyWeather.interpolate(OctahedralGaussianGrid,8,A)
544-element, 16-ring OctahedralGaussianGrid{Float64}:
  0.16641055238859648
 -0.9763586037633543
  ⋮