### PR TITLE
Make prognostics available for forcing, drag in Barotropic/SWM

### DIFF
--- a/docs/src/extending.md
+++ b/docs/src/extending.md
@@ -82,6 +82,7 @@ that is called on _every_ step of the time integration. This new method
 for `forcing!` needs to have the following function signature
 ```julia
 function forcing!(  diagn::DiagnosticVariablesLayer,
+                    progn::PrognosticVariablesLayer,
                     forcing::MyForcing,
                     time::DateTime,
                     model::ModelSetup)
@@ -339,6 +340,7 @@ then this will be called automatically with multiple dispatch.
 
 ```@example extend
 function SpeedyWeather.forcing!(diagn::SpeedyWeather.DiagnosticVariablesLayer,
+                                progn::SpeedyWeather.PrognosticVariablesLayer,
                                 forcing::StochasticStirring,
                                 time::DateTime,
                                 model::SpeedyWeather.ModelSetup)
@@ -349,7 +351,9 @@ end
 The function has to be as outlined above. The first argument has to be of type
 ``DiagnosticVariablesLayer`` as it acts on a layer of the diagnostic variables,
 where the current model state in grid-point space and the tendencies (in spectral space)
-are defined. The second argument has to be of the type of our new forcing,
+are defined. The second argument has to be a `PrognosticVariablesLayer` because,
+in general, the forcing may use the prognostic variables in spectral space.
+The third argument has to be of the type of our new forcing,
 the third argument is time which you may use or skip, the last element is a `ModelSetup`,
 but as before you can be more restrictive to define a forcing only for the
 `BarotropicModel` for example, use ``model::Barotropic`` in that case.

--- a/src/SpeedyTransforms/spectral_truncation.jl
+++ b/src/SpeedyTransforms/spectral_truncation.jl
@@ -71,7 +71,8 @@ to enforce that all coefficients for which the degree l is larger than order m a
 spectral_truncation!(alms::AbstractMatrix) = spectral_truncation!(alms,size(alms)...)
 
 function spectral_truncation!(alms::LowerTriangularMatrix{NF}) where NF
-    alms[end,:] .= zero(NF)     # set the lmax+1 mode to zero
+    lmax,mmax = size(alms)
+    alms[mmax+1:lmax,:] .= 0 # set everything to zero below the triangle
     return alms
 end
 

--- a/src/dynamics/drag.jl
+++ b/src/dynamics/drag.jl
@@ -14,6 +14,7 @@ function initialize!(   drag::NoDrag,
 end
 
 function drag!(     diagn::DiagnosticVariablesLayer,
+                    progn::PrognosticVariablesLayer,
                     drag::NoDrag,
                     time::DateTime,
                     model::ModelSetup)
@@ -23,7 +24,7 @@ end
 # Quadratic drag
 Base.@kwdef struct QuadraticDrag{NF} <: AbstractDrag{NF}
     "drag coefficient [1]"
-    c_D::Float64 = 1e-5
+    c_D::NF = 1e-5
 end
 
 QuadraticDrag(SG::SpectralGrid;kwargs...) = QuadraticDrag{SG.NF}(;kwargs...)
@@ -35,6 +36,7 @@ end
 
 # function barrier
 function drag!(     diagn::DiagnosticVariablesLayer,
+                    progn::PrognosticVariablesLayer,
                     drag::QuadraticDrag,
                     time::DateTime,
                     model::ModelSetup)

--- a/src/dynamics/forcing.jl
+++ b/src/dynamics/forcing.jl
@@ -14,6 +14,7 @@ function initialize!(   forcing::NoForcing,
 end
 
 function forcing!(  diagn::DiagnosticVariablesLayer,
+                    progn::PrognosticVariablesLayer,
                     forcing::NoForcing,
                     time::DateTime,
                     model::ModelSetup)
@@ -83,6 +84,7 @@ end
 
 # function barrier
 function forcing!(  diagn::DiagnosticVariablesLayer,
+                    progn::PrognosticVariablesLayer,
                     forcing::JetStreamForcing,
                     time::DateTime,
                     model::ModelSetup)

--- a/src/dynamics/tendencies.jl
+++ b/src/dynamics/tendencies.jl
@@ -2,17 +2,19 @@
 $(TYPEDSIGNATURES)
 Calculate all tendencies for the BarotropicModel."""
 function dynamics_tendencies!(  diagn::DiagnosticVariablesLayer,
+                                progn::PrognosticVariablesLayer,
                                 time::DateTime,
                                 model::Barotropic)
-    forcing!(diagn,model.forcing,time,model)    # = (Fᵤ, Fᵥ) forcing for u,v
-    drag!(diagn,model.drag,time,model)          # drag term for u,v
-    vorticity_flux!(diagn,model)                # = ∇×(v(ζ+f) + Fᵤ,-u(ζ+f) + Fᵥ)
+    forcing!(diagn,progn,model.forcing,time,model)  # = (Fᵤ, Fᵥ) forcing for u,v
+    drag!(diagn,progn,model.drag,time,model)        # drag term for u,v
+    vorticity_flux!(diagn,model)                    # = ∇×(v(ζ+f) + Fᵤ,-u(ζ+f) + Fᵥ)
 end
 
 """
 $(TYPEDSIGNATURES)
 Calculate all tendencies for the ShallowWaterModel."""
 function dynamics_tendencies!(  diagn::DiagnosticVariablesLayer,
+                                progn::PrognosticVariablesLayer,
                                 surface::SurfaceVariables,
                                 pres::LowerTriangularMatrix,    # spectral pressure/η for geopotential
                                 time::DateTime,                 # time to evaluate the tendencies at
@@ -22,8 +24,8 @@ function dynamics_tendencies!(  diagn::DiagnosticVariablesLayer,
     F,D = model.forcing, model.drag
 
     # for compatibility with other ModelSetups pressure pres = interface displacement η here
-    forcing!(diagn,F,time,model)            # = (Fᵤ, Fᵥ, Fₙ) forcing for u,v,η
-    drag!(diagn,D,time,model)               # drag term for momentum u,v
+    forcing!(diagn,progn,F,time,model)      # = (Fᵤ, Fᵥ, Fₙ) forcing for u,v,η
+    drag!(diagn,progn,D,time,model)         # drag term for momentum u,v
     vorticity_flux!(diagn,model)            # = ∇×(v(ζ+f) + Fᵤ,-u(ζ+f) + Fᵥ), tendency for vorticity
                                             # = ∇⋅(v(ζ+f) + Fᵤ,-u(ζ+f) + Fᵥ), tendency for divergence
     

--- a/test/extending.jl
+++ b/test/extending.jl
@@ -1,0 +1,196 @@
+@testset "Extending forcing and drag" begin
+    Base.@kwdef struct JetDrag{NF} <: SpeedyWeather.AbstractDrag{NF}
+
+        # DIMENSIONS from SpectralGrid
+        "Spectral resolution as max degree of spherical harmonics"
+        trunc::Int
+    
+        # OPTIONS
+        "Relaxation time scale τ"
+        time_scale::Second = Day(6)
+    
+        "Jet strength [m/s]"
+        u₀::Float64 = 20
+    
+        "latitude of Gaussian jet [˚N]"
+        latitude::Float64 = 30
+    
+        "Width of Gaussian jet [˚]"
+        width::Float64 = 6
+    
+        # TO BE INITIALISED
+        "Relaxation back to reference vorticity"
+        ζ₀::LowerTriangularMatrix{Complex{NF}} = zeros(LowerTriangularMatrix{Complex{NF}},trunc+2,trunc+1)
+    end
+    
+    function JetDrag(SG::SpectralGrid;kwargs...)
+        return JetDrag{SG.NF}(;SG.trunc,kwargs...)
+    end
+    
+    function SpeedyWeather.initialize!( drag::JetDrag,
+                                        model::SpeedyWeather.ModelSetup)
+    
+        (;spectral_grid, geometry) = model
+        (;Grid,NF,nlat_half) = spectral_grid
+        u = zeros(Grid{NF},nlat_half)
+    
+        lat = geometry.latds
+    
+        for ij in eachindex(u)
+            u[ij] = drag.u₀ * exp(-(lat[ij]-drag.latitude)^2/(2*drag.width^2))
+        end
+    
+        û = SpeedyTransforms.spectral(u,one_more_degree=true)
+        v̂ = zero(û)
+        SpeedyTransforms.curl!(drag.ζ₀,û,v̂,model.spectral_transform)
+        return nothing
+    end
+    
+    function SpeedyWeather.drag!(   diagn::SpeedyWeather.DiagnosticVariablesLayer,
+                                    progn::SpeedyWeather.PrognosticVariablesLayer,
+                                    drag::JetDrag,
+                                    time::DateTime,
+                                    model::SpeedyWeather.ModelSetup)
+    
+        (;vor) = progn
+        (;vor_tend) = diagn.tendencies
+        (;ζ₀) = drag
+        
+        (;radius) = model.spectral_grid
+        r = radius/drag.time_scale.value
+        for lm in eachindex(vor,vor_tend,ζ₀)
+            vor_tend[lm] -= r*(vor[lm] - ζ₀[lm])
+        end
+        
+        SpeedyTransforms.spectral_truncation!(vor_tend)    # set lmax+1 to zero
+        
+        return nothing
+    end
+    
+    Base.@kwdef struct StochasticStirring{NF} <: SpeedyWeather.AbstractForcing{NF}
+        
+        # DIMENSIONS from SpectralGrid
+        "Spectral resolution as max degree of spherical harmonics"
+        trunc::Int
+        
+        "Number of latitude rings, used for latitudinal mask"
+        nlat::Int
+    
+        
+        # OPTIONS
+        "Decorrelation time scale τ [days]"
+        decorrelation_time::Second = Day(2)
+    
+        "Stirring strength A [1/s²]"
+        strength::Float64 = 1e-11
+    
+        "Stirring latitude [˚N]"
+        latitude::Float64 = 45
+    
+        "Stirring width [˚]"
+        width::Float64 = 24
+    
+        
+        # TO BE INITIALISED
+        "Stochastic stirring term S"
+        S::LowerTriangularMatrix{Complex{NF}} = zeros(LowerTriangularMatrix{Complex{NF}},trunc+2,trunc+1)
+        
+        "a = A*sqrt(1 - exp(-2dt/τ)), the noise factor times the stirring strength [1/s²]"
+        a::Base.RefValue{NF} = Ref(zero(NF))
+            
+        "b = exp(-dt/τ), the auto-regressive factor [1]"
+        b::Base.RefValue{NF} = Ref(zero(NF))
+            
+        "Latitudinal mask, confined to mid-latitude storm track by default [1]"
+        lat_mask::Vector{NF} = zeros(NF,nlat)
+    end
+    
+    function StochasticStirring(SG::SpectralGrid;kwargs...)
+        (;trunc,Grid,nlat_half) = SG
+        nlat = RingGrids.get_nlat(Grid,nlat_half)
+        return StochasticStirring{SG.NF}(;trunc,nlat,kwargs...)
+    end
+    
+    function SpeedyWeather.initialize!( forcing::StochasticStirring,
+                                        model::SpeedyWeather.ModelSetup)
+        
+        # precompute forcing strength, scale with radius^2 as is the vorticity equation
+        (;radius) = model.spectral_grid
+        A = radius^2 * forcing.strength
+        
+        # precompute noise and auto-regressive factor, packed in RefValue for mutability
+        dt = model.time_stepping.Δt_sec
+        τ = forcing.decorrelation_time.value    # in seconds
+        forcing.a[] = A*sqrt(1 - exp(-2dt/τ))
+        forcing.b[] = exp(-dt/τ)
+        
+        # precompute the latitudinal mask
+        (;Grid,nlat_half) = model.spectral_grid
+        latd = RingGrids.get_latd(Grid,nlat_half)
+        
+        for j in eachindex(forcing.lat_mask)
+            # Gaussian centred at forcing.latitude of width forcing.width
+            forcing.lat_mask[j] = exp(-(forcing.latitude-latd[j])^2/forcing.width^2*2)
+        end
+    
+        return nothing
+    end
+    
+    function SpeedyWeather.forcing!(diagn::SpeedyWeather.DiagnosticVariablesLayer,
+                                    progn::SpeedyWeather.PrognosticVariablesLayer,
+                                    forcing::StochasticStirring,
+                                    time::DateTime,
+                                    model::SpeedyWeather.ModelSetup)
+        SpeedyWeather.forcing!(diagn,forcing,model.spectral_transform)
+    end
+    
+    function SpeedyWeather.forcing!(diagn::SpeedyWeather.DiagnosticVariablesLayer,
+                                    forcing::StochasticStirring{NF},
+                                    spectral_transform::SpectralTransform) where NF
+        
+        # noise and auto-regressive factors
+        a = forcing.a[]    # = sqrt(1 - exp(-2dt/τ))
+        b = forcing.b[]    # = exp(-dt/τ)
+        
+        (;S) = forcing
+        @inbounds for lm in eachindex(S)
+            # Barnes and Hartmann, 2011 Eq. 2
+            Qi = 2rand(Complex{NF}) - (1 + im)   # ~ [-1,1] in complex
+            S[lm] = a*Qi + b*S[lm]
+        end
+    
+        # to grid-point space
+        S_grid = diagn.dynamics_variables.a_grid
+        SpeedyTransforms.gridded!(S_grid,S,spectral_transform)
+        
+        # mask everything but mid-latitudes
+        RingGrids._scale_lat!(S_grid,forcing.lat_mask)
+        
+        # back to spectral space
+        (;vor_tend) = diagn.tendencies
+        SpeedyTransforms.spectral!(vor_tend,S_grid,spectral_transform)
+        SpeedyTransforms.spectral_truncation!(vor_tend)    # set lmax+1 to zero
+        
+        return nothing
+    end
+
+    spectral_grid = SpectralGrid(trunc=31,nlev=1)
+    
+    drag = JetDrag(spectral_grid,time_scale=Day(6))
+    forcing = StochasticStirring(spectral_grid)
+    initial_conditions = StartFromRest()
+
+    # with barotropic model
+    model = BarotropicModel(;spectral_grid,initial_conditions,forcing,drag)
+    simulation = initialize!(model)
+
+    run!(simulation,period=Day(5))
+    @test simulation.model.feedback.nars_detected == false
+
+    # with shallow water model
+    model = ShallowWaterModel(;spectral_grid,initial_conditions,forcing,drag)
+    simulation = initialize!(model)
+
+    run!(simulation,period=Day(5))
+    @test simulation.model.feedback.nars_detected == false
+end

--- a/test/geopotential.jl
+++ b/test/geopotential.jl
@@ -11,9 +11,10 @@
         temp = 280      # in Kelvin
         lf = 1
         for (progn_layer,diagn_layer) in zip(p.layers,d.layers)
-            progn_layer.timesteps[lf].temp[1] = temp*model.spectral_transform.norm_sphere
-            fill!(progn_layer.timesteps[lf].humid,0)                 # dry core
-            SpeedyWeather.gridded!(diagn_layer,progn_layer,lf,model)    # propagate spectral state to grid
+            progn_layer_lf = progn_layer.timesteps[lf]
+            progn_layer_lf.temp[1] = temp*model.spectral_transform.norm_sphere
+            fill!(progn_layer_lf.humid,0)                               # dry core
+            SpeedyWeather.gridded!(diagn_layer,progn_layer_lf,model)    # propagate spectral state to grid
             SpeedyWeather.linear_virtual_temperature!(diagn_layer,progn_layer,model,lf)
         end
 
@@ -49,7 +50,8 @@ end
 
         lf = 1
         for (progn_layer,diagn_layer) in zip(p.layers,d.layers)
-            SpeedyWeather.gridded!(diagn_layer,progn_layer,lf,m)             # propagate spectral state to grid
+            progn_layer_lf = progn_layer.timesteps[lf]
+            SpeedyWeather.gridded!(diagn_layer,progn_layer_lf,m)             # propagate spectral state to grid
             SpeedyWeather.bernoulli_potential!(diagn_layer,m.spectral_transform)
         end
     end
@@ -68,10 +70,11 @@ end
         temp = 280      # in Kelvin
         lf = 1
         for (progn_layer,diagn_layer) in zip(p.layers,d.layers)
-            progn_layer.timesteps[lf].temp[1] = temp*m.spectral_transform.norm_sphere
-            fill!(progn_layer.timesteps[lf].humid,0)                 
-            progn_layer.timesteps[lf].humid[1] = rand(NF)
-            SpeedyWeather.gridded!(diagn_layer,progn_layer,lf,m)    # propagate spectral state to grid
+            progn_layer_lf = progn_layer.timesteps[lf]
+            progn_layer_lf.temp[1] = temp*m.spectral_transform.norm_sphere
+            fill!(progn_layer_lf.humid,0)                 
+            progn_layer_lf.humid[1] = rand(NF)
+            SpeedyWeather.gridded!(diagn_layer,progn_layer_lf,m)    # propagate spectral state to grid
             
             temp_lf = progn_layer.timesteps[lf].temp     # always passed on for compat with DryCore
             SpeedyWeather.virtual_temperature!(diagn_layer,temp_lf,m)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,5 +36,8 @@ include("column_variables.jl")
 # INITIALIZATION AND INTEGRATION
 include("run_speedy.jl")
 
+# EXTENSION
+include("extending.jl")
+
 # OUTPUT 
 include("netcdf_output.jl")


### PR DESCRIPTION
With this PR the drag formulation from #394 can be simplified to

```julia
function SpeedyWeather.drag!(   diagn::SpeedyWeather.DiagnosticVariablesLayer,
                                progn::SpeedyWeather.PrognosticVariablesLayer,
                                drag::JetDrag,
                                time::DateTime,
                                model::SpeedyWeather.ModelSetup)

    (;vor) = progn
    (;vor_tend) = diagn.tendencies
    (;ζ₀) = drag
    
    (;radius) = model.spectral_grid
    r = radius/drag.time_scale.value
    for lm in eachindex(vor,vor_tend,ζ₀)
        vor_tend[lm] -= r*(vor[lm] - ζ₀[lm])
    end
    
    return nothing
end
```

because `PrognosticVariablesLayer` is passed on