### PR TITLE
remove callside @inline as this requires 1.8

### DIFF
--- a/src/RingGrids/grids_general.jl
+++ b/src/RingGrids/grids_general.jl
@@ -162,7 +162,6 @@ end
 UnitRange `ijs` to access each grid point on grid `grid`."""
 eachgridpoint(grid::AbstractGrid) = Base.OneTo(get_npoints(grid))
 function eachgridpoint(grid1::Grid,grids::Grid...) where {Grid<:AbstractGrid}
-    @inline 
     n = length(grid1)
     Base._all_match_first(X->length(X),n,grid1,grids...) || throw(BoundsError)
     return eachgridpoint(grid1)


### PR DESCRIPTION
fixes #81 

`@inline` doesn't seem to be required for no allocations

```julia
julia> A = rand(OctaHEALPixGrid,16);
julia> B = rand(OctaHEALPixGrid,16);
julia> @btime RingGrids.eachgridpoint($A,$B)
  2.535 ns (0 allocations: 0 bytes)
Base.OneTo(1024)
```