### PR TITLE
Add clean up of run folders after tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,3 +44,4 @@ include("netcdf_output.jl")
  run_folders = filter(x->startswith(x, "run-"), readdir("."))
  for folder in run_folders
      rm(folder, recursive=true)
+ end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,3 +39,8 @@ include("run_speedy_with_output.jl")
 
 # OUTPUT 
 include("netcdf_output.jl")
+
+ # CLEAN UP 
+ run_folders = filter(x->startswith(x, "run-"), readdir("."))
+ for folder in run_folders
+     rm(folder, recursive=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,5 +43,9 @@ include("netcdf_output.jl")
  # CLEAN UP 
  run_folders = filter(x->startswith(x, "run-"), readdir("."))
  for folder in run_folders
-     rm(folder, recursive=true)
+    if isdir(folder)
+        if ["output.nc","parameters.txt","progress.txt","restart.jld2"] == readdir(folder)
+            rm(folder, recursive=true)
+        end
+    end
  end


### PR DESCRIPTION
When testing SpeedyWeather locally, testing it a second time will fail as the named run folders already exist. This PR adds a clean up after testing that deletes all run folders