### PR TITLE
Speedstring precompilation warning

### DIFF
--- a/src/dynamics/models.jl
+++ b/src/dynamics/models.jl
@@ -56,6 +56,10 @@ except for `model.output` and `model.feedback` which are always called
 at in `time_stepping!`."""
 function initialize!(model::Barotropic)
     (;spectral_grid,forcing,horizontal_diffusion) = model
+
+    spectral_grid.nlev > 1 && @warn "Only nlev=1 supported for BarotropicModel, \
+        SpectralGrid with nlev=$(spectral_grid.nlev) provided."
+
     initialize!(forcing,model)
     initialize!(horizontal_diffusion,model)
 
@@ -108,6 +112,9 @@ at in `time_stepping!` and `model.implicit` which is done in `first_timesteps!`.
 function initialize!(model::ShallowWater)
     (;spectral_grid,forcing,horizontal_diffusion,
         orography,planet,spectral_transform,geometry) = model
+
+    spectral_grid.nlev > 1 && @warn "Only nlev=1 supported for ShallowWaterModel, \
+                                SpectralGrid with nlev=$(spectral_grid.nlev) provided."
 
     initialize!(forcing,model)
     initialize!(horizontal_diffusion,model)

--- a/src/output/feedback.jl
+++ b/src/output/feedback.jl
@@ -197,9 +197,11 @@ end
 # constant from the ProgressMeter module
 const DT_IN_SEC = Ref(1800)
 
-# overwrite the speedstring function from ProgressMeter
-function ProgressMeter.speedstring(sec_per_iter,dt_in_sec=SpeedyWeather.DT_IN_SEC)
-    speedstring(sec_per_iter,dt_in_sec[])
+# "extend" the speedstring function from ProgressMeter by defining it for ::AbstractFloat
+# not just ::Any to effectively overwrite it
+function ProgressMeter.speedstring(sec_per_iter::AbstractFloat)
+    dt_in_sec = SpeedyWeather.DT_IN_SEC[]   # pull global "constant"
+    speedstring(sec_per_iter,dt_in_sec)
 end
 
 """


### PR DESCRIPTION
fixes #296 by "extending" the speedstring method just with a bit more specific `::AbstractFloat` dispatch (in ProgressMeter it's `::Any`) not through overwriting

It seems to work
```julia
(@v1.9) pkg> add https://github.com/SpeedyWeather/SpeedyWeather.jl#mk/speedstring
    Updating git-repo `https://github.com/SpeedyWeather/SpeedyWeather.jl`
   Resolving package versions...
    Updating `~/.julia/environments/v1.9/Project.toml`
  [9e226e20] + SpeedyWeather v0.5.0 `https://github.com/SpeedyWeather/SpeedyWeather.jl#mk/speedstring`
    Updating `~/.julia/environments/v1.9/Manifest.toml`
  [9e226e20] + SpeedyWeather v0.5.0 `https://github.com/SpeedyWeather/SpeedyWeather.jl#mk/speedstring`
Precompiling project...
  1 dependency successfully precompiled in 17 seconds. 313 already precompiled
```