### PR TITLE
New stratosphere diffusion defaults

### DIFF
--- a/src/dynamics/define_diffusion.jl
+++ b/src/dynamics/define_diffusion.jl
@@ -4,8 +4,8 @@ Base.@kwdef struct HyperDiffusion <: DiffusionParameters
     time_scale::Float64 = 2.5                   # Diffusion time scale [hrs] for temp, vor, div
     
     # additional diffusion in stratosphere
-    power_stratosphere::Int = 1                 # additional ∇² for stratosphere
-    time_scale_stratosphere::Float64 = 12       # associated time scale
+    power_stratosphere::Int = 2                 # additional ∇² for stratosphere
+    time_scale_stratosphere::Float64 = 24       # associated time scale
     tapering_σ::Float64 = 0.2                   # increase 1/time scale linearly above this σ
 
     # reduce time scale of diffusion linearly with increasing model resolution?


### PR DESCRIPTION
Because of #289 the additional diffusion in the stratosphere is changed to a biharmonic diffusion (power=2) and a slightly longer time scale (24hours at T31). Comparison

![image](https://user-images.githubusercontent.com/25530332/231008485-6a2198cf-3d52-46eb-9083-fbdbe3daefa9.png)

Via 
```julia
julia> p,d,m = initialize_speedy(PrimitiveDryCore,nlev=31,diffusion=HyperDiffusion(power_stratosphere=2,time_scale_stratosphere=24));

julia> semilogy(0:32,1 .- m.horizontal_diffusion.∇²ⁿ_implicit[1],label=("power=2,time_scale=24"))
```

So the new default is red, it was blue, which caused problems at the transition into the stratosphere (defined by tapering_sigma here). No additional diffusion would be green (set tapering to top at the atmosphere, so effectively disable). Judging from #289 blue is unstable at T255 31 levels, but orange, red green are stable.