### PR TITLE
Truncate orography always to smooth T85

### DIFF
--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -249,7 +249,7 @@ Base.@kwdef struct Parameters{Model<:ModelSetup} <: AbstractParameters{Model}
     boundary_path::String = ""
 
     "orography"
-    orography::AbstractOrography = EarthOrography(smoothing_strength=1e-2,smoothing_power=0.1)
+    orography::AbstractOrography = EarthOrography()
 
     "scale orography by a factor"
     orography_scale::Float64 = 1

--- a/src/dynamics/boundaries.jl
+++ b/src/dynamics/boundaries.jl
@@ -15,7 +15,8 @@ end
 Base.@kwdef struct EarthOrography <: AbstractOrography
     smoothing::Bool = true              # smooth the orography field?
     smoothing_power::Float64 = 1.0      # power of Laplacian for smoothing
-    smoothing_strength::Float64 = 0.2   # highest degree l is multiplied by
+    smoothing_strength::Float64 = 0.1   # highest degree l is multiplied by
+    smoothing_truncation::Int = 85      # resolution of orography
 end
 
 struct NoOrography <: AbstractOrography end
@@ -90,7 +91,9 @@ function initialize_orography!( orog::Orography,
     
     copyto!(geopot_surf,orography_spec)     # truncates to the size of geopot_surf, no *gravity yet
     if EO.smoothing                         # smooth orography in spectral space?
-        SpeedyTransforms.spectral_smoothing!(geopot_surf,EO.smoothing_strength,power=EO.smoothing_power)
+        SpeedyTransforms.spectral_smoothing!(geopot_surf,EO.smoothing_strength,
+                                                            power=EO.smoothing_power,
+                                                            truncation=EO.smoothing_truncation)
     end
 
     gridded!(orography,geopot_surf,S)       # to grid-point space


### PR DESCRIPTION
follow up on #310 and #308 

T340 topography would now look like blue, full orography in orange, and previous default similar to green

![image](https://github.com/SpeedyWeather/SpeedyWeather.jl/assets/25530332/869162ed-3d8d-42f8-a452-256afba7177b)
