### PR TITLE
1st order upwind scheme for vertical advection

### DIFF
--- a/src/dynamics/tendencies_dynamics.jl
+++ b/src/dynamics/tendencies_dynamics.jl
@@ -296,14 +296,14 @@ function _vertical_advection!(  ξ_tend::Grid,           # tendency of quantity 
                                 ξ_below::Grid,          # quantity ξ at k+1
                                 Δσₖ::NF                 # layer thickness on σ levels
                                 ) where {NF<:AbstractFloat,Grid<:AbstractGrid{NF}}
-    Δσₖ⁻¹ = -1/Δσₖ                                      # precompute
+    Δσₖ⁻¹ = 1/Δσₖ                                      # precompute
 
     # += as the tendencies already contain the parameterizations
     for ij in eachgridpoint(ξ_tend,σ_tend_above,σ_tend_below,ξ_above,ξ,ξ_below)
         # 1st order upwind scheme
-        ξ_face_below = signbit(σ_tend_below[ij]) ? ξ_below[ij] : ξ[ij]  # upwind: if velocity < 0, pick ξ from k+1
-        ξ_face_above = signbit(σ_tend_above[ij]) ? ξ[ij] : ξ_above[ij]
-        ξ_tend[ij] += Δσₖ⁻¹ * (σ_tend_below[ij]*(ξ_face_below - ξ[ij]) + σ_tend_above[ij]*(ξ[ij] - ξ_face_above))
+        σ̇⁺ = max(σ_tend_above[ij],0)        # velocity into layer k from above
+        σ̇⁻ = min(σ_tend_below[ij],0)        # velocity into layer k from below
+        ξ_tend[ij] -= Δσₖ⁻¹ * (σ̇⁺*(ξ[ij] - ξ_above[ij]) + σ̇⁻*(ξ_below[ij] - ξ[ij]))
     end
 
     # # centred scheme


### PR DESCRIPTION
At the moment we have a 2nd order centred scheme for vertical advection, which is known to be very dispersive, e.g. 

![image](https://github.com/SpeedyWeather/SpeedyWeather.jl/assets/25530332/f8fad796-a41b-44c9-b8df-b4ac0633df12)

this arises from the general form

![image](https://github.com/SpeedyWeather/SpeedyWeather.jl/assets/25530332/8116676d-7f5e-40a3-9bde-fa48829cf12c)

for $\xi_{k+1/2} = 1/2*(\xi_k + \xi_{k+1})$, i.e. just average the values above and below, this is a centred scheme:

![image](https://github.com/SpeedyWeather/SpeedyWeather.jl/assets/25530332/cf99ffc2-4430-4da2-95af-04a0519a9a4c)

But it becomes upwind for (velocities are positive towards increasing k, i.e. top to bottom)

$$ \xi_{k+1/2} = \begin{cases} \xi_k & \text{for} & M_{k+1/2} > 0 \newline \xi_{k+1} &\text{else.} & \end{cases}$$

thanks to @valeriabarra for the suggestion