### PR TITLE
plot(::LowerTriangularMatrix)

### DIFF
--- a/src/LowerTriangularMatrices/LowerTriangularMatrices.jl
+++ b/src/LowerTriangularMatrices/LowerTriangularMatrices.jl
@@ -2,8 +2,12 @@ module LowerTriangularMatrices
 
 using DocStringExtensions
 import Adapt
+import UnicodePlots
 
 export LowerTriangularMatrix, eachharmonic
+# export plot
 
 include("lower_triangular_matrix.jl")
+include("plot.jl")
+
 end

--- a/src/LowerTriangularMatrices/plot.jl
+++ b/src/LowerTriangularMatrices/plot.jl
@@ -1,0 +1,29 @@
+function plot(L::LowerTriangularMatrix{T}; mode::Function=abs) where T
+
+    l,m = size(L)
+    title ="$l×$m LowerTriangularMatrix{$T}"
+
+    Lplot = similar(L,real(T))
+    for lm in eachharmonic(L)
+        Lplot[lm] = mode(L[lm]) 
+    end
+
+    # use at most 33x32 points in height x width, but fewer for smaller matrices
+    height = min(l,33)
+    width = min(m,32)
+
+    plot_kwargs = pairs((   xlabel="m",
+                            xoffset=-1,
+                            ylabel="ℓ",
+                            yoffset=-1,
+                            title=title,
+                            colormap=:inferno,
+                            compact=true,
+                            colorbar=true,
+                            zlabel=string(mode),
+                            array=true,
+                            width=width,
+                            height=height))
+
+    return UnicodePlots.heatmap(Lplot;plot_kwargs...)
+end

--- a/src/RingGrids/RingGrids.jl
+++ b/src/RingGrids/RingGrids.jl
@@ -66,7 +66,7 @@ export  interpolate,
         update_locator,
         update_locator!
 
-export  plot
+# export  plot
 
 include("utility_functions.jl")
 

--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -199,6 +199,7 @@ include("dynamics/models.jl")
 # OUTPUT
 include("output/output.jl")                     # defines Output
 include("output/feedback.jl")                   # defines Feedback
+include("output/plot.jl")
 
 # INTERFACE
 include("run_speedy.jl")

--- a/src/output/plot.jl
+++ b/src/output/plot.jl
@@ -1,0 +1,3 @@
+# to avoid ambiguity with exporting plot
+plot(L::LowerTriangularMatrix{T}; kwargs...) where T = LowerTriangularMatrices.plot(L;kwargs...)
+plot(G::AbstractGrid{T}; kwargs...) where T = RingGrids.plot(G;kwargs...)


### PR DESCRIPTION
Also without the `LowerTriangularMatrices.` specifier

![image](https://github.com/SpeedyWeather/SpeedyWeather.jl/assets/25530332/3e2a21d2-c992-4661-b696-c0172173aebc)
