### PR TITLE
Bugfix in vertical advection

### DIFF
--- a/src/dynamics/vertical_advection.jl
+++ b/src/dynamics/vertical_advection.jl
@@ -24,7 +24,7 @@ end
 
 @inline function retrieve_previous_stencil(k, layers, var, nlev, ::VerticalAdvection{NF, B}) where {NF, B}
     k_stencil = max.(min.(nlev, k-B:k+B), 1)
-    ξ_stencil = Tuple(retrieve_current_time_step(layers[k].grid_variables, var) for k in k_stencil)
+    ξ_stencil = Tuple(retrieve_previous_time_step(layers[k].grid_variables, var) for k in k_stencil)
     return ξ_stencil
 end
 


### PR DESCRIPTION
I was trying to run a high-resolution simulation (convinced the stability problem was solved) to replace the high-res simulation in the docs but the simulation crashed with upwinding!
I figured that I had changed just a little bit the structure of the code in #362 before merging but just enough to leave a bug not caught by the test.

This PR fixes it
(also produces the high res simulation to put in the README)