### PR TITLE
Boundary layer scheme from Held and Suarez

### DIFF
--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -1,143 +1,151 @@
 module SpeedyWeather
 
-    # STRUCTURE
-    import Parameters: @unpack
+# STRUCTURE
+import Parameters: @unpack
 
-    # NUMERICS
-    import Random
-    import FastGaussQuadrature
-    import LinearAlgebra: LinearAlgebra, Diagonal
+# NUMERICS
+import Random
+import FastGaussQuadrature
+import LinearAlgebra: LinearAlgebra, Diagonal
 
-    # GPU, PARALLEL
-    import Base.Threads: Threads, @threads
-    import FLoops: FLoops, @floop
-    import KernelAbstractions
-    import CUDA
-    import CUDAKernels
-    import Adapt: Adapt, adapt, adapt_structure
+# GPU, PARALLEL
+import Base.Threads: Threads, @threads
+import FLoops: FLoops, @floop
+import KernelAbstractions
+import CUDA
+import CUDAKernels
+import Adapt: Adapt, adapt, adapt_structure
 
-    # INPUT OUTPUT
-    import TOML
-    import Dates: Dates, DateTime
-    import Printf: @sprintf
-    import NetCDF: NetCDF, NcFile, NcDim, NcVar
-    import JLD2: jldopen
-    import CodecZlib
-    import BitInformation: round, round!
-    import UnicodePlots
-    import ProgressMeter
+# INPUT OUTPUT
+import TOML
+import Dates: Dates, DateTime
+import Printf: @sprintf
+import NetCDF: NetCDF, NcFile, NcDim, NcVar
+import JLD2: jldopen
+import CodecZlib
+import BitInformation: round, round!
+import UnicodePlots
+import ProgressMeter
 
-    # EXPORT MAIN INTERFACE TO SPEEDY
-    export  run_speedy,
-            run_speedy!,
-            initialize_speedy
+# EXPORT MAIN INTERFACE TO SPEEDY
+export  run_speedy,
+        run_speedy!,
+        initialize_speedy
 
-    # EXPORT MODELS
-    export  Barotropic,
-            BarotropicModel,
-            ShallowWater,
-            ShallowWaterModel,
-            PrimitiveEquation,
-            PrimitiveDryCore,
-            PrimitiveWetCore,
-            PrimitiveDryCoreModel,
-            PrimitiveWetCoreModel
+# EXPORT MODELS
+export  Barotropic,
+        BarotropicModel,
+        ShallowWater,
+        ShallowWaterModel,
+        PrimitiveEquation,
+        PrimitiveDryCore,
+        PrimitiveWetCore,
+        PrimitiveDryCoreModel,
+        PrimitiveWetCoreModel
 
-    # EXPORT GRIDS
-    export  LowerTriangularMatrix,
-            FullClenshawGrid,
-            FullGaussianGrid,
-            FullHEALPixGrid,
-            FullOctaHEALPixGrid,
-            OctahedralGaussianGrid,
-            OctahedralClenshawGrid,
-            HEALPixGrid,
-            OctaHEALPixGrid
+# EXPORT GRIDS
+export  LowerTriangularMatrix,
+        FullClenshawGrid,
+        FullGaussianGrid,
+        FullHEALPixGrid,
+        FullOctaHEALPixGrid,
+        OctahedralGaussianGrid,
+        OctahedralClenshawGrid,
+        HEALPixGrid,
+        OctaHEALPixGrid
 
-    # EXPORT OROGRAPHIES
-    export  NoOrography,
-            EarthOrography,
-            ZonalRidge
+# EXPORT OROGRAPHIES
+export  NoOrography,
+        EarthOrography,
+        ZonalRidge
 
-    # EXPORT INITIAL CONDITIONS
-    export  StartFromFile,
-            StartFromRest,
-            ZonalJet,
-            ZonalWind,
-            StartWithVorticity
+# EXPORT INITIAL CONDITIONS
+export  StartFromFile,
+        StartFromRest,
+        ZonalJet,
+        ZonalJetCoefs,
+        ZonalWind,
+        ZonalWindCoefs,
+        StartWithVorticity
 
-    # EXPORT STRUCTS
-    export  Parameters,
-            DynamicsConstants,
-            ParameterizationConstants,
-            Geometry,
-            SpectralTransform,
-            Boundaries,
-            PrognosticVariables,
-            DiagnosticVariables,
-            ColumnVariables
+# EXPORT BOUNDARY LAYER SCHEMES
+export  BoundaryLayer,
+        NoBoundaryLayer,
+        LinearDrag
 
-    # EXPORT SPECTRAL FUNCTIONS
-    export  spectral,
-            gridded,
-            spectral_truncation
-            
-    include("utility_functions.jl")
-    include("abstract_types.jl")
-    
-    # LowerTriangularMatrices for spherical harmonics
-    export LowerTriangularMatrices
-    include("LowerTriangularMatrices/LowerTriangularMatrices.jl")
-    using .LowerTriangularMatrices
-    
-    # RingGrids
-    export RingGrids
-    include("RingGrids/RingGrids.jl")
-    using .RingGrids
+# EXPORT STRUCTS
+export  Parameters,
+        DynamicsConstants,
+        ParameterizationConstants,
+        Geometry,
+        SpectralTransform,
+        Boundaries,
+        PrognosticVariables,
+        DiagnosticVariables,
+        ColumnVariables
 
-    # SpeedyTransforms
-    export SpeedyTransforms
-    include("SpeedyTransforms/SpeedyTransforms.jl")
-    using .SpeedyTransforms
+# EXPORT SPECTRAL FUNCTIONS
+export  spectral,
+        gridded,
+        spectral_truncation
         
-    include("gpu.jl")                       # defines utility for GPU / KernelAbstractions
-    include("default_parameters.jl")        # defines Parameters
+include("utility_functions.jl")
+include("abstract_types.jl")
+
+# LowerTriangularMatrices for spherical harmonics
+export LowerTriangularMatrices
+include("LowerTriangularMatrices/LowerTriangularMatrices.jl")
+using .LowerTriangularMatrices
+
+# RingGrids
+export RingGrids
+include("RingGrids/RingGrids.jl")
+using .RingGrids
+
+# SpeedyTransforms
+export SpeedyTransforms
+include("SpeedyTransforms/SpeedyTransforms.jl")
+using .SpeedyTransforms
     
-    # DYNAMICS
-    include("dynamics/constants.jl")                # defines DynamicsConstants
-    include("dynamics/geometry.jl")                 # defines Geometry
-    include("dynamics/boundaries.jl")               # defines Boundaries
-    include("dynamics/define_diffusion.jl")         # defines HorizontalDiffusion
-    include("dynamics/define_implicit.jl")          # defines ImplicitShallowWater, ImplicitPrimitiveEq
-    include("dynamics/parameter_structs.jl")        # defines GenLogisticCoefs
-    include("dynamics/models.jl")                   # defines ModelSetups
-    include("dynamics/prognostic_variables.jl")     # defines PrognosticVariables
-    include("dynamics/diagnostic_variables.jl")     # defines DiagnosticVariables
-    include("dynamics/initial_conditions.jl")
-    include("dynamics/scaling.jl")
-    include("dynamics/geopotential.jl")
-    include("dynamics/tendencies_dynamics.jl")
-    include("dynamics/tendencies.jl")
-    include("dynamics/implicit.jl")
-    include("dynamics/diffusion.jl")
-    include("dynamics/time_integration.jl")
-    
-    # PHYSICS
-    include("physics/constants.jl")                 # defines Parameterization Constants
-    include("physics/parameter_structs.jl")         # defines MagnusCoefs, RadiationCoefs
-    include("physics/column_variables.jl")          # defines ColumnVariables
-    include("physics/thermodynamics.jl")
-    include("physics/tendencies_parametrizations.jl")
-    include("physics/convection.jl")
-    include("physics/large_scale_condensation.jl")
-    include("physics/longwave_radiation.jl")
-    include("physics/shortwave_radiation.jl")
-    
-    # OUTPUT
-    include("output/output.jl")                     # defines Output
-    include("output/feedback.jl")                   # defines Feedback
-    include("output/pretty_printing.jl")
-    
-    # INTERFACE
-    include("run_speedy.jl")
+include("gpu.jl")                       # defines utility for GPU / KernelAbstractions
+include("default_parameters.jl")        # defines Parameters
+
+# DYNAMICS
+include("dynamics/constants.jl")                # defines DynamicsConstants
+include("dynamics/geometry.jl")                 # defines Geometry
+include("dynamics/boundaries.jl")               # defines Boundaries
+include("dynamics/define_diffusion.jl")         # defines HorizontalDiffusion
+include("dynamics/define_implicit.jl")          # defines ImplicitShallowWater, ImplicitPrimitiveEq
+include("dynamics/parameter_structs.jl")        # defines GenLogisticCoefs
+include("dynamics/models.jl")                   # defines ModelSetups
+include("dynamics/prognostic_variables.jl")     # defines PrognosticVariables
+include("dynamics/diagnostic_variables.jl")     # defines DiagnosticVariables
+include("dynamics/initial_conditions.jl")
+include("dynamics/scaling.jl")
+include("dynamics/geopotential.jl")
+include("dynamics/tendencies_dynamics.jl")
+include("dynamics/tendencies.jl")
+include("dynamics/implicit.jl")
+include("dynamics/diffusion.jl")
+include("dynamics/time_integration.jl")
+
+# PHYSICS
+include("physics/constants.jl")                 # defines Parameterization Constants
+include("physics/parameter_structs.jl")         # defines MagnusCoefs, RadiationCoefs
+include("physics/column_variables.jl")          # defines ColumnVariables
+include("physics/thermodynamics.jl")
+include("physics/tendencies.jl")
+include("physics/convection.jl")
+include("physics/large_scale_condensation.jl")
+include("physics/longwave_radiation.jl")
+include("physics/shortwave_radiation.jl")
+include("physics/boundary_layer.jl")
+
+# OUTPUT
+include("output/output.jl")                     # defines Output
+include("output/feedback.jl")                   # defines Feedback
+include("output/pretty_printing.jl")
+
+# INTERFACE
+include("run_speedy.jl")
 end

--- a/src/abstract_types.jl
+++ b/src/abstract_types.jl
@@ -25,6 +25,9 @@ abstract type AbstractBoundaries{NF} end
 # ATMOSPHERIC COLUMN FOR PARAMETERIZATIONS
 abstract type AbstractColumnVariables{NF} end
 
+# PARAMETERIZATIONS
+abstract type BoundaryLayer end
+
 # INPUT/OUTPUT
 abstract type AbstractFeedback end
 abstract type AbstractOutput end

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -95,6 +95,9 @@ Base.@kwdef struct Parameters{Model<:ModelSetup} <: AbstractParameters{Model}
     # Radiation
     radiation_coefs::Coefficients = RadiationCoefs{NF}()
 
+    # BOUNDARY LAYER
+    boundary_layer::BoundaryLayer = LinearDrag{NF}()
+
     # TIME STEPPING
     startdate::DateTime = DateTime(2000,1,1)    # time at which the integration starts
     n_days::Float64 = 10                        # number of days to integrate for

--- a/src/dynamics/tendencies.jl
+++ b/src/dynamics/tendencies.jl
@@ -1,23 +1,24 @@
 """
-    get_tendencies!(diagn,model)
+    dynamics_tendencies!(diagn,model)
 
 Calculate all tendencies for the BarotropicModel."""
-function get_tendencies!(   diagn::DiagnosticVariablesLayer,
-                            model::BarotropicModel)
+function dynamics_tendencies!(  diagn::DiagnosticVariablesLayer,
+                                model::BarotropicModel)
     
     # only (absolute) vorticity advection for the barotropic model
     vorticity_flux_divcurl!(diagn,model,curl=false)         # = -∇⋅(u(ζ+f),v(ζ+f))
 end
 
 """
-    get_tendencies!(diagn,surface,pres,time,model)
+    dynamics_tendencies!(diagn,surface,pres,time,model)
 
 Calculate all tendencies for the ShallowWaterModel."""
-function get_tendencies!(   diagn::DiagnosticVariablesLayer,
-                            surface::SurfaceVariables,
-                            pres::LowerTriangularMatrix,    # spectral pressure/η for geopotential
-                            time::DateTime,                 # time to evaluate the tendencies at
-                            model::ShallowWaterModel)       # struct containing all constants
+function dynamics_tendencies!(  diagn::DiagnosticVariablesLayer,
+                                surface::SurfaceVariables,
+                                pres::LowerTriangularMatrix,    # spectral pressure/η for geopotential
+                                time::DateTime,                 # time to evaluate the tendencies at
+                                model::ShallowWaterModel)       # struct containing all constants
+
     S,C = model.spectral_transform, model.constants
 
     # for compatibility with other ModelSetups pressure pres = interface displacement η here
@@ -33,23 +34,17 @@ function get_tendencies!(   diagn::DiagnosticVariablesLayer,
 end
 
 """
-    get_tendencies!(diagn,surface,pres,time,model)
+    dynamics_tendencies!(diagn,surface,pres,time,model)
 
 Calculate all tendencies for the primitive equation model (wet or dry)."""
-function get_tendencies!(   diagn::DiagnosticVariables,
-                            progn::PrognosticVariables,
-                            time::DateTime,
-                            model::PrimitiveEquation,
-                            lf::Int=2               # leapfrog index for tendencies
-                            )
+function dynamics_tendencies!(  diagn::DiagnosticVariables,
+                                progn::PrognosticVariables,
+                                model::PrimitiveEquation,
+                                lf::Int=2)               # leapfrog index for tendencies
 
     B, G, S = model.boundaries, model.geometry, model.spectral_transform
     @unpack surface = diagn
 
-    # PARAMETERIZATIONS
-    # parameterization_tendencies!(diagn,time,model)
-
-    # DYNAMICS
     # for semi-implicit corrections (α >= 0.5) linear gravity-wave related tendencies are
     # evaluated at previous timestep i-1 (i.e. lf=1 leapfrog time step) 
     # nonlinear terms and parameterizations are always evaluated at lf

--- a/src/dynamics/tendencies_dynamics.jl
+++ b/src/dynamics/tendencies_dynamics.jl
@@ -297,7 +297,9 @@ function _vertical_advection!(  ξ_tend::Grid,           # tendency of quantity 
                                 Δσₖ::NF                 # layer thickness on σ levels
                                 ) where {NF<:AbstractFloat,Grid<:AbstractGrid{NF}}
     Δσₖ2⁻¹ = -1/2Δσₖ                                    # precompute
-    @. ξ_tend = Δσₖ2⁻¹ * (σ_tend_below*(ξ_below - ξ) + σ_tend_above*(ξ - ξ_above))
+
+    # += as the tendencies already contain the parameterizations
+    @. ξ_tend += Δσₖ2⁻¹ * (σ_tend_below*(ξ_below - ξ) + σ_tend_above*(ξ - ξ_above))
 end
 
 function vordiv_tendencies!(diagn::DiagnosticVariablesLayer,

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -127,7 +127,7 @@ function timestep!( progn::PrognosticVariables,     # all prognostic variables
 
     # LOOP OVER LAYERS FOR DIFFUSION, LEAPFROGGING AND PROPAGATE STATE TO GRID
     for (progn_layer,diagn_layer) in zip(progn.layers,diagn.layers)
-        get_tendencies!(diagn_layer,M)                      # tendency of vorticity
+        dynamics_tendencies!(diagn_layer,M)                 # tendency of vorticity
         horizontal_diffusion!(progn_layer,diagn_layer,M)    # diffusion for vorticity
         leapfrog!(progn_layer,diagn_layer,dt,lf1,M)         # leapfrog vorticity forward
         gridded!(diagn_layer,progn_layer,lf2,M)             # propagate spectral state to grid
@@ -161,8 +161,8 @@ function timestep!( progn::PrognosticVariables{NF}, # all prognostic variables
     @unpack pres = progn
     pres_lf = pres.leapfrog[lf2]
 
-    get_tendencies!(diagn_layer,diagn_surface,pres_lf,time,M)               # tendency of vor, div, pres
-    implicit_correction!(diagn_layer,progn_layer,diagn_surface,pres,M)      # dampen gravity waves
+    dynamics_tendencies!(diagn_layer,diagn_surface,pres_lf,time,M)      # tendency of vor, div, pres
+    implicit_correction!(diagn_layer,progn_layer,diagn_surface,pres,M)  # dampen gravity waves
     horizontal_diffusion!(progn_layer,diagn_layer,M)    # diffusion for vorticity and divergence
     leapfrog!(progn_layer,diagn_layer,dt,lf1,M)         # leapfrog vorticity forward
     gridded!(diagn_layer,progn_layer,lf2,M)             # propagate spectral state to grid
@@ -194,7 +194,8 @@ function timestep!( progn::PrognosticVariables{NF}, # all prognostic variables
                     lf2::Int=2                      # leapfrog index 2 (time step used for tendencies)
                     ) where {NF<:AbstractFloat}
 
-    get_tendencies!(diagn,progn,time,model,lf2)
+    parameterization_tendencies!(diagn,time,model)
+    dynamics_tendencies!(diagn,progn,model,lf2)
     implicit_correction!(diagn,progn,model)
 
     # LOOP OVER ALL LAYERS for diffusion, leapfrog time integration

--- a/src/physics/boundary_layer.jl
+++ b/src/physics/boundary_layer.jl
@@ -1,0 +1,24 @@
+function boundary_layer!(   column::ColumnVariables,
+                            scheme::NoBoundaryLayer,
+                            model::PrimitiveEquation)
+    return nothing
+end
+
+function boundary_layer!(   column::ColumnVariables{NF},
+                            scheme::LinearDrag,
+                            model::PrimitiveEquation) where NF
+
+    (;σ_levels_full) = model.geometry
+    (;σb,drag_time) = scheme
+    kf = 1/drag_time
+    (;u,v,u_tend,v_tend) = column
+
+    @inbounds for k in eachlayer(column)
+
+        σ = σ_levels_full[k]            # σ level of layer k
+        kᵥ = kf*max(0,(σ-σb)/(1-σb))    # drag only below σb, linearly increasing to kf at σ=1
+        
+        u_tend[k] -= kᵥ*u[k]
+        v_tend[k] -= kᵥ*v[k]
+    end
+end

--- a/src/physics/column_variables.jl
+++ b/src/physics/column_variables.jl
@@ -115,8 +115,7 @@ at gridpoint index `ij`. Provide `G::Geometry` for coordinate information."""
 function get_column!(   C::ColumnVariables,
                         D::DiagnosticVariables,
                         ij::Int,            # grid point index
-                        G::Geometry,
-                        )
+                        G::Geometry)
 
     @boundscheck C.nlev == D.nlev || throw(BoundsError)
 
@@ -143,14 +142,13 @@ Write the parametrization tendencies from `C::ColumnVariables` into the horizont
 of tendencies stored in `D::DiagnosticVariables` at gridpoint index `ij`."""
 function write_column_tendencies!(  D::DiagnosticVariables,
                                     C::ColumnVariables,
-                                    ij::Int,            # grid point index
-                                    )
+                                    ij::Int)            # grid point index
 
     @boundscheck C.nlev == D.nlev || throw(BoundsError)
 
-    @inbounds for (k,layer) =  enumerate(D.layers)
-        layer.tendencies.u_tend[ij] = C.u_tend[k]
-        layer.tendencies.v_tend[ij] = C.v_tend[k]
+    for (k,layer) =  enumerate(D.layers)
+        layer.tendencies.u_tend_grid[ij] = C.u_tend[k]
+        layer.tendencies.v_tend_grid[ij] = C.v_tend[k]
         layer.tendencies.temp_tend_grid[ij] = C.temp_tend[k]
         layer.tendencies.humid_tend_grid[ij] = C.humid_tend[k]
     end

--- a/src/physics/parameter_structs.jl
+++ b/src/physics/parameter_structs.jl
@@ -58,3 +58,14 @@ Base.@kwdef struct RadiationCoefs{NF<:Real} <: Coefficients
     ablcl2::NF = 0.6    # Absorptivity of "thin" upper clouds in window and H2O bands
     ablcl1::NF = 12.0   # Absorptivity of "thick" clouds in window band (below cloud top)
 end    
+
+"""Concrete type that disables the boundary layer scheme."""
+struct NoBoundaryLayer <: BoundaryLayer end
+
+"""Following Held and Suarez, 1996 BAMS"""
+Base.@kwdef struct LinearDrag{NF<:Real} <: BoundaryLayer
+    σb::NF = 0.7        # sigma coordinate below which linear drag is applied
+    drag_time::NF = 1.0 # [day] time scale for linear drag coefficient at σ=1 (=1/kf in HS96)
+end
+
+LinearDrag(;kwargs...) = LinearDrag{Float64}(;kwargs...)


### PR DESCRIPTION
This introduces the simple boundary layer scheme from [Held and Suarez](https://journals.ametsoc.org/view/journals/bams/75/10/1520-0477_1994_075_1825_apftio_2_0_co_2.xml?tab_body=pdf) 

![image](https://user-images.githubusercontent.com/25530332/228046998-fda3cb75-cc23-4179-862d-8acd68f516af.png)

and also introduces `abstract type BoundaryLayer end` with

```julia
struct NoBoundaryLayer end
struct LinearDrag ... end
```
such that `run_speedy(boundary_layer=NoBoundaryLayer())` switches it off but

```julia
run_speedy(boundary_layer=LinearDrag(kwargs...))
```
uses that scheme and in general one can pass on any struct `<: BoundaryLayer` when also defining `boundary_layer!(column,::MyBoundaryLayer,model)` to introduce a new scheme.

@white-alistair this is the first time the `parameterization_tendencies!` loop actually runs through and executes things, but other schemes are currently commented. I want to test them one by one.