### PR TITLE
Cleanup after test

### DIFF
--- a/src/output/output.jl
+++ b/src/output/output.jl
@@ -396,3 +396,17 @@ function write_restart_file(time::DateTime,
         f["description"] = "Restart file created for SpeedyWeather.jl"
     end
 end
+
+"""
+    get_full_output_file_path(p::Parameters)
+
+Returns the full path of the output file after it was created.
+"""
+get_full_output_file_path(P::Parameters) = joinpath(P.output_path, string("run-",run_id_string(P.run_id),"/"), P.output_filename)
+
+"""
+    load_trajectory(var_name::Union{Symbol, String}, M::ModelSetup) 
+
+Loads a `var_name` trajectory of the model `M` that has been saved in a netCDF file during the time stepping.
+"""
+load_trajectory(var_name::Union{Symbol, String}, M::ModelSetup) = NetCDF.ncread(get_full_output_file_path(M.parameters), string(var_name))

--- a/test/netcdf_output.jl
+++ b/test/netcdf_output.jl
@@ -17,7 +17,7 @@
 
         t = NetCDF.ncread("run-dense-output-test/output.nc", "time")
         @test t ≈ Int64.(manual_time_axis(m.constants.Δt_sec, m.constants.n_timesteps))
-
+        
         # this is a nonsense simulation with way too large timesteps, but it's here to test the time axis output
         # 1kyrs simulation         
         p, d, m = initialize_speedy(Float32, output=true, n_days=365000, Δt_at_T31=60*24*365*10, output_dt=24*365*10, run_id="long-output-test")
@@ -26,6 +26,7 @@
         t = NetCDF.ncread("run-long-output-test/output.nc", "time")
         @test t ≈ Int64.(manual_time_axis(m.constants.Δt_sec, m.constants.n_timesteps))
 
+        @test t ≈ SpeedyWeather.load_trajectory("time", m)
     end 
 end 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,3 +39,9 @@ include("run_speedy_with_output.jl")
 
 # OUTPUT 
 include("netcdf_output.jl")
+
+# CLEAN UP 
+run_folders = filter(x->startswith(x, "run-"), readdir("."))
+for folder in run_folders
+    rm(folder, recursive=true)
+end


### PR DESCRIPTION
When testing SpeedyWeather locally, testing it a second time will fail as the named run folders already exist. This PR adds a clean up after testing that deletes all run folders