### PR TITLE
Use Julia v1.10 for CI and building Docs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,7 @@ jobs:
         version:
           - '1.8'
           - '1.9'
+          - '1.10'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
       - name: Delete preview and history + push changes

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.8'
+          version: '1.10'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/Project.toml
+++ b/Project.toml
@@ -47,11 +47,11 @@ LinearAlgebra = "1.8"
 NCDatasets = "0.12, 0.13"
 Primes = "0.5"
 Printf = "1.8"
-ProgressMeter = "^1.7"
+ProgressMeter = "1.7"
 Random = "1.8"
 Statistics = "1.8"
 TOML = "1"
-UnicodePlots = "^3.3"
+UnicodePlots = "3.3"
 julia = "1.8"
 
 [extras]


### PR DESCRIPTION
This PR run CI on Julia v1.10 and also uses this version to build the documentation.