### PR TITLE
Progress.txt output with speed and ETA

### DIFF
--- a/src/output/pretty_printing.jl
+++ b/src/output/pretty_printing.jl
@@ -21,17 +21,13 @@ function Base.show(io::IO, P::PrognosticVariables)
     print(io,UnicodePlots.heatmap(ζ_grid';plot_kwargs...))
 end
 
-# hack: define global constant whose element will be changed in initialize_feedback
-# used to pass on the time step to ProgressMeter.speedstring via calling this
-# constant from the ProgressMeter module
-const DT_IN_SEC = [1800]
-
-function ProgressMeter.speedstring(sec_per_iter,dt_in_sec=SpeedyWeather.DT_IN_SEC)
+# adapted from ProgressMeter.jl
+function speedstring(sec_per_iter,dt_in_sec)
     if sec_per_iter == Inf
         return "  N/A  days/day"
     end
 
-    sim_time_per_time = dt_in_sec[1]/sec_per_iter
+    sim_time_per_time = dt_in_sec/sec_per_iter
 
     for (divideby, unit) in (   (365*1_000, "millenia"),
                                 (365, "years"),
@@ -42,4 +38,51 @@ function ProgressMeter.speedstring(sec_per_iter,dt_in_sec=SpeedyWeather.DT_IN_SE
         end
     end
     return " <2 hours/days"
+end
+
+# adapted from ProgressMeter.jl
+function remaining_time(p::ProgressMeter.Progress)
+    elapsed_time = time() - p.tinit
+    est_total_time = elapsed_time * (p.n - p.start) / (p.counter - p.start)
+    if 0 <= est_total_time <= typemax(Int)
+        eta_sec = round(Int, est_total_time - elapsed_time )
+        eta = ProgressMeter.durationstring(eta_sec)
+    else
+        eta = "N/A"
+    end
+    return eta
+end
+
+# hack: define global constant whose element will be changed in initialize_feedback
+# used to pass on the time step to ProgressMeter.speedstring via calling this
+# constant from the ProgressMeter module
+const DT_IN_SEC = Ref(1800)
+
+function ProgressMeter.speedstring(sec_per_iter,dt_in_sec=SpeedyWeather.DT_IN_SEC)
+    speedstring(sec_per_iter,dt_in_sec[])
+end
+
+"""
+    readable_secs(secs::Real) -> Dates.CompoundPeriod
+
+Returns `Dates.CompoundPeriod` rounding to either (days, hours), (hours, minutes), (minutes,
+seconds), or seconds with 1 decimal place accuracy for >10s and two for less.
+E.g.
+```julia
+julia> readable_secs(12345)
+3 hours, 26 minutes
+```
+"""
+function readable_secs(secs::Real)
+    millisecs = Dates.Millisecond(round(secs * 10 ^ 3))
+    if millisecs >= Dates.Day(1)
+        return Dates.canonicalize(round(millisecs, Dates.Hour))
+    elseif millisecs >= Dates.Hour(1)
+        return Dates.canonicalize(round(millisecs, Dates.Minute))
+    elseif millisecs >= Dates.Minute(1)
+        return Dates.canonicalize(round(millisecs, Dates.Second))
+    elseif millisecs >= Dates.Second(10)
+        return Dates.canonicalize(round(millisecs, Dates.Millisecond(100)))
+    end
+    return Dates.canonicalize(round(millisecs, Dates.Millisecond(10)))
 end

--- a/src/run_speedy.jl
+++ b/src/run_speedy.jl
@@ -11,12 +11,12 @@ function run_speedy(::Type{NF}=DEFAULT_NF,          # default number format
                     kwargs...                       # all additional non-default parameters
                     ) where {NF<:AbstractFloat,Model<:ModelSetup}
 
-    # INITALIZE MODEL
+    # INITIALIZE MODEL
     progn_vars,diagn_vars,model_setup = initialize_speedy(NF,Model;kwargs...)
 
     # START MODEL INTEGRATION
     time_stepping!(progn_vars,diagn_vars,model_setup)
-    return progn_vars                               # return prognostic variables when finished
+    return progn_vars                              # return prognostic variables when finished
 end
 
 # if only Model M provided, use default number format NF

--- a/src/utility_functions.jl
+++ b/src/utility_functions.jl
@@ -54,31 +54,6 @@ function flipsign!(A::AbstractArray)
     A
 end
 
-"""
-    readable_secs(secs::Real) -> Dates.CompoundPeriod
-
-Returns `Dates.CompoundPeriod` rounding to either (days, hours), (hours, minutes), (minutes,
-seconds), or seconds with 1 decimal place accuracy for >10s and two for less.
-E.g.
-```julia
-julia> readable_secs(12345)
-3 hours, 26 minutes
-```
-"""
-function readable_secs(secs::Real)
-    millisecs = Dates.Millisecond(round(secs * 10 ^ 3))
-    if millisecs >= Dates.Day(1)
-        return Dates.canonicalize(round(millisecs, Dates.Hour))
-    elseif millisecs >= Dates.Hour(1)
-        return Dates.canonicalize(round(millisecs, Dates.Minute))
-    elseif millisecs >= Dates.Minute(1)
-        return Dates.canonicalize(round(millisecs, Dates.Second))
-    elseif millisecs >= Dates.Second(10)
-        return Dates.canonicalize(round(millisecs, Dates.Millisecond(100)))
-    end
-    return Dates.canonicalize(round(millisecs, Dates.Millisecond(10)))
-end
-
 # define as will only become availale in Julia 1.9
 pkgversion(m::Module) = VersionNumber(TOML.parsefile(joinpath(
     dirname(string(first(methods(m.eval)).file)), "..", "Project.toml"))["version"])


### PR DESCRIPTION
Looks now like
```
Starting SpeedyWeather.jl run 0002 on Wed, 12 Apr 2023 12:26:24
Integrating 100.0 days at a spectral resolution of T63 on a FullGaussianGrid with 18432 grid points.
Number format is Float64.
All data will be stored in /Users/milan/git/SpeedyWeather.jl/run-0002.

  5%, ETA: 0:00:19, 1236.72 years/day
 10%, ETA: 0:00:19, 1144.15 years/day
 15%, ETA: 0:00:21, 993.03 years/day
 20%, ETA: 0:00:19, 976.10 years/day
 25%, ETA: 0:00:18, 984.22 years/day
 30%, ETA: 0:00:17, 985.48 years/day
 35%, ETA: 0:00:16, 986.58 years/day
 40%, ETA: 0:00:14, 988.11 years/day
 45%, ETA: 0:00:13, 991.32 years/day
 50%, ETA: 0:00:12, 1003.44 years/day
 55%, ETA: 0:00:11, 1001.10 years/day
 60%, ETA: 0:00:10, 999.00 years/day
 65%, ETA: 0:00:08, 993.91 years/day
 70%, ETA: 0:00:07, 996.38 years/day
 75%, ETA: 0:00:06, 996.71 years/day
 80%, ETA: 0:00:05, 991.89 years/day
 85%, ETA: 0:00:04, 988.71 years/day
 90%, ETA: 0:00:02, 990.46 years/day
 95%, ETA: 0:00:01, 987.24 years/day
100%, ETA: 0:00:00, 984.24 years/day

Integration done in 24 seconds, 100 milliseconds.
```