### PR TITLE
Bug: First NetCDF time step is always 2000-01-01

### DIFF
--- a/src/dynamics/implicit.jl
+++ b/src/dynamics/implicit.jl
@@ -291,21 +291,6 @@ function initialize!(   implicit::ImplicitPrimitiveEq,
 end
 
 """$(TYPEDSIGNATURES)
-Reinitialize implicit occasionally based on time step `i` and `implicit.recalculate`."""
-function initialize!(  
-    implicit::ImplicitPrimitiveEq,
-    i::Integer,
-    dt::Real,                   # the scaled time step radius*dt
-    diagn::DiagnosticVariables,
-    geometry::Geometry,
-    constants::DynamicsConstants
-)
-    # only reinitialize occasionally, otherwise exit immediately
-    i % implicit.recalculate == 0 || return nothing
-    initialize!(implicit,dt,diagn,geometry,constants)
-end
-
-"""$(TYPEDSIGNATURES)
 Apply the implicit corrections to dampen gravity waves in the primitive equation models."""
 function implicit_correction!(  
     diagn::DiagnosticVariables,

--- a/src/output/output.jl
+++ b/src/output/output.jl
@@ -155,6 +155,7 @@ function initialize!(
     output::OutputWriter{output_NF,Model},
     feedback::AbstractFeedback,
     time_stepping::TimeStepper,
+    clock::Clock,
     diagn::DiagnosticVariables,
     model::Model
 ) where {output_NF,Model}
@@ -285,7 +286,7 @@ function initialize!(
     
     # WRITE INITIAL CONDITIONS TO FILE
     write_netcdf_variables!(output,diagn)
-    write_netcdf_time!(output,startdate)
+    write_netcdf_time!(output,clock.time)
 
     # also export parameters into run????/parameters.txt
     parameters_txt = open(joinpath(output.run_path,"parameters.txt"),"w")

--- a/src/run_speedy.jl
+++ b/src/run_speedy.jl
@@ -9,11 +9,14 @@ function run!(  simulation::Simulation;
                 output::Bool = false)
     
     (;prognostic_variables, diagnostic_variables, model) = simulation
+    (;clock) = prognostic_variables
 
     # set the clock
-    if typeof(startdate) == DateTime prognostic_variables.clock.time = startdate end
-    prognostic_variables.clock.n_days = n_days
-    initialize!(prognostic_variables.clock,model.time_stepping)
+    if typeof(startdate) == DateTime
+        clock.time = startdate
+    end
+    clock.n_days = n_days
+    initialize!(clock,model.time_stepping)
 
     model.output.output = output            # enable/disable output
     initialize && initialize!(model)        # initialize again?


### PR DESCRIPTION
Just spotted
```
193-element Vector{DateTime}:
 2000-01-01T00:00:00
 2000-01-21T00:15:00
 2000-01-21T00:30:00
 2000-01-21T00:45:00
 2000-01-21T01:00:00
 2000-01-21T01:15:00
 2000-01-21T01:30:00
 2000-01-21T01:45:00
 2000-01-21T02:00:00
 2000-01-21T02:15:00
 2000-01-21T02:30:00
 2000-01-21T02:45:00
 2000-01-21T03:00:00
 ⋮
```