### PR TITLE
Adjust time step with radius

### DIFF
--- a/src/dynamics/spectral_grid.jl
+++ b/src/dynamics/spectral_grid.jl
@@ -70,7 +70,7 @@ function Base.show(io::IO,SG::SpectralGrid)
     lat = get_lat(Grid,nlat_half)
     res_eq_y = (lat[nlat_half] - lat[nlat_half+1])*radius/1000
 
-    s(x) = @sprintf("%.3g",x)
+    s(x) = x > 1000 ? @sprintf("%i",x) : @sprintf("%.3g",x)
 
     println(io,"$(typeof(SG)):")
     println(io,"├ Spectral:   T$trunc LowerTriangularMatrix{Complex{$NF}}, radius = $radius m")

--- a/src/dynamics/spectral_grid.jl
+++ b/src/dynamics/spectral_grid.jl
@@ -1,6 +1,9 @@
 const DEFAULT_NF = Float32
 const DEFAULT_MODEL = PrimitiveDry
 const DEFAULT_GRID = OctahedralGaussianGrid
+const DEFAULT_RADIUS = 6.371e6
+const DEFAULT_TRUNC = 31
+const DEFAULT_NLEV = 8
 
 """
 Defines the horizontal spectral resolution and corresponding grid and the
@@ -15,7 +18,7 @@ Base.@kwdef struct SpectralGrid
 
     # HORIZONTAL
     "horizontal resolution as the maximum degree of spherical harmonics"
-    trunc::Int = 31
+    trunc::Int = DEFAULT_TRUNC
 
     "horizontal grid used for calculations in grid-point space"
     Grid::Type{<:AbstractGrid} = DEFAULT_GRID
@@ -24,7 +27,7 @@ Base.@kwdef struct SpectralGrid
     dealiasing::Float64 = 2
 
     "radius of the sphere [m]"
-    radius::Float64 = 6.371e6
+    radius::Float64 = DEFAULT_RADIUS
 
     # SIZE OF GRID from trunc, Grid, dealiasing:
     "number of latitude rings on one hemisphere (Equator incl)"
@@ -35,7 +38,7 @@ Base.@kwdef struct SpectralGrid
 
     # VERTICAL
     "number of vertical levels"
-    nlev::Int = 8
+    nlev::Int = DEFAULT_NLEV
 
     "coordinates used to discretize the vertical"
     vertical_coordinates::VerticalCoordinates = SigmaCoordinates(;nlev)

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -109,7 +109,7 @@ function initialize!(L::Leapfrog,model::ModelSetup)
 
     if L.adjust_with_output
         # take actual output dt from model.output and recalculate timestep
-        L.Δt_millisec = get_Δt_millisec(L.Δt_at_T31, L.trunc, L.adjust_with_output, output_dt)
+        L.Δt_millisec = get_Δt_millisec(L.Δt_at_T31, L.trunc, L.radius, L.adjust_with_output, output_dt)
         L.Δt_sec = L.Δt_millisec.value/1000
         L.Δt = L.Δt_sec/L.radius
     end


### PR DESCRIPTION
Previously the time step was automatically chosen as a function of resolution but not as a function of radius, but larger planets have effectively a coarser grid spacing, meaning they can deal with larger time steps. And vice versa: radius=1e6 currently blows up in the shallow water model because we effectively have a finer resolution by a factor of ~7x, which requires a ~7x smaller time step.

As suggested by @KristianJS 