### PR TITLE
SpectralTransform for square LowerTriMats too

### DIFF
--- a/src/SpeedyTransforms/spectral_transform.jl
+++ b/src/SpeedyTransforms/spectral_transform.jl
@@ -549,11 +549,12 @@ end
 Converts `map` to `Grid(map)` to execute `spectral(map::AbstractGrid;kwargs...)`."""
 function spectral(  map::AbstractGrid{NF};          # gridded field
                     recompute_legendre::Bool = true,# saves memory
+                    one_more_degree::Bool = false,  # for lmax+2 x mmax+1 output size
                     ) where NF                      # number format NF
 
     Grid = typeof(map)
     trunc = get_truncation(map.nlat_half)
-    S = SpectralTransform(NF,Grid,trunc,trunc;recompute_legendre)
+    S = SpectralTransform(NF,Grid,trunc+one_more_degree,trunc;recompute_legendre)
     return spectral(map,S)
 end
 

--- a/src/dynamics/initial_conditions.jl
+++ b/src/dynamics/initial_conditions.jl
@@ -183,7 +183,7 @@ function initial_conditions!(   progn::PrognosticVariables,
     # interpolate in spectral space to desired resolution
     (;lmax,mmax) = model.spectral_transform
     (;NF) = model.spectral_grid
-    u = spectral_truncation(complex(NF),u,lmax+1,mmax)
+    u = spectral_truncation(complex(NF),u,lmax,mmax)
     
     # get vorticity initial conditions from curl of u,v
     v = zero(u)     # meridional velocity zero for these initial conditions

--- a/src/dynamics/spectral_grid.jl
+++ b/src/dynamics/spectral_grid.jl
@@ -167,6 +167,6 @@ function SpeedyTransforms.SpectralTransform(spectral_grid::SpectralGrid;
                                             recompute_legendre::Bool = false,
                                             kwargs...)
     (;NF, Grid, trunc, dealiasing) = spectral_grid
-    return SpectralTransform(NF,Grid,trunc;recompute_legendre,dealiasing,kwargs...)
+    return SpectralTransform(NF,Grid,trunc+1,trunc;recompute_legendre,dealiasing,kwargs...)
 end
 

--- a/test/diffusion.jl
+++ b/test/diffusion.jl
@@ -20,7 +20,7 @@
         # than prognostic variable to act as a dissipation 
         (;lmax,mmax) = m.spectral_transform
         for m in 1:mmax+1
-            for l in max(2,m):lmax+1
+            for l in max(2,m):lmax
                 @test -sign(real(vor[l,m])) == sign(real(vor_tend[l,m]))
                 @test -sign(imag(vor[l,m])) == sign(imag(vor_tend[l,m]))
             end

--- a/test/set_vars.jl
+++ b/test/set_vars.jl
@@ -12,7 +12,7 @@
     mmax = M.spectral_transform.mmax
     lf = 1
 
-    sph_data = [rand(LowerTriangularMatrix{spectral_grid.NF}, lmax+2, mmax+1) for i=1:nlev]
+    sph_data = [rand(LowerTriangularMatrix{spectral_grid.NF}, lmax+1, mmax+1) for i=1:nlev]
 
     SpeedyWeather.set_vorticity!(P, sph_data)
     SpeedyWeather.set_divergence!(P, sph_data)
@@ -20,7 +20,7 @@
     SpeedyWeather.set_humidity!(P, sph_data)
     SpeedyWeather.set_pressure!(P, sph_data[1])
 
-    for i=1:nlev 
+    for i=1:nlev
         @test P.layers[i].timesteps[lf].vor == sph_data[i]
         @test P.layers[i].timesteps[lf].div == sph_data[i]
         @test P.layers[i].timesteps[lf].temp == sph_data[i]
@@ -48,12 +48,12 @@
     SpeedyWeather.set_pressure!(P, grid_data[1])
 
     for i=1:nlev 
-        @test all(isapprox(P.layers[i].timesteps[lf].vor, sph_data[i]))
-        @test all(isapprox(P.layers[i].timesteps[lf].div, sph_data[i]))
-        @test all(isapprox(P.layers[i].timesteps[lf].temp, sph_data[i]))
-        @test all(isapprox(P.layers[i].timesteps[lf].humid, sph_data[i]))
+        @test P.layers[i].timesteps[lf].vor ≈   sph_data[i]
+        @test P.layers[i].timesteps[lf].div ≈   sph_data[i]
+        @test P.layers[i].timesteps[lf].temp ≈  sph_data[i]
+        @test P.layers[i].timesteps[lf].humid ≈ sph_data[i]
     end 
-    @test all(isapprox(P.surface.timesteps[lf].pres,sph_data[1]))
+    @test P.surface.timesteps[lf].pres ≈ sph_data[1]
 
     grid_data = [gridded(sph_data[i], M.spectral_transform) for i in eachindex(sph_data)]
 
@@ -64,12 +64,12 @@
     SpeedyWeather.set_pressure!(P, grid_data[1], M)
 
     for i=1:nlev 
-        @test all(isapprox(P.layers[i].timesteps[lf].vor, sph_data[i]))
-        @test all(isapprox(P.layers[i].timesteps[lf].div, sph_data[i]))
-        @test all(isapprox(P.layers[i].timesteps[lf].temp, sph_data[i]))
-        @test all(isapprox(P.layers[i].timesteps[lf].humid, sph_data[i]))
+        @test P.layers[i].timesteps[lf].vor   ≈ sph_data[i]
+        @test P.layers[i].timesteps[lf].div   ≈ sph_data[i]
+        @test P.layers[i].timesteps[lf].temp  ≈ sph_data[i]
+        @test P.layers[i].timesteps[lf].humid ≈ sph_data[i]
     end 
-    @test all(isapprox(P.surface.timesteps[lf].pres,sph_data[1]))
+    @test P.surface.timesteps[lf].pres ≈ sph_data[1]
 
     # test setting matrices 
     spectral_grid = SpectralGrid(Grid=FullGaussianGrid)
@@ -86,18 +86,18 @@
     grid_data = [gridded(sph_data[i], M.spectral_transform) for i in eachindex(sph_data)]
     matrix_data = [Matrix(grid_data[i]) for i in eachindex(grid_data)]
 
-    SpeedyWeather.set_vorticity!(P, grid_data)
-    SpeedyWeather.set_divergence!(P, grid_data)
-    SpeedyWeather.set_temperature!(P, grid_data)
-    SpeedyWeather.set_humidity!(P, grid_data)
-    SpeedyWeather.set_pressure!(P, grid_data[1])
+    SpeedyWeather.set_vorticity!(P, matrix_data)
+    SpeedyWeather.set_divergence!(P, matrix_data)
+    SpeedyWeather.set_temperature!(P, matrix_data)
+    SpeedyWeather.set_humidity!(P, matrix_data)
+    SpeedyWeather.set_pressure!(P, matrix_data[1])
 
     for i=1:nlev 
-        @test all(isapprox(P.layers[i].timesteps[lf].vor, sph_data[i]))
-        @test all(isapprox(P.layers[i].timesteps[lf].div, sph_data[i]))
-        @test all(isapprox(P.layers[i].timesteps[lf].temp, sph_data[i]))
-        @test all(isapprox(P.layers[i].timesteps[lf].humid, sph_data[i]))
+        @test P.layers[i].timesteps[lf].vor   ≈ sph_data[i]
+        @test P.layers[i].timesteps[lf].div   ≈ sph_data[i]
+        @test P.layers[i].timesteps[lf].temp  ≈ sph_data[i]
+        @test P.layers[i].timesteps[lf].humid ≈ sph_data[i]
     end 
-    @test all(isapprox(P.surface.timesteps[lf].pres,sph_data[1]))
+    @test P.surface.timesteps[lf].pres ≈ sph_data[1]
 
-end 
+end

--- a/test/spectral_gradients.jl
+++ b/test/spectral_gradients.jl
@@ -122,10 +122,10 @@ end
         S = SpectralTransform(SG)
 
         lmax,mmax = S.lmax,S.mmax
-        A1 = randn(LowerTriangularMatrix{Complex{NF}},lmax+2,mmax+1)
-        A2 = randn(LowerTriangularMatrix{Complex{NF}},lmax+2,mmax+1)
-        B = zeros(LowerTriangularMatrix{Complex{NF}},lmax+2,mmax+1)
-        C = zeros(LowerTriangularMatrix{Complex{NF}},lmax+2,mmax+1)
+        A1 = randn(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
+        A2 = randn(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
+        B = zeros(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
+        C = zeros(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
 
         SpeedyWeather.divergence!(B,A1,A2,S,flipsign=true)
         SpeedyWeather.divergence!(C,A1,A2,S,flipsign=false)
@@ -144,10 +144,10 @@ end
         S = SpectralTransform(SG)
 
         lmax,mmax = S.lmax,S.mmax
-        A1 = randn(LowerTriangularMatrix{Complex{NF}},lmax+2,mmax+1)
-        A2 = randn(LowerTriangularMatrix{Complex{NF}},lmax+2,mmax+1)
-        B = zeros(LowerTriangularMatrix{Complex{NF}},lmax+2,mmax+1)
-        C = zeros(LowerTriangularMatrix{Complex{NF}},lmax+2,mmax+1)
+        A1 = randn(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
+        A2 = randn(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
+        B = zeros(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
+        C = zeros(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
 
         SpeedyWeather.divergence!(B,A1,A2,S,add=true)
         SpeedyWeather.divergence!(B,A1,A2,S,add=true)
@@ -188,9 +188,9 @@ end
         fill!(d.layers[1].tendencies.div_tend,0)
 
         # create initial conditions
-        lmax,mmax = p.trunc,p.trunc
-        vor0 = randn(LowerTriangularMatrix{Complex{NF}},lmax+2,mmax+1)
-        div0 = randn(LowerTriangularMatrix{Complex{NF}},lmax+2,mmax+1)
+        (;lmax,mmax) = m.spectral_transform
+        vor0 = randn(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
+        div0 = randn(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
         
         vor0[1,1] = 0                   # zero mean
         div0[1,1] = 0


### PR DESCRIPTION
So that both work
```julia
alms = randn(LowerTriangularMatrix{ComplexF64},32,32)
gridded(alms)

alms = randn(LowerTriangularMatrix{ComplexF64},33,32)
gridded(alms)
```
previously only the second (which is what's used inside the dynamical core) was working when externally used.