### PR TITLE
new time step scaling following Jablonowski

### DIFF
--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -209,8 +209,8 @@ Base.@kwdef struct Parameters{Model<:ModelSetup} <: AbstractParameters{Model}
     "number of days to integrate for"
     n_days::Float64 = 10
 
-    "time step in minutes for T31, scale linearly to `trunc`"
-    Δt_at_T31::Float64 = 30
+    "time step in seconds for T21, scale linearly to `trunc`"
+    Δt_at_T21::Float64 = 2400
 
 
     # NUMERICS

--- a/src/dynamics/constants.jl
+++ b/src/dynamics/constants.jl
@@ -70,7 +70,7 @@ function DynamicsConstants(P::Parameters)
     @unpack RH_thresh_pbl_lsc, RH_thresh_range_lsc, RH_thresh_max_lsc, humid_relax_time_lsc = P  # Large-scale condensation
     @unpack pres_thresh_cnv, RH_thresh_pbl_cnv, RH_thresh_trop_cnv, humid_relax_time_cnv, max_entrainment, ratio_secondary_mass_flux = P  # Convection
         
-    Δt      = floor(Δt_at_T21*(21/trunc))       # scale time step Δt to specified resolution
+    Δt      = round(Δt_at_T21*(21/trunc))       # scale time step Δt to specified resolution
     Δt_sec  = convert(Int,Δt)                   # encode time step Δt [s] as integer
     Δt_hrs  = Δt/3600                           # convert time step Δt from minutes to hours
     n_timesteps = ceil(Int,24*n_days/Δt_hrs)    # number of time steps to integrate for

--- a/src/dynamics/constants.jl
+++ b/src/dynamics/constants.jl
@@ -64,14 +64,13 @@ function DynamicsConstants(P::Parameters)
 
     # TIME INTEGRATION CONSTANTS
     @unpack robert_filter, williams_filter = P
-    @unpack trunc, Δt_at_T31, n_days, output_dt = P
+    @unpack trunc, Δt_at_T21, n_days, output_dt = P
 
     # PARAMETRIZATION CONSTANTS
     @unpack RH_thresh_pbl_lsc, RH_thresh_range_lsc, RH_thresh_max_lsc, humid_relax_time_lsc = P  # Large-scale condensation
     @unpack pres_thresh_cnv, RH_thresh_pbl_cnv, RH_thresh_trop_cnv, humid_relax_time_cnv, max_entrainment, ratio_secondary_mass_flux = P  # Convection
-
-    Δt_min_at_trunc = Δt_at_T31*(31/trunc)      # scale time step Δt to specified resolution
-    Δt      = round(Δt_min_at_trunc*60)         # convert time step Δt from minutes to whole seconds
+        
+    Δt      = floor(Δt_at_T21*(21/trunc))       # scale time step Δt to specified resolution
     Δt_sec  = convert(Int,Δt)                   # encode time step Δt [s] as integer
     Δt_hrs  = Δt/3600                           # convert time step Δt from minutes to hours
     n_timesteps = ceil(Int,24*n_days/Δt_hrs)    # number of time steps to integrate for

--- a/test/netcdf_output.jl
+++ b/test/netcdf_output.jl
@@ -23,7 +23,7 @@
         
         # this is a nonsense simulation with way too large timesteps, but it's here to test the time axis output
         # 1kyrs simulation
-        p, d, m = initialize_speedy(Float32, output=true, output_path=tmp_output_path, n_days=365000, Δt_at_T31=60*24*365*10, output_dt=24*365*10, run_id="long-output-test")
+        p, d, m = initialize_speedy(Float32, trunc=21, output=true, output_path=tmp_output_path, n_days=365000, Δt_at_T21=3600*24*365*10, output_dt=24*365*10, run_id="long-output-test")
         SpeedyWeather.time_stepping!(p, d, m)
 
         tmp_read_path = joinpath(tmp_output_path, "run-long-output-test", "output.nc")


### PR DESCRIPTION
Jablonowski et al use 

![image](https://user-images.githubusercontent.com/25530332/231873921-1d16aeef-e747-429a-86e7-2d33f6112e95.png)

our time step was slightly longer, new defaults so that we stay below theirs! Now just do:

```julia
dt(T) = 2400*(21/T)
```