### PR TITLE
Missing `(-1)^{n+1}` factor from hyperdiffusion term

### DIFF
--- a/docs/src/dynamical_core.md
+++ b/docs/src/dynamical_core.md
@@ -15,10 +15,10 @@ The barotropic vorticity equation is the prognostic equation that describes the 
 relative vorticity ``\zeta`` with advection, Coriolis force and diffusion in a single global layer.
 
 ```math
-\frac{\partial \zeta}{\partial t} + \nabla \cdot (\mathbf{u}(\zeta + f)) = \nu\nabla^{2n}\zeta
+\frac{\partial \zeta}{\partial t} + \nabla \cdot (\mathbf{u}(\zeta + f)) = (-1)^{n+1}\nu\nabla^{2n}\zeta
 ```
-with time ``t``, velocity vector ``\mathbf{u} = (u,v)``, Coriolis parameter ``f`` and hyperdiffusion
-``\nu\nabla^{2n}\zeta`` (see [Horizontal diffusion](@ref)). Starting with some relative vorticity
+with time ``t``, velocity vector ``\mathbf{u} = (u, v)``, Coriolis parameter ``f`` and hyperdiffusion
+``(-1)^{n+1} \nu \nabla^{2n} \zeta`` (see [Horizontal diffusion](@ref)). Starting with some relative vorticity
 ``\zeta``, the [Laplacian](@ref) is inverted to obtain the stream function ``\Psi``
 
 ```math

--- a/docs/src/dynamical_core.md
+++ b/docs/src/dynamical_core.md
@@ -17,8 +17,8 @@ relative vorticity ``\zeta`` with advection, Coriolis force and diffusion in a s
 ```math
 \frac{\partial \zeta}{\partial t} + \nabla \cdot (\mathbf{u}(\zeta + f)) = (-1)^{n+1}\nu\nabla^{2n}\zeta
 ```
-with time ``t``, velocity vector ``\mathbf{u} = (u, v)``, Coriolis parameter ``f`` and hyperdiffusion
-``(-1)^{n+1} \nu \nabla^{2n} \zeta`` (see [Horizontal diffusion](@ref)). Starting with some relative vorticity
+with time ``t``, velocity vector ``\mathbf{u} = (u, v)``, Coriolis parameter ``f``, and hyperdiffusion
+``(-1)^{n+1} \nu \nabla^{2n} \zeta`` (``n`` is the hyperdiffusion order; see [Horizontal diffusion](@ref)). Starting with some relative vorticity
 ``\zeta``, the [Laplacian](@ref) is inverted to obtain the stream function ``\Psi``
 
 ```math

--- a/src/dynamics/define_diffusion.jl
+++ b/src/dynamics/define_diffusion.jl
@@ -53,35 +53,34 @@ function HorizontalDiffusion(   scheme::HyperDiffusion,
         @unpack time_scale, time_scale_stratosphere = scheme
     end
 
-    # Diffusion is applied by multiplication of the (absolute) eigenvalues of the Laplacian l*(l+1)
-    # normalise by the largest eigenvalue lmax*(lmax+1) such that the highest wavenumber lmax
+    # Diffusion is applied by multiplication of the eigenvalues of the Laplacian -l*(l+1)
+    # normalise by the largest eigenvalue -lmax*(lmax+1) such that the highest wavenumber lmax
     # is dampened to 0 at the given time scale raise to a power of the Laplacian for hyperdiffusion
     # (=more scale-selective for smaller wavenumbers)
-    largest_eigenvalue = lmax*(lmax+1)
+    largest_eigenvalue = -lmax*(lmax+1)
 
     # PREALLOCATE as vector as only dependend on degree l
     # Damping coefficients for explicit part of the diffusion (=ν∇²ⁿ)
     ∇²ⁿ = zeros(NF,lmax+2)                  # for temperature and vorticity (explicit)
     ∇²ⁿ_stratosphere = zeros(NF,lmax+2)     # for divergence (explicit)
 
-    # Implicit part (= 1/(1+2Δtν∇²ⁿ))
+    # Implicit part (= 1/(1-2Δtν∇²ⁿ))
     ∇²ⁿ_implicit = zeros(NF,lmax+2)
     ∇²ⁿ_implicit_stratosphere = zeros(NF,lmax+2)
 
     # PRECALCULATE for every degree l
     for l in 0:lmax+1
-        # eigenvalue is l*(l+1), but 1-based here l→l-1
-        norm_eigenvalue = l*(l+1)/largest_eigenvalue        # normal diffusion ∇²
+        eigenvalue_norm = -l*(l+1)/largest_eigenvalue       # normal diffusion ∇², power=1
 
-        # Explicit part (=ν∇²ⁿ), time scales to damping frequencies [1/s] times norm. eigenvalue
+        # Explicit part (=-ν∇²ⁿ), time scales to damping frequencies [1/s] times norm. eigenvalue
         # time scale [hrs] *3600-> [s]
-        ∇²ⁿ[l+1] = norm_eigenvalue^power/(3600*time_scale)*radius
-        ∇²ⁿ_implicit[l+1] = 1/(1+2Δt*∇²ⁿ[l+1])              # and implicit part of the diffusion (= 1/(1+2Δtν∇²ⁿ))
+        ∇²ⁿ[l+1] = -eigenvalue_norm^power/(3600*time_scale)*radius
+        ∇²ⁿ_implicit[l+1] = 1/(1-2Δt*∇²ⁿ[l+1])              # and implicit part of the diffusion (= 1/(1-2Δtν∇²ⁿ))
 
         # add additional diffusion for stratosphere
-        ∇²ⁿ_stratosphere[l+1] = ∇²ⁿ[l+1] + 
+        ∇²ⁿ_stratosphere[l+1] = ∇²ⁿ[l+1] - 
             norm_eigenvalue^power_stratosphere/(3600*time_scale_stratosphere)*radius
-        ∇²ⁿ_implicit_stratosphere[l+1] = 1/(1+2Δt*∇²ⁿ_stratosphere[l+1])
+        ∇²ⁿ_implicit_stratosphere[l+1] = 1/(1-2Δt*∇²ⁿ_stratosphere[l+1])
     end
 
     return HorizontalDiffusion(∇²ⁿ,∇²ⁿ_stratosphere,∇²ⁿ_implicit,∇²ⁿ_implicit_stratosphere)

--- a/src/dynamics/define_diffusion.jl
+++ b/src/dynamics/define_diffusion.jl
@@ -70,7 +70,7 @@ function HorizontalDiffusion(   scheme::HyperDiffusion,
 
     # PRECALCULATE for every degree l
     for l in 0:lmax+1
-        eigenvalue_norm = -l*(l+1)/largest_eigenvalue       # normal diffusion ∇², power=1
+        eigenvalue_norm = -l*(l+1)/largest_eigenvalue       # normalised diffusion ∇², power=1
 
         # Explicit part (=-ν∇²ⁿ), time scales to damping frequencies [1/s] times norm. eigenvalue
         # time scale [hrs] *3600-> [s]
@@ -79,7 +79,7 @@ function HorizontalDiffusion(   scheme::HyperDiffusion,
 
         # add additional diffusion for stratosphere
         ∇²ⁿ_stratosphere[l+1] = ∇²ⁿ[l+1] - 
-            norm_eigenvalue^power_stratosphere/(3600*time_scale_stratosphere)*radius
+            eigenvalue_norm^power_stratosphere/(3600*time_scale_stratosphere)*radius
         ∇²ⁿ_implicit_stratosphere[l+1] = 1/(1-2Δt*∇²ⁿ_stratosphere[l+1])
     end
 

--- a/src/dynamics/diffusion.jl
+++ b/src/dynamics/diffusion.jl
@@ -6,7 +6,7 @@
 
 Apply horizontal diffusion to a 2D field `A` in spectral space by updating its tendency `tendency`
 with an implicitly calculated diffusion term. The implicit diffusion of the next time step is split
-into an explicit part `damp_expl` and an implicit part `damp_impl`, such that both can be calculated
+into an explicit part `∇²ⁿ_expl` and an implicit part `∇²ⁿ_impl`, such that both can be calculated
 in a single forward step by using `A` as well as its tendency `tendency`."""
 function horizontal_diffusion!( tendency::LowerTriangularMatrix{Complex{NF}},   # tendency of a 
                                 A::LowerTriangularMatrix{Complex{NF}},          # spectral horizontal field
@@ -21,9 +21,9 @@ function horizontal_diffusion!( tendency::LowerTriangularMatrix{Complex{NF}},   
     for m in 1:mmax         # loops over all columns/order m
         for l in m:lmax-1   # but skips the lmax+2 degree (1-based)
             lm += 1         # single index lm corresponding to harmonic l,m
-            tendency[lm] = (tendency[lm] - ∇²ⁿ_expl[l]*A[lm])*∇²ⁿ_impl[l]
+            tendency[lm] = (tendency[lm] + ∇²ⁿ_expl[l]*A[lm])*∇²ⁿ_impl[l]
         end
-        lm += 1         # skip last row, LowerTriangularMatrices are of size lmax+2 x mmax+1
+        lm += 1             # skip last row for scalar quantities
     end
 end
 


### PR DESCRIPTION
I believe that the hyperdiffusion term is missing a $(-1)^{n+1}$ factor? For example, for $n=1$ it's plain-old viscosity so it  should be $+\nu\nabla^2\zeta$ but for $n=2$ it should be $-\nu\nabla^4\zeta$, otherwise the hyperdiffusion is not dissipative.

Am I right? If so, perhaps this mistake propagates elsewhere in the docs?

closes #286