### PR TITLE
Output_dt in leapfrog time stepping and some adjustments for using Dates 

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,7 +5,7 @@ PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
-Documenter = "0.26, 0.27"
-NCDatasets = "0.12"
+Documenter = "0.26, 0.27, 1"
+NCDatasets = "0.12, 0.13"
 UnicodePlots = "^3.3"
 PythonPlot = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,13 @@
 using Documenter, SpeedyWeather
 
 makedocs(
-     format=Documenter.HTML(prettyurls=get(ENV, "CI", nothing)=="true",
-                            ansicolor=true),
-    sitename="SpeedyWeather.jl",
-    authors="M Klöwer and SpeedyWeather contributors",
-    modules=[SpeedyWeather],
-    pages=["Home"=>"index.md",
+    format = Documenter.HTML(prettyurls=get(ENV, "CI", nothing)=="true",
+                            ansicolor=true,
+                            size_threshold = 600_000),      # in bytes
+    sitename = "SpeedyWeather.jl",
+    authors = "M Klöwer and SpeedyWeather contributors",
+    modules = [SpeedyWeather],
+    pages = ["Home"=>"index.md",
             "Installation"=>"installation.md",
             "How to run SpeedyWeather.jl"=>"how_to_run_speedy.md",
             "Model setups"=>"setups.md",

--- a/docs/src/how_to_run_speedy.md
+++ b/docs/src/how_to_run_speedy.md
@@ -178,9 +178,9 @@ and we have initialized the `ShallowWaterModel` we have defined earlier.
 After this step you can continue to tweak your model setup but note that
 some model components are immutable, or that your changes may not be
 propagated to other model components that rely on it. But you can, for
-example, change the output time step (in hours) like so
+example, change the output time step like so
 ```@example howto
-simulation.model.output.output_dt = 1
+simulation.model.output.output_dt = Second(3600)
 ```
 Now, if there's output, it will be every hour. Furthermore the initial
 conditions can be set with the `initial_conditions` model component

--- a/docs/src/how_to_run_speedy.md
+++ b/docs/src/how_to_run_speedy.md
@@ -112,7 +112,7 @@ Meaning that if you want to have a shorter or longer time step you can create a 
 `SpectralGrid` as first argument.
 ```@example howto
 spectral_grid = SpectralGrid(trunc=63,nlev=1)
-time_stepping = Leapfrog(spectral_grid,Δt_at_T31=15)
+time_stepping = Leapfrog(spectral_grid,Δt_at_T31=Minute(15))
 ```
 The actual time step at the given resolution (here T63) is then `Δt_sec`, there's
 also `Δt` which is a scaled time step used internally, because SpeedyWeather.jl

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -27,9 +27,9 @@ also pass on further keyword arguments. So let's start with an example.
 
 ## Example 1: NetCDF output every hour
 
-If we want to increase the frequency of the output we can choose `output_dt` (default `=6` in hours) like so
+If we want to increase the frequency of the output we can choose `output_dt` (default `=Hour(6)`) like so
 ```julia
-julia> my_output_writer = OutputWriter(spectral_grid, PrimitiveDry, output_dt=1)
+julia> my_output_writer = OutputWriter(spectral_grid, PrimitiveDry, output_dt=Hour(1))
 julia> model = PrimitiveDryModel(;spectral_grid, output=my_output_writer)
 ```
 which will now output every hour. It is important to pass on the new output writer `my_output_writer` to the
@@ -66,6 +66,12 @@ julia> diff(ds["time"][:])
 ```
 This is so that we don't interpolate in time during output to hit exactly every 6 hours, but at
 the same time have a constant spacing in time between output time steps.
+
+If we want to overwrite this behaviour, we can choose `adjust_Δt_with_output=true` and specifiy an `output_dt` in the `Leapfrog` time stepper like this:
+```Julia
+julia> time_stepper = Leapfrog(spectral_grid, adjust_Δt_with_output=true, output_dt=Hour(1))
+```
+In this case the internal time step will be adjusted to be a divisor of `output_dt`, so that the output will be exactly every `output_dt`
 
 ## Example 2: Output onto a higher/lower resolution grid
 
@@ -165,9 +171,7 @@ search: OutputWriter
 
     •  startdate::Dates.DateTime
 
-    •  output_dt::Float64: [OPTION] output frequency, time step [hrs]
-
-    •  output_dt_sec::Int64: actual output time step [sec]
+    •  output_dt::Second: [OPTION] output frequency, time step
 
     •  output_vars::Vector{Symbol}: [OPTION] which variables to output,
        u, v, vor, div, pres, temp, humid

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -11,8 +11,8 @@ The output writer is a component of every Model, i.e. `BarotropicModel`, `Shallo
 ```@example netcdf
 using SpeedyWeather
 spectral_grid = SpectralGrid()
-my_output_writer = OutputWriter(spectral_grid, ShallowWater)
-model = ShallowWaterModel(;spectral_grid, output=my_output_writer)
+output = OutputWriter(spectral_grid, ShallowWater)
+model = ShallowWaterModel(;spectral_grid, output=output)
 nothing # hide
 ```
 
@@ -27,11 +27,11 @@ Then we can also pass on further keyword arguments. So let's start with an examp
 
 If we want to increase the frequency of the output we can choose `output_dt` (default `=Hour(6)`) like so
 ```@example netcdf
-my_output_writer = OutputWriter(spectral_grid, ShallowWater, output_dt=Hour(1))
-model = ShallowWaterModel(;spectral_grid, output=my_output_writer)
+output = OutputWriter(spectral_grid, ShallowWater, output_dt=Hour(1))
+model = ShallowWaterModel(;spectral_grid, output=output)
 nothing # hide
 ```
-which will now output every hour. It is important to pass on the new output writer `my_output_writer` to the
+which will now output every hour. It is important to pass on the new output writer `output` to the
 model constructor, otherwise it will not be part of your model and the default is used instead.
 Note that the choice of `output_dt` can affect the actual time step that is used for the model
 integration, which is explained in the following.
@@ -44,11 +44,15 @@ time_stepping.Δt_sec
 seconds. Depending on the output frequency (we chose `output_dt = Hour(1)` above)
 this will be slightly adjusted during model initialization:
 ```@example netcdf
+output = OutputWriter(spectral_grid, ShallowWater, output_dt=Hour(1))
+model = ShallowWaterModel(;spectral_grid, time_stepping, output)
 simulation = initialize!(model)
 model.time_stepping.Δt_sec
 ```
 The shorter the output time step the more the model time step needs to be adjusted
-to match the desired output time step exactly. This is important so that for daily output at noon this does not slowly shift towards night over years of model integration. One can always disable this adjustment with
+to match the desired output time step exactly. This is important so that for daily output at
+noon this does not slowly shift towards night over years of model integration.
+One can always disable this adjustment with
 ```@example netcdf
 time_stepping = Leapfrog(spectral_grid,adjust_with_output=false)
 time_stepping.Δt_sec
@@ -56,7 +60,7 @@ time_stepping.Δt_sec
 and a little info will be printed to explain that even though you wanted
 `output_dt = Hour(1)` you will not actually get this upon initialization:
 ```@example netcdf
-model = ShallowWaterModel(;spectral_grid, time_stepping, output=my_output_writer)
+model = ShallowWaterModel(;spectral_grid, time_stepping, output)
 simulation = initialize!(model)
 ```
 

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -182,10 +182,46 @@ search: OutputWriter
 
     •  pkg_version::VersionNumber
 
-    •  startdate::Dates.DateTime
+    •  startdate::DateTime
 
     •  output_dt::Second: [OPTION] output frequency, time step
 
     •  output_vars::Vector{Symbol}: [OPTION] which variables to output,
        u, v, vor, div, pres, temp, humid
+
+    •  missing_value::Union{Float32, Float64}: [OPTION] missing value to
+       be used in netcdf output
+
+    •  compression_level::Int64: [OPTION] lossless compression level;
+       1=low but fast, 9=high but slow
+
+    •  shuffle::Bool: [OPTION] shuffle/bittranspose filter for
+       compression
+
+    •  keepbits::SpeedyWeather.Keepbits: [OPTION] mantissa bits to keep
+       for every variable
+
+    •  output_every_n_steps::Int64
+
+    •  timestep_counter::Int64
+
+    •  output_counter::Int64
+
+    •  netcdf_file::Union{Nothing, NCDatasets.NCDataset}
+
+    •  input_Grid::Type{<:AbstractGrid}
+
+    •  as_matrix::Bool: [OPTION] sort grid points into a matrix
+       (interpolation-free), for OctahedralClenshawGrid, OctaHEALPixGrid
+       only
+
+    •  quadrant_rotation::NTuple{4, Int64}
+
+    •  matrix_quadrant::NTuple{4, Tuple{Int64, Int64}}
+
+    •  output_Grid::Type{<:AbstractFullGrid}: [OPTION] the grid used for
+       output, full grids only
+
+    •  nlat_half::Int64: [OPTION] the resolution of the output grid,
+       default: same nlat_half as in the dynamical core
 ```

--- a/docs/src/ringgrids.md
+++ b/docs/src/ringgrids.md
@@ -72,8 +72,11 @@ based on [UnicodePlots](https://github.com/JuliaPlots/UnicodePlots.jl)' `heatmap
 ```@example ringgrids
 nlat_half = 24
 grid = randn(OctahedralGaussianGrid,nlat_half)
-plot(grid)
+RinGrids.plot(grid)
 ```
+(Note that to skip the `RingGrids.` in the last line you can do `import SpeedyWeather.RingGrids: plot`,
+`import SpeedyWeather: plot` or simply `using SpeedyWeather`. It's just that `LowerTriangularMatrices`
+also defines `plot` which otherwise causes naming conflicts.)
 
 ## Indexing RingGrids
 

--- a/docs/src/ringgrids.md
+++ b/docs/src/ringgrids.md
@@ -72,7 +72,7 @@ based on [UnicodePlots](https://github.com/JuliaPlots/UnicodePlots.jl)' `heatmap
 ```@example ringgrids
 nlat_half = 24
 grid = randn(OctahedralGaussianGrid,nlat_half)
-RinGrids.plot(grid)
+RingGrids.plot(grid)
 ```
 (Note that to skip the `RingGrids.` in the last line you can do `import SpeedyWeather.RingGrids: plot`,
 `import SpeedyWeather: plot` or simply `using SpeedyWeather`. It's just that `LowerTriangularMatrices`

--- a/docs/src/setups.md
+++ b/docs/src/setups.md
@@ -106,11 +106,16 @@ run!(simulation,n_days=6,output=true)
 ```
 The progress bar tells us that the simulation run got the identification "0001"
 (which just counts up, so yours might be higher), meaning that
-data is stored in the folder `/run_0001`, so let's plot that data properly (and not just using UnicodePlots).
+data is stored in the folder `/run_0001`. In general we can check this also via
+```@example galewsky_setup
+id = model.output.id
+```
+So let's plot that data properly (and not just using UnicodePlots). `$id` in the following just means
+that the string is interpolated to `run_0001` if this is the first unnamed run in your folder.
 ```@example galewsky_setup
 using PythonPlot, NCDatasets
 ioff() # hide
-ds = NCDataset("run_0001/output.nc")
+ds = NCDataset("run_$id/output.nc")
 ds["vor"]
 ```
 Vorticity `vor` is stored as a lon x lat x vert x time array, we may want to look at the first time step,
@@ -162,7 +167,7 @@ simulation = initialize!(model)
 run!(simulation,n_days=12,output=true)
 ```
 
-This time the run got a new run id, which you see in the progress bar, but can also always check
+This time the run got a new run id, which you see in the progress bar, but can again always check
 after the `run!` call (the automatic run id is only determined just before the main time loop starts)
 with `model.output.id`, but otherwise we do as before.
 ```@example galewsky_setup

--- a/docs/src/setups.md
+++ b/docs/src/setups.md
@@ -198,7 +198,7 @@ using SpeedyWeather
 spectral_grid = SpectralGrid(trunc=63,nlev=1)
 forcing = JetStreamForcing(spectral_grid,latitude=60)
 drag = QuadraticDrag(spectral_grid)
-output = OutputWriter(spectral_grid,ShallowWater,output_dt=6,output_vars=[:u,:v,:pres,:orography])
+output = OutputWriter(spectral_grid,ShallowWater,output_dt=Hour(6),output_vars=[:u,:v,:pres,:orography])
 model = ShallowWaterModel(;spectral_grid,output,drag,forcing)
 simulation = initialize!(model)
 model.feedback.verbose = false # hide
@@ -251,7 +251,7 @@ time_stepping = SpeedyWeather.Leapfrog(spectral_grid,Δt_at_T31=30)
 implicit = SpeedyWeather.ImplicitShallowWater(spectral_grid,α=0.5)
 orography = EarthOrography(spectral_grid,smoothing=false)
 initial_conditions = SpeedyWeather.RandomWaves()
-output = OutputWriter(spectral_grid,ShallowWater,output_dt=12,output_vars=[:u,:pres,:div,:orography])
+output = OutputWriter(spectral_grid,ShallowWater,output_dt=Hour(12),output_vars=[:u,:pres,:div,:orography])
 model = ShallowWaterModel(;spectral_grid,orography,output,initial_conditions,implicit,time_stepping)
 simulation = initialize!(model)
 model.feedback.verbose = false # hide

--- a/docs/src/setups.md
+++ b/docs/src/setups.md
@@ -132,7 +132,7 @@ ax.set_xlabel("longitude")
 ax.set_ylabel("latitude")
 ax.set_title("Relative vorticity")
 tight_layout() # hide
-savefig("galewsky1.png") # hide
+savefig("galewsky1.png", dpi=70) # hide
 nothing # hide
 ```
 ![Galewsky jet pyplot1](galewsky1.png)
@@ -144,7 +144,7 @@ And now the last time step, that means time = 12days is
 t = ds.dim["time"]
 vor = Matrix{Float32}(ds["vor"][:,:,1,t])
 ax.pcolormesh(lon,lat,vor')
-savefig("galewsky2.png") # hide
+savefig("galewsky2.png", dpi=70) # hide
 nothing # hide
 ```
 ![Galewsky jet pyplot2](galewsky2.png)
@@ -185,7 +185,7 @@ ax.set_xlabel("longitude")
 ax.set_ylabel("latitude")
 ax.set_title("Relative vorticity")
 tight_layout() # hide
-savefig("galewsky3.png") # hide
+savefig("galewsky3.png", dpi=70) # hide
 nothing # hide
 ```
 ![Galewsky jet pyplot3](galewsky3.png)
@@ -238,7 +238,7 @@ ax.set_ylabel("latitude")
 ax.set_title("Zonal wind [m/s]")
 colorbar(q,ax=ax)
 tight_layout() # hide
-savefig("polar_jets.png") # hide
+savefig("polar_jets.png", dpi=70) # hide
 nothing # hide
 ```
 ![Polar jets pyplot](polar_jets.png)
@@ -307,7 +307,7 @@ ax.set_xlabel("longitude")
 ax.set_ylabel("latitude")
 ax.set_title("Divergence")
 tight_layout() # hide
-savefig("gravity_waves.png") # hide
+savefig("gravity_waves.png", dpi=70) # hide
 nothing # hide
 ```
 ![Gravity waves pyplot](gravity_waves.png)
@@ -354,7 +354,7 @@ ax.set_xlabel("longitude")
 ax.set_ylabel("latitude")
 ax.set_title("Surface relative vorticity")
 tight_layout() # hide
-savefig("jablonowski.png") # hide
+savefig("jablonowski.png", dpi=70) # hide
 nothing # hide
 ```
 ![Jablonowski pyplot](jablonowski.png)

--- a/docs/src/setups.md
+++ b/docs/src/setups.md
@@ -252,7 +252,7 @@ using Random # hide
 Random.seed!(1234) # hide
 using SpeedyWeather
 spectral_grid = SpectralGrid(trunc=127,nlev=1)
-time_stepping = SpeedyWeather.Leapfrog(spectral_grid,Δt_at_T31=30)
+time_stepping = SpeedyWeather.Leapfrog(spectral_grid,Δt_at_T31=Minute(30))
 implicit = SpeedyWeather.ImplicitShallowWater(spectral_grid,α=0.5)
 orography = EarthOrography(spectral_grid,smoothing=false)
 initial_conditions = SpeedyWeather.RandomWaves()

--- a/docs/src/speedytransforms.md
+++ b/docs/src/speedytransforms.md
@@ -53,6 +53,7 @@ By default, the `gridded` transforms onto a [`FullGaussianGrid`](@ref FullGaussi
 into a vector west to east, starting at the prime meridian, then north to south, see [RingGrids](@ref).
 We can visualize `map` quickly with a UnicodePlot via `plot` (see [Visualising RingGrid data](@ref))
 ```@example speedytransforms
+import SpeedyWeather.RingGrids: plot    # not necessary when `using SpeedyWeather`
 plot(map)
 ```
 Yay! This is the what the ``l=m=1`` spherical harmonic is supposed to look like!

--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -17,7 +17,7 @@ import Adapt: Adapt, adapt, adapt_structure
 
 # INPUT OUTPUT
 import TOML
-import Dates: Dates, DateTime
+import Dates: Dates, DateTime, Second, Minute, Hour, Day, value
 import Printf: Printf, @sprintf
 import NCDatasets: NCDatasets, NCDataset, defDim, defVar
 import JLD2: jldopen

--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -17,7 +17,7 @@ import Adapt: Adapt, adapt, adapt_structure
 
 # INPUT OUTPUT
 import TOML
-import Dates: Dates, DateTime, Second, Minute, Hour, Day, value
+import Dates: Dates, DateTime, Second, Minute, Hour, Day, Week
 import Printf: Printf, @sprintf
 import NCDatasets: NCDatasets, NCDataset, defDim, defVar
 import JLD2: jldopen

--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -4,6 +4,7 @@ module SpeedyWeather
 using DocStringExtensions
 
 # NUMERICS
+import Primes
 import Random
 import FastGaussQuadrature
 import LinearAlgebra: LinearAlgebra, Diagonal

--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -17,7 +17,7 @@ import Adapt: Adapt, adapt, adapt_structure
 
 # INPUT OUTPUT
 import TOML
-import Dates: Dates, DateTime, Second, Minute, Hour, Day, Week
+import Dates: Dates, DateTime, Millisecond, Second, Minute, Hour, Day
 import Printf: Printf, @sprintf
 import NCDatasets: NCDatasets, NCDataset, defDim, defVar
 import JLD2: jldopen
@@ -27,7 +27,7 @@ import UnicodePlots
 import ProgressMeter
 
 # to avoid a `using Dates` to pass on DateTime arguments
-export DateTime
+export DateTime, Second, Minute, Hour, Day
 
 # EXPORT MONOLITHIC INTERFACE TO SPEEDY
 export  run_speedy,

--- a/src/dynamics/forcing.jl
+++ b/src/dynamics/forcing.jl
@@ -43,7 +43,7 @@ Base.@kwdef struct JetStreamForcing{NF} <: AbstractForcing{NF}
     speed::Float64 = 85
 
     "time scale [days]"
-    time_scale::Float64 = 30
+    time_scale::Second = Day(30)
 
     "precomputed amplitude vector [m/s²]"
     amplitude::Vector{NF} = zeros(NF,nlat)
@@ -62,7 +62,7 @@ function initialize!(   forcing::JetStreamForcing,
     θ₀ = (latitude-width)/360*2π        # southern boundary of jet [radians]
     θ₁ = (latitude+width)/360*2π        # northern boundary of jet
     eₙ = exp(-4/(θ₁-θ₀)^2)              # normalisation, so that speed is at max
-    A₀ = speed/eₙ/(time_scale*24*3600)  # amplitude [m/s²] without lat dependency
+    A₀ = speed/eₙ/time_scale.value      # amplitude [m/s²] without lat dependency
     A₀ *= radius                        # scale by radius as are the momentum equations
 
     (;nlat,colat) = model.geometry

--- a/src/dynamics/models.jl
+++ b/src/dynamics/models.jl
@@ -61,6 +61,10 @@ function initialize!(model::Barotropic;time::DateTime = DEFAULT_DATE)
     spectral_grid.nlev > 1 && @warn "Only nlev=1 supported for BarotropicModel, \
         SpectralGrid with nlev=$(spectral_grid.nlev) provided."
 
+    # slightly adjust model time step to be a convenient divisor of output timestep
+    initialize!(model.time_stepping,model)
+
+    # initialize components
     initialize!(model.forcing,model)
     initialize!(model.drag,model)
     initialize!(model.horizontal_diffusion,model)
@@ -122,6 +126,10 @@ function initialize!(model::ShallowWater;time::DateTime = DEFAULT_DATE)
     spectral_grid.nlev > 1 && @warn "Only nlev=1 supported for ShallowWaterModel, \
                                 SpectralGrid with nlev=$(spectral_grid.nlev) provided."
 
+    # slightly adjust model time step to be a convenient divisor of output timestep
+    initialize!(model.time_stepping,model)
+
+    # initialize components
     initialize!(model.forcing,model)
     initialize!(model.drag,model)
     initialize!(model.horizontal_diffusion,model)
@@ -193,6 +201,9 @@ except for `model.output` and `model.feedback` which are always called
 at in `time_stepping!` and `model.implicit` which is done in `first_timesteps!`."""
 function initialize!(model::PrimitiveDry;time::DateTime = DEFAULT_DATE)
     (;spectral_grid) = model
+
+    # slightly adjust model time step to be a convenient divisor of output timestep
+    initialize!(model.time_stepping,model)
 
     # numerics (implicit is initialized later)
     initialize!(model.horizontal_diffusion,model)
@@ -284,6 +295,9 @@ except for `model.output` and `model.feedback` which are always called
 at in `time_stepping!` and `model.implicit` which is done in `first_timesteps!`."""
 function initialize!(model::PrimitiveWet;time::DateTime = DEFAULT_DATE)
     (;spectral_grid) = model
+
+    # slightly adjust model time step to be a convenient divisor of output timestep
+    initialize!(model.time_stepping,model)
 
     # numerics (implicit is initialized later)
     initialize!(model.horizontal_diffusion,model)

--- a/src/dynamics/prognostic_variables.jl
+++ b/src/dynamics/prognostic_variables.jl
@@ -28,7 +28,7 @@ end
 $(TYPEDSIGNATURES)
 Initialize the clock with the time step `Δt` in the `time_stepping`."""
 function initialize!(clock::Clock,time_stepping::TimeStepper)
-    clock.n_timesteps = ceil(Int,24*clock.n_days/(value(time_stepping.Δt_sec)/3600))
+    clock.n_timesteps = ceil(Int,3600*24*clock.n_days/time_stepping.Δt_sec.value)
     return clock
 end
 

--- a/src/dynamics/prognostic_variables.jl
+++ b/src/dynamics/prognostic_variables.jl
@@ -28,7 +28,7 @@ end
 $(TYPEDSIGNATURES)
 Initialize the clock with the time step `Δt` in the `time_stepping`."""
 function initialize!(clock::Clock,time_stepping::TimeStepper)
-    clock.n_timesteps = ceil(Int,24*clock.n_days/(value(time_stepping.Δt_sec)/3600))
+    clock.n_timesteps = ceil(Int,24*clock.n_days/(value(Hour(time_stepping.Δt_sec))))
     return clock
 end
 

--- a/src/dynamics/prognostic_variables.jl
+++ b/src/dynamics/prognostic_variables.jl
@@ -28,7 +28,7 @@ end
 $(TYPEDSIGNATURES)
 Initialize the clock with the time step `Δt` in the `time_stepping`."""
 function initialize!(clock::Clock,time_stepping::TimeStepper)
-    clock.n_timesteps = ceil(Int,24*clock.n_days/(value(Hour(time_stepping.Δt_sec))))
+    clock.n_timesteps = ceil(Int,24*clock.n_days/(value(time_stepping.Δt_sec)/3600))
     return clock
 end
 

--- a/src/dynamics/prognostic_variables.jl
+++ b/src/dynamics/prognostic_variables.jl
@@ -28,7 +28,7 @@ end
 $(TYPEDSIGNATURES)
 Initialize the clock with the time step `Δt` in the `time_stepping`."""
 function initialize!(clock::Clock,time_stepping::TimeStepper)
-    clock.n_timesteps = ceil(Int,3600*24*clock.n_days/time_stepping.Δt_sec.value)
+    clock.n_timesteps = ceil(Int,3600*24*clock.n_days/time_stepping.Δt_sec)
     return clock
 end
 

--- a/src/dynamics/prognostic_variables.jl
+++ b/src/dynamics/prognostic_variables.jl
@@ -28,7 +28,7 @@ end
 $(TYPEDSIGNATURES)
 Initialize the clock with the time step `Δt` in the `time_stepping`."""
 function initialize!(clock::Clock,time_stepping::TimeStepper)
-    clock.n_timesteps = ceil(Int,24*clock.n_days/time_stepping.Δt_hrs)
+    clock.n_timesteps = ceil(Int,24*clock.n_days/(value(time_stepping.Δt_sec)/3600))
     return clock
 end
 

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -34,7 +34,7 @@ Base.@kwdef struct Leapfrog{NF} <: TimeStepper{NF}
     Δt_sec::Second = get_Δt_sec(Second(Δt_at_T31), trunc, adjust_Δt_with_output, Second(output_dt))
 
     "time step Δt [s/m] at specified resolution, scaled by 1/radius"
-    Δt::NF = value(Δt_sec)/radius  
+    Δt::NF = Δt_sec.value/radius  
 end
 
 """
@@ -47,13 +47,13 @@ adjusted to the closest divisor of `output_dt` so that the output time axis is k
 function get_Δt_sec(Δt_at_T31, trunc, adjust_Δt_with_output, output_dt)
 
     scaling_factor = (32/(trunc+1))
-    scaled_Δt_at_T31 = value(Δt_at_T31)*scaling_factor
+    scaled_Δt_at_T31 = Δt_at_T31.value*scaling_factor
 
     if adjust_Δt_with_output
         # by using ceil we will always adjust Δt_at_T31 to be smaller than original one
-        k = ceil(value(output_dt) / scaled_Δt_at_T31)
+        k = ceil(output_dt.value / scaled_Δt_at_T31)
     
-        Δt_sec = Second(round(Int, (value(output_dt)/k) * inv(scaling_factor)))
+        Δt_sec = Second(round(Int, output_dt.value/k/scaling_factor))
     else 
         Δt_sec = Second(round(Int, scaled_Δt_at_T31))
     end 

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -57,13 +57,18 @@ function get_Δt_millisec(
         k = round(Int,Second(output_dt).value / Δt_at_trunc)
         divisors = Primes.divisors(Millisecond(output_dt).value)
         sort!(divisors)
-        i = findfirst(x -> x>=k,divisors)
+        i = findfirst(x -> x>=k, divisors)
         k_new = isnothing(i) ? k : divisors[i]
         Δt_millisec = Millisecond(round(Int, Millisecond(output_dt).value/k_new))
 
-        if k_new/k > 1.05   # provide info on 
-            p = round(Int,(k/k_new - 1)*100)
-            @info "Adjust with output: Time step shortened to $Δt_millisec ($p%)"
+        # provide info when time step is significantly shortened or lengthened
+        Δt_millisec_unadjusted = round(Int,1000*Δt_at_trunc)
+        Δt_ratio = Δt_millisec.value/Δt_millisec_unadjusted
+
+        if abs(Δt_ratio - 1) > 0.05     # only when +-5% changes
+            p = round(Int,(Δt_ratio - 1)*100)
+            ps = p > 0 ? "+" : ""
+            @info "Time step changed from $Δt_millisec_unadjusted to $Δt_millisec ($ps$p%) to match output frequency."
         end
     else 
         Δt_millisec = Millisecond(round(Int, 1000*Δt_at_trunc))

--- a/src/output/feedback.jl
+++ b/src/output/feedback.jl
@@ -80,7 +80,7 @@ function initialize!(feedback::Feedback,clock::Clock,model::ModelSetup)
 
     # hack: redefine element in global constant dt_in_sec
     # used to pass on the time step to ProgressMeter.speedstring
-    DT_IN_SEC[] = model.time_stepping.Δt_sec        
+    DT_IN_SEC[] = value(model.time_stepping.Δt_sec)     
 
     if feedback.output   # with netcdf output write progress.txt
         (; run_path, id) = feedback

--- a/src/output/feedback.jl
+++ b/src/output/feedback.jl
@@ -80,7 +80,7 @@ function initialize!(feedback::Feedback,clock::Clock,model::ModelSetup)
 
     # hack: redefine element in global constant dt_in_sec
     # used to pass on the time step to ProgressMeter.speedstring
-    DT_IN_SEC[] = value(model.time_stepping.Δt_sec)     
+    DT_IN_SEC[] = model.time_stepping.Δt_sec.value   
 
     if feedback.output   # with netcdf output write progress.txt
         (; run_path, id) = feedback

--- a/src/output/feedback.jl
+++ b/src/output/feedback.jl
@@ -80,7 +80,7 @@ function initialize!(feedback::Feedback,clock::Clock,model::ModelSetup)
 
     # hack: redefine element in global constant dt_in_sec
     # used to pass on the time step to ProgressMeter.speedstring
-    DT_IN_SEC[] = model.time_stepping.Δt_sec.value   
+    DT_IN_SEC[] = model.time_stepping.Δt_sec
 
     if feedback.output   # with netcdf output write progress.txt
         (; run_path, id) = feedback
@@ -208,7 +208,7 @@ end
 # hack: define global constant whose element will be changed in initialize_feedback
 # used to pass on the time step to ProgressMeter.speedstring via calling this
 # constant from the ProgressMeter module
-const DT_IN_SEC = Ref(1800)
+const DT_IN_SEC = Ref(1800.0)
 
 # "extend" the speedstring function from ProgressMeter by defining it for ::AbstractFloat
 # not just ::Any to effectively overwrite it
@@ -228,7 +228,7 @@ julia> readable_secs(12345)
 ```
 """
 function readable_secs(secs::Real)
-    millisecs = Dates.Millisecond(round(secs * 10 ^ 3))
+    millisecs = Dates.Millisecond(round(secs * 1000))
     if millisecs >= Dates.Day(1)
         return Dates.canonicalize(round(millisecs, Dates.Hour))
     elseif millisecs >= Dates.Hour(1)

--- a/src/output/output.jl
+++ b/src/output/output.jl
@@ -54,11 +54,8 @@ Base.@kwdef mutable struct OutputWriter{NF<:Union{Float32,Float64},Model<:ModelS
     # WHAT/WHEN OPTIONS
     startdate::DateTime = DateTime(2000,1,1)
 
-    "[OPTION] output frequency, time step [hrs]"
-    output_dt::Float64 = 6
-
-    "actual output time step [sec]"
-    output_dt_sec::Int = 0
+    "[OPTION] output frequency, time step"
+    output_dt::Second = Hour(6)
 
     "[OPTION] which variables to output, u, v, vor, div, pres, temp, humid"
     output_vars::Vector{Symbol} = default_output_vars(Model)
@@ -175,8 +172,8 @@ function initialize!(
     feedback.output = true          # if output=true set feedback.output=true too!
 
     # OUTPUT FREQUENCY
-    output.output_every_n_steps = max(1,floor(Int,output.output_dt/time_stepping.Δt_hrs))
-    output.output_dt_sec = output.output_every_n_steps*time_stepping.Δt_sec
+    output.output_every_n_steps = max(1,round(Int, output.output_dt/time_stepping.Δt_sec))
+    output.output_dt = output.output_every_n_steps*time_stepping.Δt_sec
 
     # RESET COUNTERS
     output.timestep_counter = 0         # time step counter

--- a/src/physics/large_scale_condensation.jl
+++ b/src/physics/large_scale_condensation.jl
@@ -78,7 +78,7 @@ function large_scale_condensation!(
 
     (;gravity, water_density) = constants
     (;Δt_sec) = time_stepping
-    pₛΔt_gρ = pₛ*Δt_sec.value/gravity/water_density   # precompute constant
+    pₛΔt_gρ = pₛ*Δt_sec/gravity/water_density   # precompute constant
 
     (;σ_levels_thick) = geometry
     latent_heat = convert(NF, atmosphere.latent_heat_condensation)

--- a/src/physics/large_scale_condensation.jl
+++ b/src/physics/large_scale_condensation.jl
@@ -13,7 +13,7 @@ Base.@kwdef struct SpeedyCondensation{NF<:AbstractFloat} <: AbstractCondensation
     relative_baseline::Float64 = 0.9
 
     "Relaxation time for humidity [hrs]"
-    time_scale::Float64 = 4.0
+    time_scale::Second = Hour(4)
 
     # precomputed arrays
     n_stratosphere_levels::Base.RefValue{Int} = Ref(0)
@@ -67,7 +67,7 @@ function large_scale_condensation!(
     ) where NF
 
     (;relative_threshold,relative_baseline) = scheme
-    time_scale = convert(NF,3600*scheme.time_scale)     # [hrs] -> [s]
+    time_scale⁻¹ = scheme.time_scale.value
     n_stratosphere_levels = scheme.n_stratosphere_levels[]
 
     (;humid, pres) = column               # prognostic variables: specific humidity, surface pressure
@@ -93,7 +93,7 @@ function large_scale_condensation!(
         if humid[k] > humid_threshold
 
             # accumulate in tendencies (nothing is added if humidity not above threshold)
-            humid_tend_k = -(humid[k] - humid_baseline) / time_scale                   # Formula 22
+            humid_tend_k = -(humid[k] - humid_baseline) * time_scale⁻¹                  # Formula 22
             # temp_tend[k] += -latent_heat * min(humid_tend_k, humid_tend_max[k]*pres[k]) # Formula 23
             temp_tend[k] += -latent_heat * humid_tend_k             # Formula 23, without limiter
 

--- a/src/physics/large_scale_condensation.jl
+++ b/src/physics/large_scale_condensation.jl
@@ -78,7 +78,7 @@ function large_scale_condensation!(
 
     (;gravity, water_density) = constants
     (;Δt_sec) = time_stepping
-    pₛΔt_gρ = pₛ*Δt_sec/gravity/water_density   # precompute constant
+    pₛΔt_gρ = pₛ*value(Δt_sec)/gravity/water_density   # precompute constant
 
     (;σ_levels_thick) = geometry
     latent_heat = convert(NF, atmosphere.latent_heat_condensation)

--- a/src/physics/large_scale_condensation.jl
+++ b/src/physics/large_scale_condensation.jl
@@ -78,7 +78,7 @@ function large_scale_condensation!(
 
     (;gravity, water_density) = constants
     (;Δt_sec) = time_stepping
-    pₛΔt_gρ = pₛ*value(Δt_sec)/gravity/water_density   # precompute constant
+    pₛΔt_gρ = pₛ*Δt_sec.value/gravity/water_density   # precompute constant
 
     (;σ_levels_thick) = geometry
     latent_heat = convert(NF, atmosphere.latent_heat_condensation)

--- a/src/physics/large_scale_condensation.jl
+++ b/src/physics/large_scale_condensation.jl
@@ -67,7 +67,7 @@ function large_scale_condensation!(
     ) where NF
 
     (;relative_threshold,relative_baseline) = scheme
-    time_scale⁻¹ = scheme.time_scale.value
+    time_scale⁻¹ = inv(convert(NF,scheme.time_scale.value))
     n_stratosphere_levels = scheme.n_stratosphere_levels[]
 
     (;humid, pres) = column               # prognostic variables: specific humidity, surface pressure

--- a/src/utility_functions.jl
+++ b/src/utility_functions.jl
@@ -101,10 +101,15 @@ function print_fields(io::IO,A,keys;arrays::Bool=false)
     end
 end
 
-function Base.convert(::Type{Second},x::Real)
+Dates.Second(x::AbstractFloat) = convert(Second,x)
+Dates.Minute(x::AbstractFloat) = Second(60x)
+Dates.Hour(  x::AbstractFloat) = Minute(60x)
+Dates.Day(   x::AbstractFloat) = Hour(24x)
+
+function Base.convert(::Type{Second},x::AbstractFloat)
     xr = round(Int64,x)
     @info "Rounding and converting $x to $xr for integer seconds."
-    return convert(Second,xr)
+    return Second(xr)
 end
 
 function Base.convert(::Type{Second},x::Integer)

--- a/src/utility_functions.jl
+++ b/src/utility_functions.jl
@@ -100,3 +100,14 @@ function print_fields(io::IO,A,keys;arrays::Bool=false)
         print(io,s_without_comma)    
     end
 end
+
+function Base.convert(::Type{Second},x::Real)
+    xr = round(Int64,x)
+    @info "Rounding and converting $x to $xr for integer seconds."
+    return convert(Second,xr)
+end
+
+function Base.convert(::Type{Second},x::Integer)
+    @info "Input '$x' assumed to have units of seconds. Use Minute($x), Hour($x), Day($x) otherwise."
+    return Second(round(Int64,x))
+end

--- a/test/dates.jl
+++ b/test/dates.jl
@@ -1,0 +1,27 @@
+@testset "Sec, min, hrs arguments" begin
+    SG = SpectralGrid(trunc=42,nlev=1)
+    L1 = Leapfrog(SG,Δt_at_T31=30)
+    L2 = Leapfrog(SG,Δt_at_T31=Second(30))
+    @test L1.Δt == L2.Δt
+    
+    L3 = Leapfrog(SG,Δt_at_T31=Second(300))
+    L4 = Leapfrog(SG,Δt_at_T31=Minute(5))
+    @test L3.Δt == L4.Δt
+
+    L4 = Leapfrog(SG,Δt_at_T31=Minute(60))
+    L5 = Leapfrog(SG,Δt_at_T31=Hour(1))
+    @test L4.Δt == L5.Δt
+
+    # without adjustment
+    L1 = Leapfrog(SG,Δt_at_T31=30,adjust_with_output=false)
+    L2 = Leapfrog(SG,Δt_at_T31=Second(30),adjust_with_output=false)
+    @test L1.Δt == L2.Δt
+    
+    L3 = Leapfrog(SG,Δt_at_T31=Second(300),adjust_with_output=false)
+    L4 = Leapfrog(SG,Δt_at_T31=Minute(5),adjust_with_output=false)
+    @test L3.Δt == L4.Δt
+
+    L4 = Leapfrog(SG,Δt_at_T31=Minute(60),adjust_with_output=false)
+    L5 = Leapfrog(SG,Δt_at_T31=Hour(1),adjust_with_output=false)
+    @test L4.Δt == L5.Δt
+end

--- a/test/netcdf_output.jl
+++ b/test/netcdf_output.jl
@@ -108,7 +108,7 @@ end
     function manual_time_axis(startdate, dt, n_timesteps)
         time_axis = zeros(typeof(startdate), n_timesteps+1)
         for i=0:n_timesteps
-            time_axis[i+1] = startdate + Dates.Second(dt*i)
+            time_axis[i+1] = startdate + dt*i
         end 
         time_axis 
     end 
@@ -124,11 +124,11 @@ end
     progn = simulation.prognostic_variables
     tmp_read_path = joinpath(model.output.run_path,model.output.filename)
     t = NCDataset(tmp_read_path)["time"][:]
-    @test t == manual_time_axis(model.output.startdate,model.time_stepping.Δt_sec,progn.clock.n_timesteps)
+    @test t == manual_time_axis(model.output.startdate,model.time_stepping.Δt_millisec,progn.clock.n_timesteps)
     
     # do a simulation with the adjust_Δt_with_output turned on 
     output = OutputWriter(spectral_grid,PrimitiveDry,path=tmp_output_path,id="adjust_dt_with_output-test",output_dt=Minute(70))
-    time_stepping = Leapfrog(spectral_grid, adjust_Δt_with_output=true, output_dt=Minute(70))
+    time_stepping = Leapfrog(spectral_grid, adjust_with_output=true)
     model = PrimitiveDryModel(;spectral_grid,output,time_stepping)
     simulation = initialize!(model)
     run!(simulation,output=true,n_days=1)
@@ -150,6 +150,6 @@ end
     progn = simulation.prognostic_variables
     tmp_read_path = joinpath(model.output.run_path,model.output.filename)
     t = NCDataset(tmp_read_path)["time"][:]
-    @test t == manual_time_axis(model.output.startdate,model.time_stepping.Δt_sec,progn.clock.n_timesteps)
+    @test t == manual_time_axis(model.output.startdate,model.time_stepping.Δt_millisec,progn.clock.n_timesteps)
     @test t == SpeedyWeather.load_trajectory("time", model)
 end

--- a/test/netcdf_output.jl
+++ b/test/netcdf_output.jl
@@ -152,11 +152,4 @@ end
     t = NCDataset(tmp_read_path)["time"][:]
     @test t == manual_time_axis(model.output.startdate,model.time_stepping.Δt_sec,progn.clock.n_timesteps)
     @test t == SpeedyWeather.load_trajectory("time", model)
-
-
-    # do a simulation with the adjust_Δt_with_output turned on 
-    output = OutputWriter(spectral_grid,PrimitiveDry,path=tmp_output_path,id="long-output-test",output_dt=Hour(24*365*10))
-    model = PrimitiveDryModel(;spectral_grid,output,time_stepping)
-
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 
 # GENERAL
 include("utility_functions.jl")
+include("dates.jl")
 include("lower_triangular_matrix.jl")
 include("grids.jl")
 include("interpolation.jl")

--- a/test/vertical_advection.jl
+++ b/test/vertical_advection.jl
@@ -1,13 +1,14 @@
-using SpeedyWeather: WENOVerticalAdvection, CenteredVerticalAdvection, UpwindVerticalAdvection
-using SpeedyWeather: vertical_advection!
-
 @testset "Vertical advection runs" begin
     spectral_grid = SpectralGrid()
     model_types = (PrimitiveDryModel, PrimitiveWetModel)
-    advection_schems = (WENOVerticalAdvection, CenteredVerticalAdvection, UpwindVerticalAdvection)
+    advection_schems = (SpeedyWeather.WENOVerticalAdvection,
+                        SpeedyWeather.CenteredVerticalAdvection,
+                        SpeedyWeather.UpwindVerticalAdvection)
 
     for Model in model_types, VerticalAdvection in advection_schems
-        model = Model(; spectral_grid, vertical_advection = VerticalAdvection(spectral_grid))
+        model = Model(; spectral_grid,
+                        vertical_advection = VerticalAdvection(spectral_grid),
+                        physics=false)
         simulation = initialize!(model)
         run!(simulation,n_days=10)
         @test simulation.model.feedback.nars_detected == false    


### PR DESCRIPTION
This implements #416 and part of #417. 

I made `Δt_sec` a `Second` as well, so it can be only full seconds. This also means that the adjusted `Δt_at_T31` will be a bit smaller and the integration will take a few more steps. If we would want to implement it like Milan wrote in #416 then we would need `Δt_sec` as a Float or Millisecond. I am not opposed to that, but I thought in the initial draft I do everything in SI. 

So with this I already implemented a part of #417 as well, but I did not adjust everything. After this is done, we definitely also need to go over the documentation. I already made some small corrections based on this PR, but no proper rewrite of the respective sections. 

I am on vacation next week, so don't expect any replies from me. Feel free to modify this PR/branch. 