### PR TITLE
Plot `::AbstractGrid` as Unicode heatmap

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,8 @@
 using Documenter, SpeedyWeather
 
 makedocs(
-    format = Documenter.HTML(
-    prettyurls = get(ENV, "CI", nothing) == "true"),
+    format=Documenter.HTML(prettyurls=get(ENV, "CI", nothing)=="true",
+    ansicolor=true),
     sitename="SpeedyWeather.jl",
     authors="M Klöwer and SpeedyWeather contributors",
     modules=[SpeedyWeather],

--- a/docs/src/ringgrids.md
+++ b/docs/src/ringgrids.md
@@ -19,88 +19,61 @@ The following explanation of how to use these can be mostly applied to any of th
 there are certain functions that are not defined, e.g. the full grids can be trivially converted
 to a `Matrix` but not the `OctahedralGaussianGrid`.
 
+!!! note "What is a ring?"
+    We use the term *ring*, short for *iso-latitude ring*, to refer to a sequence of grid points
+    that all share the same latitude. A latitude-longitude grid is a ring grid, as it organises
+    its grid-points into rings. However, other grids, like the
+    [cubed-sphere](https://en.wikipedia.org/wiki/Quadrilateralized_spherical_cube)
+    are not based on iso-latitude rings. SpeedyWeather.jl only works with ring grids
+    because its a requirement for the [Spherical Harmonic Transform](@ref) to be efficient.
+    See [Grids](@ref).
+
 ## Creating data on a RingGrid
 
-Every grid in RingGrids has a `data` field, which is a vector containing the data on the grid.
+Every `grid` in RingGrids has a `grid.data` field, which is a vector containing the data on the grid.
 The grid points are unravelled west to east then north to south, meaning that it starts at
 90˚N and 0˚E then walks eastward for 360˚ before jumping on the next latitude ring further south,
 this way circling around the sphere till reaching the south pole. This may also be called _ring order_.
 
-Data on a 96x48 `Matrix` which follows this ring order can be put on a `FullGaussianGrid` like so
-```julia
-julia> map
-96×48 Matrix{Float32}:
- -0.219801   -0.519598   1.2066    …   0.81304    -1.16023    1.0353
- -0.55615    -1.05712   -0.227948     -2.06369     1.10353    1.60918
-  0.446913   -0.856431   1.58896      -1.0894     -0.894315   0.632353
-  0.445915   -0.107201  -0.577785      0.574784   -0.825049   1.29677
-  1.194      -0.353374   1.30581       0.465554    0.358457  -0.726567
-  1.28693     1.43997    0.691283  …  -0.330544   -0.267588   0.181308
-  ⋮                                ⋱   ⋮
- -0.432703    0.17233    0.89222       0.888913    1.32787   -0.248779
- -0.404498    0.127172  -0.64237       0.127979   -1.55253   -2.00749
- -0.857746   -0.433251  -0.468293      1.09825    -0.291169   1.07452
-  0.375367   -0.218278   0.492855     -0.287976    0.878996  -1.19745
- -0.0619525  -0.129129  -1.35502   …   0.0824819   0.481736   0.845638
-
-julia> grid = FullGaussianGrid(map)
-4608-element, 48-ring FullGaussianGrid{Float32}:
- -0.21980117
- -0.5561496
-  0.44691312
-  0.4459149
-  1.1940043
-  1.2869298
-  ⋮
- -0.24877885
- -2.007495
-  1.0745221
- -1.197454
-  0.84563845
+Data in a `Matrix` which follows this ring order can be put on a `FullGaussianGrid` like so
+```@example ringgrids
+using SpeedyWeather.RingGrids
+map = randn(Float32,8,4)
 ```
-A full Gaussian grid has always ``2N`` x ``N`` grid points, but a `FullClenshawGrid` has ``2N`` x ``N-1``, if those dimensions don't match, the creation will throw an error. To reobtain the data from a grid, you can access its `data` field
-which returns a normal `Vector`
-```julia
-julia> grid.data
-4608-element Vector{Float32}:
- -0.21980117
- -0.5561496
-  0.44691312
-  0.4459149
-  1.1940043
-  1.2869298
-  ⋮
- -0.24877885
- -2.007495
-  1.0745221
- -1.197454
-  0.84563845
+
+```@example ringgrids
+grid = FullGaussianGrid(map)
+```
+A full Gaussian grid has always ``2N`` x ``N`` grid points, but a `FullClenshawGrid` has ``2N`` x ``N-1``,
+if those dimensions don't match, the creation will throw an error. To reobtain the data from a grid,
+you can access its `data` field which returns a normal `Vector`
+```@example ringgrids
+grid.data
 ```
 Which can be reshaped to reobtain `map` from above. Alternatively you can `Matrix(grid)` to do this in one step
-```julia
-julia> map == Matrix(FullGaussianGrid(map))
-true
+```@example ringgrids
+map == Matrix(FullGaussianGrid(map))
 ```
 You can also use `zeros`,`ones`,`rand`,`randn` to create a grid, whereby `nlat_half`, i.e. the number of latitude
 rings on one hemisphere, Equator included, is used as a resolution parameter and here as a second argument.
-```julia
-julia> nlat_half = 4
-julia> grid = randn(OctahedralGaussianGrid{Float16},nlat_half)
-208-element, 8-ring OctahedralGaussianGrid{Float16}:
- -1.868
-  0.493
-  0.3142
-  1.871
-  1.349
-  0.623
-  ⋮
-  1.064
-  0.4346
- -0.641
-  0.1445
-  0.3909
+```@example ringgrids
+nlat_half = 4
+grid = randn(OctahedralGaussianGrid{Float16},nlat_half)
 ```
 and any element type `T` can be used for `OctahedralGaussianGrid{T}` and similar for other grid types.
+
+## Visualising RingGrid data
+
+As only the full grids can be reshaped into a matrix, the underyling data structure of any `AbstractGrid`
+is a vector. As shown in the examples above, one can therefore inspect the data as if it was a vector.
+But as that data has, through its `<:AbstractGrid` type, all the geometric information available to plot
+it on a map, RingGrids also exports `plot` function,
+based on [UnicodePlots](https://github.com/JuliaPlots/UnicodePlots.jl)' `heatmap`.
+```@example ringgrids
+nlat_half = 24
+grid = randn(OctahedralGaussianGrid,nlat_half)
+plot(grid)
+```
 
 ## Indexing RingGrids
 
@@ -109,20 +82,12 @@ exciting here are some examples how to make better use of the information that t
 
 We obtain the latitudes of the rings of a grid by calling `get_latd` (`get_lond` is only defined for full
 grids, or use `get_latdlonds` for latitudes, longitudes per grid point not per ring)
-```julia
-julia> latd = get_latd(grid)
-8-element Vector{Float64}:
-  73.79921362856324
-  52.81294318999426
-  31.704091745007943
-  10.569882312576093
- -10.569882312576093
- -31.704091745007943
- -52.81294318999426
- -73.79921362856324
+```@example ringgrids
+grid = randn(OctahedralClenshawGrid,5)
+latd = get_latd(grid)
 ```
 Now we could calculate Coriolis and add it on the grid as follows
-```julia
+```@example ringgrids
 rotation = 7.29e-5                  # angular frequency of Earth's rotation [rad/s]
 coriolis = 2rotation*sind.(latd)    # vector of coriolis parameters per latitude ring
 
@@ -139,7 +104,7 @@ end
 loop over all in-ring indices `i` (changing longitudes) to do something on the grid.
 Something similar can be done to scale/unscale with the cosine of latitude for example.
 We can always loop over all grid-points like so
-```julia
+```@example ringgrids
 for ij in eachgridpoint(grid)
     grid[ij]
 end
@@ -154,53 +119,16 @@ above. This information generally can also be used to interpolate our data from 
 request an interpolated value on some coordinates. Using our data on `grid` which is an `OctahedralGaussianGrid`
 from above we can use the `interpolate` function to get it onto a `FullGaussianGrid` (or any other grid for
 purpose)
-```julia
-julia> grid
-208-element, 8-ring OctahedralGaussianGrid{Float16}:
- -1.868
-  0.493
-  0.3142
-  1.871
-  1.349
-  0.623
-  ⋮
-  1.064
-  0.4346
- -0.641
-  0.1445
-  0.3909
-
-julia> interpolate(FullGaussianGrid,grid)
-128-element, 8-ring FullGaussianGrid{Float64}:
- -1.8681640625
-  0.4482421875
-  1.0927734375
-  1.4794921875
-  0.623046875
- -0.6435546875
-  ⋮
- -0.57763671875
-  1.064453125
-  0.16552734375
- -0.248291015625
-  0.329345703125
+```@example ringgrids
+grid = randn(OctahedralGaussianGrid{Float32},4)
 ```
-By default this will linearly interpolate (it's an anvil interpolator, see below) onto a grid with the same
+```@example ringgrids
+interpolate(FullGaussianGrid,grid)
+```
+By default this will linearly interpolate (it's an [Anvil interpolator](@ref), see below) onto a grid with the same
 `nlat_half`, but we can also coarse-grain or fine-grain by specifying `nlat_half` directly as 2nd argument
-```julia
-julia> interpolate(FullGaussianGrid,6,grid)
-288-element, 12-ring FullGaussianGrid{Float64}:
- -1.248046875
-  0.08984375
-  0.2763671875
-  0.76513671875
-  1.1767578125
-  ⋮
-  0.26416015625
- -0.295166015625
- -0.271728515625
-  0.0511474609375
-  0.0814208984375
+```@example ringgrids
+interpolate(FullGaussianGrid,6,grid)
 ```
 So we got from an `8-ring OctahedralGaussianGrid{Float16}` to a `12-ring FullGaussianGrid{Float64}`, so it did
 a conversion from `Float16` to `Float64` on the fly too, because the default precision is `Float64` unless
@@ -208,19 +136,13 @@ specified. `interpolate(FullGaussianGrid{Float16},6,grid)` would have interpolat
 `Float16`.
 
 One can also interpolate onto a give cordinate ˚N, ˚E like so
-```julia
-julia> interpolate(30.0,10.0,grid)
-1-element Vector{Float16}:
- 0.9297
+```@example ringgrids
+interpolate(30.0,10.0,grid)
 ```
 we interpolated the data from `grid` onto 30˚N, 10˚E. To do this simultaneously for many coordinates they can
 be packed into a vector too
-```julia
-julia> interpolate([30.0,40.0,50.0],[10.0,10.0,10.0],grid)
-3-element Vector{Float16}:
-  0.9297
-  0.08887
- -0.929
+```@example ringgrids
+interpolate([30.0,40.0,50.0],[10.0,10.0,10.0],grid)
 ```
 which returns the data on `grid` at 30˚N, 40˚N, 50˚N, and 10˚E respectively. Note how the interpolation here
 retains the element type of `grid`.
@@ -247,138 +169,74 @@ to grid B many times, you can just reuse the same interpolator. If you want to c
 of the output grid but its total number of points remain constants then you can update the locator
 inside the interpolator and only else you will need to create a new interpolator. Let's look at this
 in practice. Say we have two grids an want to interpolate between them
-```julia
-julia> grid_in = rand(HEALPixGrid,4)
-julia> grid_out = zeros(FullClenshawGrid,6)
-julia> interp = RingGrids.interpolator(grid_out,grid_in)
+```@example ringgrids
+grid_in = rand(HEALPixGrid,4)
+grid_out = zeros(FullClenshawGrid,6)
+interp = RingGrids.interpolator(grid_out,grid_in)
 ```
 Now we have created an interpolator `interp` which knows about the geometry where to interpolate
 *from* and the coordinates there to interpolate *to*. It is also initialized, meaning it has
 precomputed the indices to of `grid_in` that are supposed to be used. It just does not know about
 the data of `grid_in` (and neither of `grid_out` which will be overwritten anyway). We can now do
-```julia
-julia> interpolate!(grid_out,grid_in,interp);
-julia> grid_out
-264-element, 11-ring FullClenshawGrid{Float64}:
- 0.47698810225785837
- 0.49923033302273034
- 0.5214725637876022
- 0.5437147945524742
- ⋮
- 0.6277318221906577
- 0.5934538182075797
- 0.6009226488782581
- 0.6083914795489366
+```@example ringgrids
+interpolate!(grid_out,grid_in,interp)
+grid_out
 ```
-which is identical to `interpolate(grid_out,grid_in)` but you can reuse `interp` with more data.
+which is identical to `interpolate(grid_out,grid_in)` but you can reuse `interp` for other data.
 The interpolation can also handle various element types (the interpolator `interp` does not have
 to be updated for this either)
-```julia
-julia> grid_out = zeros(FullClenshawGrid{Float16},6);
-julia> interpolate!(grid_out,grid_in,interp)
-julia> grid_out
-264-element, 11-ring FullClenshawGrid{Float16}:
- 0.477
- 0.4993
- 0.5215
- 0.544
- 0.5493
- 0.555
- ⋮
- 0.662
- 0.628
- 0.5933
- 0.601
- 0.6084
+```@example ringgrids
+grid_out = zeros(FullClenshawGrid{Float16},6);
+interpolate!(grid_out,grid_in,interp)
+grid_out
 ```
-and we have converted data from a `HEALPixGrid{Float64}` (which is always default if not specified)
+and we have converted data from a `HEALPixGrid{Float64}` (`Float64` is always default if not specified)
 to a `FullClenshawGrid{Float16}` including the type conversion Float64-Float16 on the fly.
 Technically there are three data types and their combinations possible: The input data will come
 with a type, the output array has an element type and the interpolator has precomputed weights
 with a given type. Say we want to go from Float16 data on an `OctahedralGaussianGrid` to Float16
 on a `FullClenshawGrid` but using Float32 precision for the interpolation itself, we would do
 this by
-```julia
-julia> grid_in = randn(OctahedralGaussianGrid{Float16},24)
-julia> grid_out = zeros(FullClenshawGrid{Float16},24)
-julia> interp = RingGrids.interpolator(Float32,grid_out,grid_in)
-julia> interpolate!(grid_out,grid_in,interp)
-julia> grid_out
-4512-element, 47-ring FullClenshawGrid{Float16}:
- -0.954
- -0.724
- -0.4941
- -0.264
- -0.03433
-  0.1796
-  ⋮
- -0.5703
- -0.3481
- -0.07666
-  0.1958
-  0.467
+```@example ringgrids
+grid_in = randn(OctahedralGaussianGrid{Float16},24)
+grid_out = zeros(FullClenshawGrid{Float16},24)
+interp = RingGrids.interpolator(Float32,grid_out,grid_in)
+interpolate!(grid_out,grid_in,interp)
+grid_out
 ```
 As a last example we want to illustrate a situation where we would always want to interplate onto
 10 coordinates, but their locations may change. In order to avoid recreating an interpolator object
 we would do (`AnvilInterpolator` is described in [Anvil interpolator](@ref))
-```julia
-julia> npoints = 10    # number of coordinates to interpolate onto
-julia> interp = AnvilInterpolator(Float32,HEALPixGrid,24,npoints)
+```@example ringgrids
+npoints = 10    # number of coordinates to interpolate onto
+interp = AnvilInterpolator(Float32,HEALPixGrid,24,npoints)
 ```
 with the first argument being the number format used during interpolation, then the input grid type,
 its resolution in terms of `nlat_half` and then the number of points to interpolate onto. However,
 `interp` is not yet initialized as it does not know about the destination coordinates yet. Let's define
 them, but note that we already decided there's only 10 of them above.
-```julia
-julia> latds = collect(0.0:5.0:45.0)
-10-element Vector{Float64}:
-  0.0
-  5.0
-  ⋮
- 40.0
- 45.0
-
-julia> londs = collect(-10.0:2.0:8.0)
-10-element Vector{Float64}:
- -10.0
-  -8.0
-  -6.0
-  ⋮
-   6.0
-   8.0
+```@example ringgrids
+latds = collect(0.0:5.0:45.0)
+londs = collect(-10.0:2.0:8.0)
+nothing # hide
 ```
 now we can update the locator inside our interpolator as follows
-```julia
-julia> RingGrids.update_locator!(interp,latds,londs)
+```@example ringgrids
+RingGrids.update_locator!(interp,latds,londs)
 ```
 With data matching the input from above, a `nlat_half=24` HEALPixGrid, and allocate 10-element output vector
-```julia
-julia> output_vec = zeros(10)
-julia> grid_input = rand(HEALPixGrid,24)
+```@example ringgrids
+output_vec = zeros(10)
+grid_input = rand(HEALPixGrid,24)
+nothing # hide
 ```
 we can use the interpolator as follows
-```julia
-julia> interpolate!(output_vec,grid_input,interp)
-10-element Vector{Float64}:
- 0.3182548251299291
- 0.7499448926757676
- 0.25733825675836064
-  ⋮
- 0.2949249541923441
- 0.6690698461409016
- 0.6159433564856793
+```@example ringgrids
+interpolate!(output_vec,grid_input,interp)
 ```
 which is the approximately the same as doing it directly without creating an interpolator first and updating its locator
-```julia
-julia> interpolate(latds,londs,grid_input)
-10-element Vector{Float64}:
- 0.31825482404891603
- 0.7499448923165136
- 0.25733824520344434
-  ⋮
- 0.294924962125593
- 0.6690698486360254
- 0.6159433558779497
+```@example ringgrids
+interpolate(latds,londs,grid_input)
 ```
 but allows for a reuse of the interpolator. Note that the two output arrays are not exactly identical because we manually
 set our interpolator `interp` to use `Float32` for the interplation whereas the default is `Float64`.

--- a/src/RingGrids/RingGrids.jl
+++ b/src/RingGrids/RingGrids.jl
@@ -1,7 +1,10 @@
 module RingGrids
 
-using DocStringExtensions
+# DOCUMENTATION AND VISUALISATION
+using  DocStringExtensions
+import UnicodePlots
 
+# NUMERICS
 import Statistics: mean
 import FastGaussQuadrature
 
@@ -55,14 +58,16 @@ export  interpolate,
         update_locator,
         update_locator!
 
+export  plot
+
 include("utility_functions.jl")
 
 include("grids_general.jl")
-include("show.jl")
 include("full_grids.jl")
 include("octahedral.jl")
 include("healpix.jl")
 include("octahealpix.jl")
 include("quadrature_weights.jl")
 include("interpolation.jl")
+include("show.jl")
 end

--- a/src/RingGrids/grids_general.jl
+++ b/src/RingGrids/grids_general.jl
@@ -133,6 +133,7 @@ function get_latdlonds(Grid::Type{<:AbstractGrid},nlat_half::Integer)
 end
 
 get_latd(grid::Grid) where {Grid<:AbstractGrid} = get_latd(Grid,grid.nlat_half)
+get_lond(grid::Grid) where {Grid<:AbstractGrid} = get_lond(Grid,grid.nlat_half)
 
 function get_latd(Grid::Type{<:AbstractGrid},nlat_half::Integer)
     colat = get_colat(Grid,nlat_half)

--- a/src/RingGrids/interpolation.jl
+++ b/src/RingGrids/interpolation.jl
@@ -174,7 +174,10 @@ function interpolator(  Aout::AbstractGrid,
 end
     
 ## FUNCTIONS
-interpolate(latd::Real,lond::Real,A::AbstractGrid) = interpolate([latd],[lond],A)
+function interpolate(latd::Real,lond::Real,A::AbstractGrid)
+    Ai = interpolate([latd],[lond],A)
+    return Ai[1]
+end
 
 function interpolate(   latds::Vector{NF},     # latitudes to interpolate onto (90˚N...-90˚N)
                         londs::Vector{NF},     # longitudes to interpolate into (0˚...360˚E)

--- a/src/RingGrids/interpolation.jl
+++ b/src/RingGrids/interpolation.jl
@@ -407,21 +407,30 @@ function find_lon_indices(  λ::NF,      # longitude to find incides for (0˚...
 end
 
 """
-    N,S = average_on_poles( A::AbstractGrid,
-                            rings::Vector{<:UnitRange})
-
-N,S are the interpolated values of A onto the north/south pole, by averaging all values on the
-northern/southern-most rings respectively."""
-average_on_poles(A::AbstractGrid{NF},rings::Vector{<:UnitRange}) where NF = average_on_poles(NF,A,rings)
-
-function average_on_poles(  ::Type{NF},
-                            A::AbstractGrid,
+$(TYPEDSIGNATURES)
+Computes the average at the North and South pole from a given grid `A` and it's precomputed
+ring indices `rings`. The North pole average is an equally weighted average of all grid points
+on the northern-most ring. Similar for the South pole."""
+function average_on_poles(  A::AbstractGrid{NF},
                             rings::Vector{<:UnitRange{<:Integer}}
                             ) where {NF<:AbstractFloat}
     
     A_northpole = mean(view(A,rings[1]))    # average of all grid points around the north pole
     A_southpole = mean(view(A,rings[end]))  # same for south pole
     return convert(NF,A_northpole), convert(NF,A_southpole)
+end
+
+"""
+$(TYPEDSIGNATURES)
+Method for `A::Abstract{T<:Integer}` which rounds the averaged values
+to return the same number format `NF`."""
+function average_on_poles(  A::AbstractGrid{NF},
+                            rings::Vector{<:UnitRange{<:Integer}}
+                            ) where {NF<:Integer}
+    
+    A_northpole = mean(view(A,rings[1]))    # average of all grid points around the north pole
+    A_southpole = mean(view(A,rings[end]))  # same for south pole
+    return round(NF,A_northpole), round(NF,A_southpole)
 end
 
 """
@@ -446,19 +455,20 @@ longitude/x-coordinate. See schematic:
               0...............1 # fraction of distance Δcd between c,d
 ```
 ^ fraction of distance Δy between a-b and c-d."""
-function anvil_average( a::NF,      # top left value
-                        b::NF,      # top right value
-                        c::NF,      # bottom left value
-                        d::NF,      # bottom right value
-                        Δab::Real,  # fraction of distance between a,b ∈ [0,1)
-                        Δcd::Real,  # fraction of distance between c,d ∈ [0,1)
-                        Δy::Real,   # fraction of distance between ab,cd ∈ [0,1)
-                        ) where NF
+function anvil_average(
+    a,      # top left value
+    b,      # top right value
+    c,      # bottom left value
+    d,      # bottom right value
+    Δab,    # fraction of distance between a,b ∈ [0,1)
+    Δcd,    # fraction of distance between c,d ∈ [0,1)
+    Δy,     # fraction of distance between ab,cd ∈ [0,1)
+    )
 
     # the type of the weights is ::Real, but the following is written such that
     # always NF (the type of the data values a,b,c,d) is returned
-    ab_average = a + (b-a)*convert(NF,Δab)      # a for Δab=0, b for Δab=1
-    cd_average = c + (d-c)*convert(NF,Δcd)      # c for Δab=0, b for Δab=1
-    abcd_average = ab_average + (cd_average-ab_average)*convert(NF,Δy)
+    ab_average = a + (b-a)*Δab      # a for Δab=0, b for Δab=1
+    cd_average = c + (d-c)*Δcd      # c for Δab=0, b for Δab=1
+    abcd_average = ab_average + (cd_average-ab_average)*Δy
     return abcd_average
 end

--- a/src/RingGrids/show.jl
+++ b/src/RingGrids/show.jl
@@ -5,3 +5,29 @@ function Base.array_summary(io::IO, grid::AbstractGrid, inds::Tuple{Vararg{Base.
     print(io, Base.dims2string(length.(inds)), ", $(get_nlat(grid))-ring ")
     Base.showarg(io, grid, true)
 end
+
+function plot(A::AbstractGrid;title::String="$(get_nlat(A))-ring $(typeof(A))")
+    A_full = interpolate(full_grid(typeof(A)),A.nlat_half,A)
+    plot(A_full;title)
+end
+
+function plot(A::AbstractFullGrid;title::String="$(get_nlat(A))-ring $(typeof(A))")
+
+    A_matrix = Matrix(A)
+    nlon,nlat = size(A_matrix)
+    A_view = view(A_matrix,:,nlat:-1:1)
+
+    plot_kwargs = pairs((   xlabel="˚E",
+                            xfact=360/(nlon-1),
+                            ylabel="˚N",
+                            yfact=180/(nlat-1),
+                            yoffset=-90,
+                            title=title,
+                            colormap=:viridis,
+                            compact=true,
+                            colorbar=true,
+                            width=60,
+                            height=30))
+
+    UnicodePlots.heatmap(A_view';plot_kwargs...)
+end

--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -66,7 +66,8 @@ export  LowerTriangularMatrix,
         OctahedralGaussianGrid,
         OctahedralClenshawGrid,
         HEALPixGrid,
-        OctaHEALPixGrid
+        OctaHEALPixGrid,
+        plot
 
 export  Leapfrog
 

--- a/src/dynamics/prognostic_variables.jl
+++ b/src/dynamics/prognostic_variables.jl
@@ -354,24 +354,7 @@ get_humidity(progn::PrognosticVariables; kwargs...) = get_var(progn, :humid; kwa
 get_pressure(progn::PrognosticVariables; lf::Integer=1) = progn.surface.timesteps[lf].pres
 
 function Base.show(io::IO, P::PrognosticVariables)
-
-    ζ = P.layers[end].timesteps[1].vor  # create a view on vorticity
-    ζ_grid = Matrix(gridded(ζ))         # to grid space
-    ζ_grid = ζ_grid[:,end:-1:1]         # flip latitudes
-
-    nlon,nlat = size(ζ_grid)
-
-    plot_kwargs = pairs((   xlabel="˚E",
-                            xfact=360/(nlon-1),
-                            ylabel="˚N",
-                            yfact=180/(nlat-1),
-                            yoffset=-90,
-                            title="Surface relative vorticity",
-                            colormap=:viridis,
-                            compact=true,
-                            colorbar=true,
-                            width=60,
-                            height=30))
-
-    print(io,UnicodePlots.heatmap(ζ_grid';plot_kwargs...))
+    ζ = P.layers[end].timesteps[1].vor          # create a view on surface relative vorticity
+    ζ_grid = gridded(ζ)                         # to grid space
+    print(io,plot(ζ_grid,title="Surface relative vorticity"))
 end


### PR DESCRIPTION
It bothered me for a while that once we have data on a grid (meaning all its geometric information is available) that we couldn't directly unicode-plot that data. With this PR we can do `plot(::AbstractGrid)`

```julia
julia> A = randn(HEALPixGrid,24);
julia> plot(A)
```

![image](https://github.com/SpeedyWeather/SpeedyWeather.jl/assets/25530332/6ac8ec2e-27aa-4f78-a7f5-0d41c7dccb93)

Under the hood this is interpolated onto the corresponding full grid, reinterpreted as Matrix and `UnicodePlots.heatmap`ped. 
