### PR TITLE
Use Temporary Files for Test Output

### DIFF
--- a/test/netcdf_output.jl
+++ b/test/netcdf_output.jl
@@ -12,7 +12,7 @@
             time_axis 
         end 
 
-        tmp_output_path = mktempdir(pwd(), prefix = "tmp_test_output_")  # Cleaned up when the process exits
+        tmp_output_path = mktempdir(pwd(), prefix = "tmp_testruns_")  # Cleaned up when the process exits
         
         p, d, m = initialize_speedy(Float32, output=true, output_path=tmp_output_path, n_days=1, output_dt=0, run_id="dense-output-test")
         SpeedyWeather.time_stepping!(p, d, m)

--- a/test/netcdf_output.jl
+++ b/test/netcdf_output.jl
@@ -12,22 +12,24 @@
             time_axis 
         end 
 
-        p, d, m = initialize_speedy(Float32, output=true, n_days=1, output_dt=0, run_id="dense-output-test")
+        tmp_output_path = mktempdir(pwd(), prefix = "tmp_test_output_")  # Cleaned up when the process exits
+        
+        p, d, m = initialize_speedy(Float32, output=true, output_path=tmp_output_path, n_days=1, output_dt=0, run_id="dense-output-test")
         SpeedyWeather.time_stepping!(p, d, m)
 
-        t = NetCDF.ncread("run-dense-output-test/output.nc", "time")
+        tmp_read_path = joinpath(tmp_output_path, "run-dense-output-test", "output.nc")
+        t = NetCDF.ncread(tmp_read_path, "time")
         @test t ≈ Int64.(manual_time_axis(m.constants.Δt_sec, m.constants.n_timesteps))
         
         # this is a nonsense simulation with way too large timesteps, but it's here to test the time axis output
-        # 1kyrs simulation         
-        p, d, m = initialize_speedy(Float32, output=true, n_days=365000, Δt_at_T31=60*24*365*10, output_dt=24*365*10, run_id="long-output-test")
+        # 1kyrs simulation
+        p, d, m = initialize_speedy(Float32, output=true, output_path=tmp_output_path, n_days=365000, Δt_at_T31=60*24*365*10, output_dt=24*365*10, run_id="long-output-test")
         SpeedyWeather.time_stepping!(p, d, m)
 
-        t = NetCDF.ncread("run-long-output-test/output.nc", "time")
+        tmp_read_path = joinpath(tmp_output_path, "run-long-output-test", "output.nc")
+        t = NetCDF.ncread(tmp_read_path, "time")
         @test t ≈ Int64.(manual_time_axis(m.constants.Δt_sec, m.constants.n_timesteps))
 
         @test t ≈ SpeedyWeather.load_trajectory("time", m)
     end 
 end 
-
-

--- a/test/run_speedy_with_output.jl
+++ b/test/run_speedy_with_output.jl
@@ -1,32 +1,35 @@
 @testset "Output on various grids" begin
-    p = run_speedy(Float64,output=true)
+    tmp_output_path = mktempdir(pwd(), prefix = "tmp_test_output_")  # Cleaned up when the process exits
+
+    p = run_speedy(Float64,output=true,output_path=tmp_output_path)
     @test all(isfinite.(p.layers[1].leapfrog[1].vor))
 
-    p = run_speedy(Float32,output=true)
+    p = run_speedy(Float32,output=true,output_path=tmp_output_path)
     @test all(isfinite.(p.layers[1].leapfrog[1].vor))
 
-    p = run_speedy(Float64,Grid=FullClenshawGrid,output=true)
+    p = run_speedy(Float64,Grid=FullClenshawGrid,output=true,output_path=tmp_output_path)
     @test all(isfinite.(p.layers[1].leapfrog[1].vor))
 
-    p = run_speedy(Float64,Grid=OctahedralGaussianGrid,output=true)
+    p = run_speedy(Float64,Grid=OctahedralGaussianGrid,output=true,output_path=tmp_output_path)
     @test all(isfinite.(p.layers[1].leapfrog[1].vor))
 
-    p = run_speedy(Float64,Grid=OctahedralClenshawGrid,output=true)
+    p = run_speedy(Float64,Grid=OctahedralClenshawGrid,output=true,output_path=tmp_output_path)
     @test all(isfinite.(p.layers[1].leapfrog[1].vor))
 
-    p = run_speedy(Float64,Grid=OctahedralClenshawGrid,output_matrix=true,output=true)
+    p = run_speedy(Float64,Grid=OctahedralClenshawGrid,output_matrix=true,output=true,output_path=tmp_output_path)
     @test all(isfinite.(p.layers[1].leapfrog[1].vor))
 
-    p = run_speedy(Float64,Grid=OctahedralClenshawGrid,output_matrix=true,output_NF=Float32,output=true)
+    p = run_speedy(Float64,Grid=OctahedralClenshawGrid,output_matrix=true,output_NF=Float32,output=true,output_path=tmp_output_path)
     @test all(isfinite.(p.layers[1].leapfrog[1].vor))
 end
 
 @testset "Restart from output file" begin
+    tmp_output_path = mktempdir(pwd(), prefix = "tmp_test_output_")  # Cleaned up when the process exits
     
-    p1, d1, m1 = initialize_speedy(Float32, ShallowWater, output=true, run_id="restart-test")
+    p1, d1, m1 = initialize_speedy(Float32, ShallowWater, output=true, output_path=tmp_output_path, run_id="restart-test")
     run_speedy!(p1, d1, m1)
  
-    p2, d2, m2 = initialize_speedy(Float32, ShallowWater, initial_conditions=StartFromFile, restart_id="restart-test")
+    p2, d2, m2 = initialize_speedy(Float32, ShallowWater, initial_conditions=StartFromFile, output_path=tmp_output_path, restart_id="restart-test")
 
     for varname in propertynames(p1.layers[1].leapfrog[1])
         if SpeedyWeather.has(p1, varname)

--- a/test/run_speedy_with_output.jl
+++ b/test/run_speedy_with_output.jl
@@ -1,5 +1,5 @@
 @testset "Output on various grids" begin
-    tmp_output_path = mktempdir(pwd(), prefix = "tmp_test_output_")  # Cleaned up when the process exits
+    tmp_output_path = mktempdir(pwd(), prefix = "tmp_testruns_")  # Cleaned up when the process exits
 
     p = run_speedy(Float64,output=true,output_path=tmp_output_path)
     @test all(isfinite.(p.layers[1].leapfrog[1].vor))
@@ -24,7 +24,7 @@
 end
 
 @testset "Restart from output file" begin
-    tmp_output_path = mktempdir(pwd(), prefix = "tmp_test_output_")  # Cleaned up when the process exits
+    tmp_output_path = mktempdir(pwd(), prefix = "tmp_testruns_")  # Cleaned up when the process exits
     
     p1, d1, m1 = initialize_speedy(Float32, ShallowWater, output=true, output_path=tmp_output_path, run_id="restart-test")
     run_speedy!(p1, d1, m1)


### PR DESCRIPTION
@maximilian-gelbrecht since we seem to be talking past each other on the other PR, I thought it would be easier to just show you what I mean here.

In my opinion this is the most correct, clean, and safe way of dealing with files and folders that are created by tests.

Whether you're running the tests locally using `] test` or `include("path_to_test")`, you can run the tests repeatedly without any issues, ensuring that successive test runs are independent.

It also avoids the dangerous use of `rm` on all files matching a certain pattern.