### PR TITLE
eta/pres was not output

### DIFF
--- a/src/dynamics/diagnostic_variables.jl
+++ b/src/dynamics/diagnostic_variables.jl
@@ -237,6 +237,7 @@ function Base.zeros(
 end
 
 DiagnosticVariables(SG::SpectralGrid) = zeros(DiagnosticVariables,SG,DEFAULT_MODEL)
+DiagnosticVariables(SG::SpectralGrid,Model::Type{<:ModelSetup}) = zeros(DiagnosticVariables,SG,Model)
 
 # LOOP OVER ALL GRID POINTS (extend from RingGrids module)
 RingGrids.eachgridpoint(diagn::DiagnosticVariables) = Base.OneTo(diagn.npoints)

--- a/src/dynamics/implicit.jl
+++ b/src/dynamics/implicit.jl
@@ -17,8 +17,8 @@ Base.@kwdef struct ImplicitShallowWater{NF<:AbstractFloat} <: AbstractImplicit{N
     α::Float64 = 1
 
     # PRECOMPUTED ARRAYS, to be initiliased with initialize!
-    H::Base.RefValue{NF} = Ref(zero(NF))   # layer_thicknes
-    ξH::Base.RefValue{NF} = Ref(zero(NF))  # = 2αΔt*layer_thickness, store in RefValue for mutability
+    H::Base.RefValue{NF} = Ref(zero(NF))    # layer_thickness
+    ξH::Base.RefValue{NF} = Ref(zero(NF))   # = 2αΔt*layer_thickness, store in RefValue for mutability
     g∇²::Vector{NF} = zeros(NF,trunc+2)     # = gravity*eigenvalues
     ξg∇²::Vector{NF} = zeros(NF,trunc+2)    # = 2αΔt*gravity*eigenvalues
     S⁻¹::Vector{NF} = zeros(NF,trunc+2)     # = 1 / (1-ξH*ξg∇²), implicit operator
@@ -27,7 +27,7 @@ end
 """
 $(TYPEDSIGNATURES)
 Generator using the resolution from `spectral_grid`."""
-function ImplicitShallowWater(spectral_grid::SpectralGrid,kwargs...) 
+function ImplicitShallowWater(spectral_grid::SpectralGrid;kwargs...) 
     (;NF,trunc) = spectral_grid
     return ImplicitShallowWater{NF}(;trunc,kwargs...)
 end
@@ -75,7 +75,7 @@ function initialize!(   implicit::ImplicitShallowWater,
         eigenvalue = -l*(l-1)               # =∇², with without 1/radius², 1-based -l*l(l+1) → -l*(l-1)
         g∇²[l] = gravity*eigenvalue         # doesn't actually change with dt
         ξg∇²[l] = ξ*g∇²[l]                  # update ξg∇² with new ξ
-        S⁻¹[l] = inv(1 - ξH[]*ξg∇²[l])    # update 1/(1-ξ²gH∇²) with new ξ
+        S⁻¹[l] = inv(1 - ξH[]*ξg∇²[l])      # update 1/(1-ξ²gH∇²) with new ξ
     end
 end
 

--- a/src/dynamics/models.jl
+++ b/src/dynamics/models.jl
@@ -66,7 +66,7 @@ function initialize!(model::Barotropic)
     initialize!(horizontal_diffusion,model)
 
     prognostic_variables = initial_conditions(model)
-    diagnostic_variables = DiagnosticVariables(spectral_grid)
+    diagnostic_variables = DiagnosticVariables(spectral_grid,Barotropic)
     return Simulation(prognostic_variables,diagnostic_variables,model)
 end
 
@@ -125,7 +125,7 @@ function initialize!(model::ShallowWater)
     initialize!(orography,planet,spectral_transform,geometry)
 
     prognostic_variables = initial_conditions(model)
-    diagnostic_variables = DiagnosticVariables(spectral_grid)
+    diagnostic_variables = DiagnosticVariables(spectral_grid,ShallowWater)
     return Simulation(prognostic_variables,diagnostic_variables,model)
 end
 
@@ -191,7 +191,7 @@ function initialize!(model::PrimitiveDry)
     # initialize!(model.vertical_diffusion,model)
 
     prognostic_variables = initial_conditions(model)
-    diagnostic_variables = DiagnosticVariables(spectral_grid)
+    diagnostic_variables = DiagnosticVariables(spectral_grid,PrimitiveDry)
     return Simulation(prognostic_variables,diagnostic_variables,model)
 end
 
@@ -261,7 +261,7 @@ function initialize!(model::PrimitiveWet)
     # initialize!(model.vertical_diffusion,model)
 
     prognostic_variables = initial_conditions(model)
-    diagnostic_variables = DiagnosticVariables(spectral_grid)
+    diagnostic_variables = DiagnosticVariables(spectral_grid,PrimitiveWet)
     return Simulation(prognostic_variables,diagnostic_variables,model)
 end
    


### PR DESCRIPTION
Now the model type is correctly passed to DiagnosticVariables
```julia
julia> typeof(simulation.diagnostic_variables)
DiagnosticVariables{Float32, OctahedralGaussianGrid{Float32}, ShallowWater}
```
was always `PrimitiveDry` before, this caused a conversion of `pres` in output from (falsely) logarithm of surface pressure to hPa, even for the ShallowWater model where `pres` is in meters.