### PR TITLE
copy! for PrognosticVariables

### DIFF
--- a/src/dynamics/initial_conditions.jl
+++ b/src/dynamics/initial_conditions.jl
@@ -264,18 +264,7 @@ function initial_conditions!(   ::Type{StartFromFile},
     version = restart_file["version"]   # currently unused, TODO check for compat with version
     time = restart_file["time"]         # currently unused
 
-    var_names = propertynames(progn_old.layers[1].leapfrog[1])
-
-    for var_name in var_names
-        if has(progn_new, var_name) 
-            var = get_var(progn_old, var_name) 
-            set_var!(progn_new, var_name, var)
-        end
-    end 
-    pres = get_pressure(progn_old)
-    set_pressure!(progn_new, pres)
-
-    return progn_new
+    return copy!(progn_new, progn_old)
 end
 
 function homogeneous_temperature!(  progn::PrognosticVariables,

--- a/src/dynamics/prognostic_variables.jl
+++ b/src/dynamics/prognostic_variables.jl
@@ -1,3 +1,5 @@
+import Base: copy!
+
 """One vertical layer of prognostic variables represented by their spectral coefficients."""
 struct PrognosticVariablesLayer{NF<:AbstractFloat}
     # all matrices are of size lmax x mmax
@@ -97,6 +99,28 @@ function Base.zeros(::Type{PrognosticVariables{NF}},
 end
 
 has(progn::PrognosticVariables{NF,M}, var_name::Symbol) where {NF,M} = has(M, var_name)
+
+"""
+    copy!(progn_new::PrognosticVariables, progn_old::PrognosticVariables)
+
+Copies entries of `progn_old` into `progn_new`. Only copies those variables that are present 
+in the model of both `progn_new` and `progn_old`.
+"""
+function Base.copy!(progn_new::PrognosticVariables, progn_old::PrognosticVariables)
+
+    var_names = propertynames(progn_old.layers[1].leapfrog[1])
+
+    for var_name in var_names
+        if has(progn_new, var_name) 
+            var = get_var(progn_old, var_name) 
+            set_var!(progn_new, var_name, var)
+        end
+    end 
+    pres = get_pressure(progn_old)
+    set_pressure!(progn_new, pres)
+
+    return progn_new
+end
 
 # SET_VAR FUNCTIONS TO ASSIGN NEW VALUES TO PrognosticVariables
 

--- a/test/run_speedy_with_output.jl
+++ b/test/run_speedy_with_output.jl
@@ -37,3 +37,21 @@ end
     end
     @test all(SpeedyWeather.get_pressure(p1) .== SpeedyWeather.get_pressure(p2))
 end 
+
+@testset "Restart from PrognosticVariables" begin 
+
+    p1, d1, m1 = initialize_speedy(Float32, ShallowWater)
+    run_speedy!(p1, d1, m1)
+ 
+    p2, d2, m2 = initialize_speedy(Float32, ShallowWater)
+    copy!(p2, p1)
+
+    for varname in propertynames(p1.layers[1].leapfrog[1])
+        if SpeedyWeather.has(p1, varname)
+            for (var_new, var_old) in zip(SpeedyWeather.get_var(p1, varname), SpeedyWeather.get_var(p2, varname))
+                @test all(var_new .== var_old)
+            end
+        end
+    end
+    @test all(SpeedyWeather.get_pressure(p1) .== SpeedyWeather.get_pressure(p2))
+end


### PR DESCRIPTION
I took the copy operation for PrognosticVariables that was already implemented when restarting from the restart file and made it a separate function. With that it is really easy to restart from Prognostic Variables, e.g. when spinning up the model 

You could do the `set_var` before, but with `copy!` you do all variabels at once. 

```Julia 

# spin up 
 p1, d1, m1 = initialize_speedy(Float32, ShallowWater)
 run_speedy!(p1, d1, m1)
 
# proper run (e.g. with output on) 
p2, d2, m2 = initialize_speedy(Float32, ShallowWater)
copy!(p2, p1)
```