### PR TITLE
Vertical diffusion of humidity

### DIFF
--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -183,6 +183,7 @@ include("dynamics/vertical_advection.jl")
 include("dynamics/implicit.jl")
 include("dynamics/scaling.jl")
 include("dynamics/tendencies.jl")
+include("dynamics/hole_filling.jl")
 
 # PARAMETERIZATIONS
 include("physics/tendencies.jl")

--- a/src/abstract_types.jl
+++ b/src/abstract_types.jl
@@ -1,4 +1,5 @@
 # MODELS
+abstract type AbstractSimulation{Model} end
 abstract type ModelSetup end
 abstract type Barotropic <: ModelSetup end
 abstract type ShallowWater <: ModelSetup end

--- a/src/dynamics/hole_filling.jl
+++ b/src/dynamics/hole_filling.jl
@@ -1,0 +1,22 @@
+abstract type AbstractHoleFilling{NF} end
+
+struct ClipNegatives{NF} <: AbstractHoleFilling{NF} end
+ClipNegatives(SG::SpectralGrid) = ClipNegatives{SG.NF}()
+
+# nothing to initialize
+initialize!(H::ClipNegatives,::PrimitiveWet) = nothing
+
+# function barrier
+function hole_filling!(
+    A::AbstractGrid,
+    H::ClipNegatives,
+    model::PrimitiveWet)
+
+    hole_filling!(A,H)
+end
+
+function hole_filling!(A::AbstractGrid,H::ClipNegatives)
+    @inbounds for ij in eachgridpoint(A)
+        A[ij] = max(A[ij],0)
+    end
+end

--- a/src/dynamics/initial_conditions.jl
+++ b/src/dynamics/initial_conditions.jl
@@ -463,7 +463,6 @@ function initialize_humidity!(  progn::PrognosticVariables,
     spectral_truncation!(humid_surf)
 
     # Specific humidity at tropospheric levels (stratospheric humidity remains zero)
-    a = model.spectral_transform.norm_sphere
     for k in n_stratosphere_levels+1:nlev
         for lm in eachharmonic(humid_surf)
             progn.layers[k].timesteps[1].humid[lm] = humid_surf[lm]*σ_levels_full[k]^scale_height_ratio

--- a/src/dynamics/models.jl
+++ b/src/dynamics/models.jl
@@ -19,8 +19,8 @@ $(SIGNATURES)
 The BarotropicModel struct holds all other structs that contain precalculated constants,
 whether scalars or arrays that do not change throughout model integration.
 $(TYPEDFIELDS)"""
-Base.@kwdef struct BarotropicModel{NF<:AbstractFloat, D<:AbstractDevice} <: Barotropic
-    spectral_grid::SpectralGrid = SpectralGrid(nlev=1)
+Base.@kwdef mutable struct BarotropicModel{NF<:AbstractFloat, D<:AbstractDevice} <: Barotropic
+    spectral_grid::SpectralGrid
 
     # DYNAMICS
     planet::AbstractPlanet = Earth()
@@ -81,8 +81,8 @@ $(SIGNATURES)
 The ShallowWaterModel struct holds all other structs that contain precalculated constants,
 whether scalars or arrays that do not change throughout model integration.
 $(TYPEDFIELDS)"""
-Base.@kwdef struct ShallowWaterModel{NF<:AbstractFloat, D<:AbstractDevice} <: ShallowWater
-    spectral_grid::SpectralGrid = SpectralGrid(nlev=1)
+Base.@kwdef mutable struct ShallowWaterModel{NF<:AbstractFloat, D<:AbstractDevice} <: ShallowWater
+    spectral_grid::SpectralGrid
 
     # DYNAMICS
     planet::AbstractPlanet = Earth()
@@ -145,8 +145,8 @@ $(SIGNATURES)
 The PrimitiveDryModel struct holds all other structs that contain precalculated constants,
 whether scalars or arrays that do not change throughout model integration.
 $(TYPEDFIELDS)"""
-Base.@kwdef struct PrimitiveDryModel{NF<:AbstractFloat, D<:AbstractDevice} <: PrimitiveDry
-    spectral_grid::SpectralGrid = SpectralGrid()
+Base.@kwdef mutable struct PrimitiveDryModel{NF<:AbstractFloat, D<:AbstractDevice} <: PrimitiveDry
+    spectral_grid::SpectralGrid
 
     # DYNAMICS
     dynamics::Bool = true
@@ -233,8 +233,8 @@ $(SIGNATURES)
 The PrimitiveDryModel struct holds all other structs that contain precalculated constants,
 whether scalars or arrays that do not change throughout model integration.
 $(TYPEDFIELDS)"""
-Base.@kwdef struct PrimitiveWetModel{NF<:AbstractFloat, D<:AbstractDevice} <: PrimitiveWet
-    spectral_grid::SpectralGrid = SpectralGrid()
+Base.@kwdef mutable struct PrimitiveWetModel{NF<:AbstractFloat, D<:AbstractDevice} <: PrimitiveWet
+    spectral_grid::SpectralGrid
 
     # DYNAMICS
     dynamics::Bool = true
@@ -253,8 +253,8 @@ Base.@kwdef struct PrimitiveWetModel{NF<:AbstractFloat, D<:AbstractDevice} <: Pr
     # PHYSICS/PARAMETERIZATIONS
     physics::Bool = true
     thermodynamics::Thermodynamics{NF} = Thermodynamics(spectral_grid,atmosphere)
-    boundary_layer_drag::BoundaryLayerDrag{NF} = LinearDrag(spectral_grid)
-    temperature_relaxation::TemperatureRelaxation{NF} = HeldSuarez(spectral_grid)
+    boundary_layer_drag::BoundaryLayerDrag{NF} = NoBoundaryLayerDrag(spectral_grid)
+    temperature_relaxation::TemperatureRelaxation{NF} = NoTemperatureRelaxation(spectral_grid)
     static_energy_diffusion::VerticalDiffusion{NF} = StaticEnergyDiffusion(spectral_grid)
     humidity_diffusion::VerticalDiffusion{NF} = HumidityDiffusion(spectral_grid)
     large_scale_condensation::AbstractCondensation{NF} = SpeedyCondensation(spectral_grid)
@@ -270,7 +270,8 @@ Base.@kwdef struct PrimitiveWetModel{NF<:AbstractFloat, D<:AbstractDevice} <: Pr
     horizontal_diffusion::HorizontalDiffusion{NF} = HyperDiffusion(spectral_grid)
     implicit::AbstractImplicit{NF} = ImplicitPrimitiveEq(spectral_grid)
     vertical_advection::VerticalAdvection{NF} = CenteredVerticalAdvection(spectral_grid)
-    
+    hole_filling::AbstractHoleFilling{NF} = ClipNegatives(spectral_grid)
+
     # INTERNALS
     geometry::Geometry{NF} = Geometry(spectral_grid)
     constants::DynamicsConstants{NF} = DynamicsConstants(spectral_grid,planet,atmosphere,geometry)

--- a/src/dynamics/models.jl
+++ b/src/dynamics/models.jl
@@ -3,7 +3,7 @@ $(TYPEDSIGNATURES)
 Simulation is a container struct to be used with `run!(::Simulation)`.
 It contains
 $(TYPEDFIELDS)"""
-struct Simulation{Model<:ModelSetup}
+struct Simulation{Model<:ModelSetup} <: AbstractSimulation{Model}
     "define the current state of the model"
     prognostic_variables::PrognosticVariables
 
@@ -162,8 +162,8 @@ Base.@kwdef struct PrimitiveDryModel{NF<:AbstractFloat, D<:AbstractDevice} <: Pr
 
     # PHYSICS/PARAMETERIZATIONS
     physics::Bool = true
-    boundary_layer_drag::BoundaryLayerDrag{NF} = NoBoundaryLayerDrag(spectral_grid)
-    temperature_relaxation::TemperatureRelaxation{NF} = NoTemperatureRelaxation(spectral_grid)
+    boundary_layer_drag::BoundaryLayerDrag{NF} = LinearDrag(spectral_grid)
+    temperature_relaxation::TemperatureRelaxation{NF} = HeldSuarez(spectral_grid)
     static_energy_diffusion::VerticalDiffusion{NF} = StaticEnergyDiffusion(spectral_grid)
     surface_thermodynamics::AbstractSurfaceThermodynamics{NF} = SurfaceThermodynamicsConstant(spectral_grid)
     surface_wind::AbstractSurfaceWind{NF} = SurfaceWind(spectral_grid)
@@ -253,9 +253,10 @@ Base.@kwdef struct PrimitiveWetModel{NF<:AbstractFloat, D<:AbstractDevice} <: Pr
     # PHYSICS/PARAMETERIZATIONS
     physics::Bool = true
     thermodynamics::Thermodynamics{NF} = Thermodynamics(spectral_grid,atmosphere)
-    boundary_layer_drag::BoundaryLayerDrag{NF} = NoBoundaryLayerDrag(spectral_grid)
-    temperature_relaxation::TemperatureRelaxation{NF} = NoTemperatureRelaxation(spectral_grid)
+    boundary_layer_drag::BoundaryLayerDrag{NF} = LinearDrag(spectral_grid)
+    temperature_relaxation::TemperatureRelaxation{NF} = HeldSuarez(spectral_grid)
     static_energy_diffusion::VerticalDiffusion{NF} = StaticEnergyDiffusion(spectral_grid)
+    humidity_diffusion::VerticalDiffusion{NF} = HumidityDiffusion(spectral_grid)
     large_scale_condensation::AbstractCondensation{NF} = SpeedyCondensation(spectral_grid)
     surface_thermodynamics::AbstractSurfaceThermodynamics{NF} = SurfaceThermodynamicsConstant(spectral_grid)
     surface_wind::AbstractSurfaceWind{NF} = SurfaceWind(spectral_grid)
@@ -309,6 +310,7 @@ function initialize!(model::PrimitiveWet;time::DateTime = DEFAULT_DATE)
     initialize!(model.boundary_layer_drag,model)
     initialize!(model.temperature_relaxation,model)
     initialize!(model.static_energy_diffusion,model)
+    initialize!(model.humidity_diffusion,model)
     initialize!(model.large_scale_condensation,model)
     initialize!(model.convection,model)
 

--- a/src/dynamics/models.jl
+++ b/src/dynamics/models.jl
@@ -20,7 +20,7 @@ The BarotropicModel struct holds all other structs that contain precalculated co
 whether scalars or arrays that do not change throughout model integration.
 $(TYPEDFIELDS)"""
 Base.@kwdef mutable struct BarotropicModel{NF<:AbstractFloat, D<:AbstractDevice} <: Barotropic
-    spectral_grid::SpectralGrid
+    spectral_grid::SpectralGrid = SpectralGrid(nlev=1)
 
     # DYNAMICS
     planet::AbstractPlanet = Earth()
@@ -82,7 +82,7 @@ The ShallowWaterModel struct holds all other structs that contain precalculated 
 whether scalars or arrays that do not change throughout model integration.
 $(TYPEDFIELDS)"""
 Base.@kwdef mutable struct ShallowWaterModel{NF<:AbstractFloat, D<:AbstractDevice} <: ShallowWater
-    spectral_grid::SpectralGrid
+    spectral_grid::SpectralGrid = SpectralGrid(nlev=1)
 
     # DYNAMICS
     planet::AbstractPlanet = Earth()
@@ -146,7 +146,7 @@ The PrimitiveDryModel struct holds all other structs that contain precalculated 
 whether scalars or arrays that do not change throughout model integration.
 $(TYPEDFIELDS)"""
 Base.@kwdef mutable struct PrimitiveDryModel{NF<:AbstractFloat, D<:AbstractDevice} <: PrimitiveDry
-    spectral_grid::SpectralGrid
+    spectral_grid::SpectralGrid = SpectralGrid()
 
     # DYNAMICS
     dynamics::Bool = true
@@ -234,7 +234,7 @@ The PrimitiveDryModel struct holds all other structs that contain precalculated 
 whether scalars or arrays that do not change throughout model integration.
 $(TYPEDFIELDS)"""
 Base.@kwdef mutable struct PrimitiveWetModel{NF<:AbstractFloat, D<:AbstractDevice} <: PrimitiveWet
-    spectral_grid::SpectralGrid
+    spectral_grid::SpectralGrid = SpectralGrid()
 
     # DYNAMICS
     dynamics::Bool = true

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -339,10 +339,10 @@ function timestep!( progn::PrognosticVariables{NF}, # all prognostic variables
             progn_layer = progn.layers[k]
             progn_layer_lf = progn_layer.timesteps[lf2]
 
-            horizontal_diffusion!(progn_layer,diagn_layer,model)    # implicit diffusion of vor, div, temp
-            leapfrog!(progn_layer,diagn_layer,dt,lf1,model)         # time step forward for vor, div, temp
+            horizontal_diffusion!(progn_layer,diagn_layer,model)    # for vor, div, temp, humid
+            leapfrog!(progn_layer,diagn_layer,dt,lf1,model)         # time step forward for vor, div, temp, humid
             gridded!(diagn_layer,progn_layer_lf,model)              # propagate spectral state to grid
-        else                                                        # surface level
+        else                                                        # surface level, time step for pressure
             leapfrog!(progn.surface,diagn.surface,dt,lf1,model)
             (;pres_grid) = diagn.surface
             pres_lf = progn.surface.timesteps[lf2].pres

--- a/src/output/feedback.jl
+++ b/src/output/feedback.jl
@@ -161,7 +161,7 @@ function nar_detection!(feedback::Feedback,progn::PrognosticVariables)
     if ~nars_detected_here
         nars_vor = ~isfinite(vor[1])    # just check first mode
                                         # spectral transform propagates NaRs globally anyway
-        nars_vor && @warn "NaR detected at time step $i"
+        nars_vor && @warn "NaN or Inf detected at time step $i"
         nars_detected_here |= nars_vor
     end
 

--- a/src/physics/column_variables.jl
+++ b/src/physics/column_variables.jl
@@ -53,6 +53,25 @@ function get_column!(   C::ColumnVariables,
     get_column!(C,D,P,ij,jring,G,L)
 end
 
+function get_column(    S::AbstractSimulation,
+                        ij::Integer)
+    (;prognostic_variables, diagnostic_variables) = S
+    (;geometry, land_sea_mask) = S.model
+
+    column = deepcopy(S.diagnostic_variables.columns[1])
+    reset_column!(column)
+
+    get_column!(column,
+                diagnostic_variables,
+                prognostic_variables,
+                ij,
+                geometry,
+                land_sea_mask)
+
+    @info "Receiving column at $(column.latd)˚N, $(column.lond)˚E."
+    return column
+end
+
 """
 $(TYPEDSIGNATURES)
 Write the parametrization tendencies from `C::ColumnVariables` into the horizontal fields

--- a/src/physics/column_variables.jl
+++ b/src/physics/column_variables.jl
@@ -31,7 +31,7 @@ function get_column!(   C::ColumnVariables,
         C.u[k] = layer.grid_variables.u_grid[ij]
         C.v[k] = layer.grid_variables.v_grid[ij]
         C.temp[k] = layer.grid_variables.temp_grid[ij]
-        C.humid[k] = layer.grid_variables.humid_grid[ij]
+        C.humid[k] = layer.grid_variables.humid_grid[ij] 
     end
 
     # TODO skin = surface approximation for now
@@ -67,6 +67,9 @@ function get_column(    S::AbstractSimulation,
                 ij,
                 geometry,
                 land_sea_mask)
+
+    # execute all parameterizations for this column to return a consistent state
+    parameterization_tendencies!(column,S.model)
 
     @info "Receiving column at $(column.latd)˚N, $(column.lond)˚E."
     return column

--- a/src/physics/define_column.jl
+++ b/src/physics/define_column.jl
@@ -18,11 +18,11 @@ Base.@kwdef mutable struct ColumnVariables{NF<:AbstractFloat} <: AbstractColumnV
     latd::NF = 0                            # latitude, needed for shortwave radiation
     land_fraction::NF = 0                   # fraction of the column that is over land
 
-    # PROGNOSTIC VARIABLES, last element is surface
-    const u::Vector{NF} = zeros(NF,nlev+1)          # zonal velocity [m/s]
-    const v::Vector{NF} = zeros(NF,nlev+1)          # meridional velocity [m/s]
-    const temp::Vector{NF} = zeros(NF,nlev+1)       # temperature [K]
-    const humid::Vector{NF} = zeros(NF,nlev+1)      # specific humidity [kg/kg]
+    # PROGNOSTIC VARIABLES
+    const u::Vector{NF} = zeros(NF,nlev)        # zonal velocity [m/s]
+    const v::Vector{NF} = zeros(NF,nlev)        # meridional velocity [m/s]
+    const temp::Vector{NF} = zeros(NF,nlev)     # temperature [K]
+    const humid::Vector{NF} = zeros(NF,nlev)    # specific humidity [kg/kg]
 
     # (log) pressure per layer, surface is prognostic, last element here, but precompute other layers too
     const ln_pres::Vector{NF} = zeros(NF,nlev+1)    # logarithm of pressure [log(Pa)]
@@ -50,6 +50,10 @@ Base.@kwdef mutable struct ColumnVariables{NF<:AbstractFloat} <: AbstractColumnV
     const flux_humid_upward::Vector{NF} = zeros(NF,nlev+1)
     const flux_humid_downward::Vector{NF} = zeros(NF,nlev+1)
 
+    surface_u::NF = 0
+    surface_v::NF = 0
+    surface_temp::NF = 0
+    surface_humid::NF = 0
     surface_wind_speed::NF = 0
     skin_temperature_sea::NF = 0
     skin_temperature_land::NF = 0
@@ -123,4 +127,16 @@ Base.@kwdef mutable struct ColumnVariables{NF<:AbstractFloat} <: AbstractColumnV
     # Shortwave radiation: shortwave_radiation
     rel_hum::Vector{NF} = fill(NF(NaN), nlev) # Relative humidity
     grad_dry_static_energy::NF = NF(NaN)      # gradient of dry static energy
+end
+
+function plot(column::ColumnVariables,var::Symbol=:temp)
+    v = getfield(column,var)
+    z = 1:length(v)
+
+    x,y = column.lond, column.latd
+    title = "Column at $(y)˚N, $(x)˚E"
+    ylabel = "k"
+    yflip = true
+
+    UnicodePlots.lineplot(v,z;title,xlabel=string(var),ylabel,yflip)
 end

--- a/src/physics/define_column.jl
+++ b/src/physics/define_column.jl
@@ -62,6 +62,7 @@ Base.@kwdef mutable struct ColumnVariables{NF<:AbstractFloat} <: AbstractColumnV
     # THERMODYNAMICS
     surface_air_density::NF = 0
     const sat_humid::Vector{NF} = zeros(NF,nlev)                # Saturation specific humidity [kg/kg]
+    const rel_humid::Vector{NF} = zeros(NF,nlev)                # Relative humidity [1]
     const sat_vap_pres::Vector{NF} = zeros(NF,nlev)             # Saturation vapour pressure [Pa]
     const dry_static_energy::Vector{NF} = zeros(NF,nlev)        # Dry static energy
     const moist_static_energy::Vector{NF} = zeros(NF,nlev)      # Moist static energy
@@ -125,7 +126,7 @@ Base.@kwdef mutable struct ColumnVariables{NF<:AbstractFloat} <: AbstractColumnV
     qcloud::NF = NF(NaN)       # Equivalent specific humidity of clouds
     fmask::NF = NF(NaN)        # Fraction of land
     # Shortwave radiation: shortwave_radiation
-    rel_hum::Vector{NF} = fill(NF(NaN), nlev) # Relative humidity
+    # rel_hum::Vector{NF} = fill(NF(NaN), nlev) # Relative humidity
     grad_dry_static_energy::NF = NF(NaN)      # gradient of dry static energy
 end
 

--- a/src/physics/surface_fluxes.jl
+++ b/src/physics/surface_fluxes.jl
@@ -40,7 +40,7 @@ function surface_thermodynamics!(   column::ColumnVariables,
                                     model::PrimitiveDry)
 
     # surface value is same as lowest model level
-    column.surface_temp = column.temp   # todo use constant POTENTIAL temperature
+    column.surface_temp = column.temp[end]   # todo use constant POTENTIAL temperature
     column.surface_air_density = column.pres[end]/C.R_dry/column.surface_temp
 end
 

--- a/src/physics/surface_fluxes.jl
+++ b/src/physics/surface_fluxes.jl
@@ -7,8 +7,8 @@ function surface_fluxes!(column::ColumnVariables,model::PrimitiveEquation)
     surface_wind_stress!(column,model.surface_wind)
 
     # now call other heat and humidity fluxes
-    # sensible_heat_flux!(column,model.surface_heat_flux,model.constants)
-    # evaporation!(column,model)
+    sensible_heat_flux!(column,model.surface_heat_flux,model.constants)
+    evaporation!(column,model)
 end
 
 struct SurfaceThermodynamicsConstant{NF<:AbstractFloat} <: AbstractSurfaceThermodynamics{NF} end
@@ -91,8 +91,8 @@ function surface_wind_stress!(  column::ColumnVariables{NF},
     # column.flux_v_upward[end] -= v_flux
     
     # SPEEDY documentation eq. 52, 53, accumulate fluxes with +=
-    # column.flux_u_upward[end] -= ρ*drag*V₀*surface_u
-    # column.flux_v_upward[end] -= ρ*drag*V₀*surface_v
+    column.flux_u_upward[end] -= ρ*drag*V₀*surface_u
+    column.flux_v_upward[end] -= ρ*drag*V₀*surface_v
     
     return nothing
 end

--- a/src/physics/tendencies.jl
+++ b/src/physics/tendencies.jl
@@ -32,6 +32,7 @@ function parameterization_tendencies!(
 
         # VERTICAL DIFFUSION
         static_energy_diffusion!(column,model)
+        humidity_diffusion!(column,model)
 
         # HELD-SUAREZ
         temperature_relaxation!(column,model)
@@ -62,17 +63,17 @@ function fluxes_to_tendencies!(
     constants::DynamicsConstants,
 )
     
-    (;nlev,u_tend,flux_u_upward,flux_u_downward) = column
-    (;v_tend,flux_v_upward,flux_v_downward) = column
-    (;humid_tend,flux_humid_upward,flux_humid_downward) = column
-    (;temp_tend,flux_temp_upward,flux_temp_downward) = column
+    (;nlev, u_tend, flux_u_upward, flux_u_downward) = column
+    (;      v_tend, flux_v_upward, flux_v_downward) = column
+    (;humid_tend, flux_humid_upward, flux_humid_downward) = column
+    (;temp_tend,  flux_temp_upward,  flux_temp_downward) = column
 
     Δσ = geometry.σ_levels_thick
     pₛ = column.pres[end]               # surface pressure
     (;radius) = constants               # used for scaling
-    
+
     # TODO ONLY FOR TESTING TO MAKE PARAMETERIZATIONS WEAKER
-    radius /= 1.5
+    radius /= 2
 
     # for g/Δp and g/(Δp*cₚ), see Fortran SPEEDY documentation eq. (3,5)
     g_pₛ = constants.gravity/pₛ

--- a/src/physics/thermodynamics.jl
+++ b/src/physics/thermodynamics.jl
@@ -124,6 +124,7 @@ function saturation_humidity!(
         sat_vap_pres[k] = saturation_vapour_pressure(temp[k],thermodynamics.tetens_coefs)
         sat_humid[k] = saturation_humidity(sat_vap_pres[k],pres[k];mol_ratio)
         rel_humid[k] = humid[k]/sat_humid[k]
+        # rel_humid[k] > 2 && @info "$(column.ij), $k"
     end
 end
 
@@ -133,6 +134,13 @@ saturation_vapour_pressure(temp_kelvin::Integer) = saturation_vapour_pressure(Fl
 # version that pulls default Tetens coefficients
 function saturation_vapour_pressure(temp_kelvin::NF) where NF
     return saturation_vapour_pressure(temp_kelvin,TetensCoefs{NF}())
+end
+
+function relative_humidity(temp_kelvin,humid,pres)
+    sat_vap_pres = saturation_vapour_pressure(temp_kelvin)
+    sat_vap_pres, pres = promote(sat_vap_pres, pres)
+    sat_humid = saturation_humidity(sat_vap_pres,pres)
+    return humid/sat_humid  # = relative humidity [1]
 end
 
 """

--- a/src/physics/thermodynamics.jl
+++ b/src/physics/thermodynamics.jl
@@ -1,25 +1,33 @@
 """
-Parameters for computing saturation vapour pressure using the August-Roche-Magnus formula,
+Parameters for computing saturation vapour pressure of water using the Tetens' equation,
 
-    eᵢ(T) = e₀ * exp(Cᵢ * (T - T₀) / (T - Tᵢ)),
+    eᵢ(T) = e₀ * exp(Cᵢ * (T - T₀) / (T + Tᵢ)),
 
-where T is in Kelvin and i = 1,2 for saturation with respect to water and ice,
-respectively.
+where T is in Kelvin and i = 1,2 for saturation above and below freezing,
+respectively. From Tetens (1930), and Murray (1967) for below freezing.
 $(TYPEDFIELDS)"""
-Base.@kwdef struct MagnusCoefs{NF<:AbstractFloat}
-    "Saturation vapour pressure at 0°C [Pa]"
-    e₀::NF = 610.8
+Base.@kwdef struct TetensCoefs{NF<:AbstractFloat}
+    "Saturation water vapour pressure at 0°C [Pa]"
+    e₀::NF = 610.78
 
     "0°C in Kelvin"
-    T₀::NF = 273.16
-    T₁::NF = 35.86
-    T₂::NF = 7.66
-    C₁::NF = 17.269
+    T₀::NF = 273.15
+
+    "Tetens denominator (water) [˚C]"
+    T₁::NF = 237.3
+
+    "Tetens denominator following Murray (1967, ice) [˚C]"
+    T₂::NF = 265.5
+
+    "Tetens numerator scaling [1], above freezing"
+    C₁::NF = 17.27
+
+    "Tetens numerator scaling [1], below freezing"
     C₂::NF = 21.875
 end
 
 Base.@kwdef struct Thermodynamics{NF} <: AbstractThermodynamics{NF}
-    magnus_coefs::MagnusCoefs{NF} = MagnusCoefs{NF}()
+    tetens_coefs::TetensCoefs{NF} = TetensCoefs{NF}()
     mol_ratio::NF 
     latent_heat_condensation::NF
     latent_heat_sublimation::NF
@@ -93,12 +101,12 @@ function dry_static_energy!(column::ColumnVariables,constants::DynamicsConstants
 end
 
 """$(TYPEDSIGNATURES)
-Compute (1) the saturation vapour pressure as a function of temperature using the
-August-Roche-Magnus formula,
+Compute (1) the saturation water vapour pressure as a function of temperature using the
+Tetens equation,
 
     eᵢ(T) = e₀ * exp(Cᵢ * (T - T₀) / (T - Tᵢ)),
 
-where T is in Kelvin and i = 1,2 for saturation with respect to water and ice,
+where T is in Kelvin and i = 1,2 for saturation above and below freezing,
 respectively. And (2) the saturation specific humidity according to the formula,
 
     0.622 * e / (p - (1 - 0.622) * e),
@@ -109,20 +117,38 @@ function saturation_humidity!(
     column::ColumnVariables,
     thermodynamics::Thermodynamics,
 )
-    (;sat_humid, sat_vap_pres, pres, temp) = column
+    (;sat_humid, rel_humid, sat_vap_pres, pres, temp, humid) = column
     (;mol_ratio) = thermodynamics      # = mol_mass_vapour/mol_mass_dry_air = 0.622
 
     for k in eachlayer(column)
-        sat_vap_pres[k] = saturation_vapour_pressure(temp[k],thermodynamics.magnus_coefs)
+        sat_vap_pres[k] = saturation_vapour_pressure(temp[k],thermodynamics.tetens_coefs)
         sat_humid[k] = saturation_humidity(sat_vap_pres[k],pres[k];mol_ratio)
+        rel_humid[k] = humid[k]/sat_humid[k]
     end
 end
 
-function saturation_vapour_pressure(temp::NF,magnus_coefs::MagnusCoefs{NF}) where NF
-    # change coefficients for water (temp > T₀) or ice (else)
-    (;e₀, T₀, C₁, C₂, T₁, T₂) = magnus_coefs
-    C, T = temp > T₀ ? (C₁, T₁) : (C₂, T₂)
-    return e₀ * exp(C * (temp - T₀) / (temp - T))
+# integer version to convert to Float64
+saturation_vapour_pressure(temp_kelvin::Integer) = saturation_vapour_pressure(Float64(temp_kelvin))
+
+# version that pulls default Tetens coefficients
+function saturation_vapour_pressure(temp_kelvin::NF) where NF
+    return saturation_vapour_pressure(temp_kelvin,TetensCoefs{NF}())
+end
+
+"""
+$(TYPEDSIGNATURES)
+Saturation water vapour pressure as a function of temperature using the
+Tetens equation,
+
+    eᵢ(T) = e₀ * exp(Cᵢ * (T - T₀) / (T - Tᵢ)),
+
+where T is in Kelvin and i = 1,2 for saturation above and below freezing,
+respectively."""
+function saturation_vapour_pressure(temp_kelvin::NF,tetens_coefs::TetensCoefs{NF}) where NF
+    (;e₀, T₀, C₁, C₂, T₁, T₂) = tetens_coefs
+    C, T = temp_kelvin > T₀ ? (C₁, T₁) : (C₂, T₂)      # change coefficients above/below freezing
+    temp_celsius = temp_kelvin - T₀
+    return e₀ * exp(C * temp_celsius / (temp_celsius + T))
 end
 
 function saturation_humidity(sat_vap_pres::NF,pres::NF;mol_ratio::NF = NF(0.622)) where NF
@@ -131,7 +157,7 @@ end
 
 function saturation_humidity(temp::NF,pres::NF,thermodynamics::Thermodynamics{NF}) where NF
     (;mol_ratio) = thermodynamics
-    sat_vap_pres = saturation_vapour_pressure(temp,thermodynamics.magnus_coefs)
+    sat_vap_pres = saturation_vapour_pressure(temp,thermodynamics.tetens_coefs)
     return saturation_humidity(sat_vap_pres,pres;mol_ratio)
 end
 

--- a/src/physics/vertical_diffusion.jl
+++ b/src/physics/vertical_diffusion.jl
@@ -23,10 +23,10 @@ gradient of static energy wrt to geopotential, see Fortran SPEEDY documentation.
 $(TYPEDFIELDS)"""
 Base.@kwdef struct StaticEnergyDiffusion{NF<:AbstractFloat} <: VerticalDiffusion{NF}
     "time scale for strength"
-    time_scale::Second = Hour(24)
+    time_scale::Second = Hour(6)
 
     "[1] ∂SE/∂Φ, vertical gradient of static energy SE with geopotential Φ"
-    static_energy_lapse_rate::NF = 0.1
+    static_energy_lapse_rate::NF = 0.1          
     
     # precomputations
     Fstar::Base.RefValue{NF} = Ref(zero(NF))    # excluding the surface pressure pₛ
@@ -56,14 +56,21 @@ function static_energy_diffusion!(  column::ColumnVariables,
     pₛ = column.pres[end]               # surface pressure
     Fstar = scheme.Fstar[]*pₛ
     Γˢᵉ = scheme.static_energy_lapse_rate 
-    
+
     # relax static energy profile back to a reference gradient Γˢᵉ
     @inbounds for k in 1:nlev-1
         # Fortran SPEEDY doc eq (74)
         SEstar = dry_static_energy[k+1] + Γˢᵉ*(geopot[k] - geopot[k+1])
         SE = dry_static_energy[k]
         if SE < SEstar
-            flux_temp_upward[k+1] += Fstar*(SEstar - SE)
+            # SPEEDY code applies the flux to all layers below
+            # effectively fluxing temperature from below the surface to
+            # given height. It doesn't really make sense to me in
+            # a meteorology sense to me since it can flux through stable layers,
+            # but it's more stable and that's good enough for now.
+            for kk = k+1:nlev
+                flux_temp_upward[kk] += Fstar*(SEstar - SE)
+            end
         end
     end
 end
@@ -79,9 +86,6 @@ Base.@kwdef struct HumidityDiffusion{NF<:AbstractFloat} <: VerticalDiffusion{NF}
     "[1] ∂RH/∂σ, vertical gradient of relative humidity RH wrt sigma coordinate σ"
     humidity_gradient::NF = 0.5
 
-    "[1] disable above this σ level"
-    σ_min::NF = 0.5
-    
     # precomputations
     Fstar::Base.RefValue{NF} = Ref(zero(NF))    # excluding the surface pressure pₛ
 end
@@ -99,6 +103,9 @@ function initialize!(   scheme::HumidityDiffusion,
     
     # Fortran SPEEDY documentation equation (70), excluding the surface pressure pₛ
     scheme.Fstar[] = C₀/gravity/scheme.time_scale.value
+
+    # SPEEDY code version
+    # scheme.Fstar[] = C₀/scheme.time_scale.value
 end
 
 # function barrier
@@ -124,114 +131,33 @@ function humidity_diffusion!(   column::ColumnVariables,
                                 scheme::HumidityDiffusion,
                                 geometry::Geometry)
     
-    (;nlev, humid, sat_humid, flux_humid_upward) = column
+    (;nlev, sat_humid, rel_humid, flux_humid_upward) = column
     pₛ = column.pres[end]               # surface pressure
-    Fstar = scheme.Fstar[]*pₛ
+    Fstar = scheme.Fstar[]*pₛ           
+    # Fstar = scheme.Fstar[]              # SPEEDY code version
     Γ = scheme.humidity_gradient        # relative humidity wrt σ
     σ = geometry.σ_levels_full
-
-    # skip stratosphere
-    ktop = findfirst(σₖ -> σₖ >= scheme.σ_min,σ)
-    ktop = isnothing(ktop) ? 1 : ktop
+    σ_half = geometry.σ_levels_half
 
     # relax humidity profile back to a reference gradient Γ
-    relative_humidity_below = humid[1]/sat_humid[1]
-    @inbounds for k in ktop:nlev-2
+    # SPEEDY skips the uppermost levels, but maybe less relevant due to the
+    # σ_half[k] scaling of the flux
+    for k in 1:nlev-1  
 
         Γσ = Γ*(σ[k+1] - σ[k])
-        relative_humidity_above = relative_humidity_below
-        relative_humidity_below = humid[k+1]/sat_humid[k+1]
-        ΔRH = (relative_humidity_below - relative_humidity_above)
+        Δrel_humid = rel_humid[k+1] - rel_humid[k]
 
         # Fortran SPEEDY doc eq (71)
-        if ΔRH > Γσ
+        if Δrel_humid > Γσ
             # Fortran SPEEDY doc eq (72)
-            flux_humid_upward[k+1] += Fstar*sat_humid[k]*ΔRH
+            # the σh[k] is not in the documentation, but it makes the diffusion
+            # weaker higher up, so it's maybe not bad after all
+            flux_humid_upward[k+1] += Fstar*σ_half[k]*sat_humid[k]*Δrel_humid
+        
+            # SPEEDY code version
+            # flux = Fstar*σ_half[k]*sat_humid[k]*Δrel_humid
+            # humid_tend[k] += flux*rsig[k]
+            # humid_tend[k+1] -= flux*rsig[k+1]
         end
     end
 end
-
-
-# Base.@kwdef struct VerticalLaplacian{NF<:Real} <: VerticalDiffusion{NF}
-#     time_scale::NF = 10.0       # [hours] time scale to control the strength of vertical diffusion
-#     height_scale::NF = 100.0    # [m] scales for Δσ so that time_scale is sensible
-
-#     resolution_scaling::NF = 1.0    # (inverse) scaling with resolution T
-#     nlev_scaling::NF = -2.0         # (inverse) scaling with n vertical levels
-# end
-
-# # generator so that arguments are converted to Float64
-# VerticalLaplacian(;kwargs...) = VerticalLaplacian{Float64}(;kwargs...)
-
-# function vertical_diffusion!(   column::ColumnVariables{NF},
-#                                 scheme::VerticalLaplacian,
-#                                 model::PrimitiveEquation) where NF
-
-#     (;nlev,u_tend,v_tend,temp_tend) = column
-#     (;u,v,temp) = column
-#     (;time_scale, height_scale, resolution_scaling, nlev_scaling) = scheme
-#     (;trunc) = model.parameters
-#     ∇²_below = model.parameterization_constants.vert_diff_∇²_below
-#     ∇²_above = model.parameterization_constants.vert_diff_∇²_above
-
-#     # GET DIFFUSION COEFFICIENT as a function of u,v,temp and surface pressure
-#     # *3600 for [hrs] → [s], *1e3 for [km] → [m]
-#     # include a height scale, technically not needed, but so that the dimensionless
-#     # 1/Δσ² gets a resonable scale in meters such that the time scale is not
-#     # counterintuitively in seconds or years
-#     ν0 = model.geometry.radius*inv(time_scale*3600) / height_scale^2
-#     ν0 /= (32/(trunc+1))^resolution_scaling*(8/nlev)^nlev_scaling
-#     ν0 = convert(NF,ν0)
-
-#     # DO DIFFUSION
-#     @inbounds begin
-        
-#         # top layer with no flux boundary conditions at k=1/2
-#         ν∇²_below = ν0*∇²_below[1]                      # diffusion operator
-#         u_tend[1] += ν∇²_below*(u[2] - u[1])            # diffusion of u
-#         v_tend[1] += ν∇²_below*(v[2] - v[1])            # diffusion of v
-#         temp_tend[1] += ν∇²_below*(temp[2] - temp[1])   # diffusion of temperature
-
-#         # full Laplacian in other layers
-#         for k in 2:nlev-1
-#             # diffusion coefficient ν times 1/Δσ²-like operator
-#             ν∇²_above = ν0*∇²_above[k-1]
-#             ν∇²_below = ν0*∇²_below[k]
-#             ν∇²_at_k = ν∇²_above + ν∇²_below
-
-#             # discrete Laplacian, like the (1, -2, 1)-stencil but for variable Δσ
-#             u_tend[k] += ν∇²_below*u[k+1] - ν∇²_at_k*u[k] + ν∇²_above*u[k-1]
-#             v_tend[k] += ν∇²_below*v[k+1] - ν∇²_at_k*v[k] + ν∇²_above*v[k-1]
-#             temp_tend[k] += ν∇²_below*temp[k+1] - ν∇²_at_k*temp[k] + ν∇²_above*temp[k-1]
-#         end
-
-#         # bottom layer with no flux boundary conditions at k=nlev+1/2
-#         ν∇²_above = ν0*∇²_above[end]
-#         u_tend[end] += ν∇²_above*(u[end-1] - u[end])
-#         v_tend[end] += ν∇²_above*(v[end-1] - v[end])
-#         temp_tend[end] += ν∇²_above*(temp[end-1] - temp[end])
-#     end
-
-#     return nothing
-# end
-
-# function initialize_vertical_diffusion!(K::ParameterizationConstants,
-#                                         scheme::VerticalLaplacian,
-#                                         P::Parameters,
-#                                         G::Geometry)
-
-#     (;vert_diff_∇²_above, vert_diff_∇²_below, vert_diff_Δσ) = K
-#     Δσ = G.σ_levels_thick
-    
-#     # thickness Δσ of half levels
-#     @. vert_diff_Δσ = 1/2*(Δσ[2:end] + Δσ[1:end-1])
-
-#     # 1/Δσ² but for variable Δσ on half levels
-#     # = 1/(1/2*Δσₖ(Δσ_k-1 + Δσₖ))
-#     @. vert_diff_∇²_above = inv(Δσ[2:end]*vert_diff_Δσ)
-    
-#     # = 1/(1/2*Δσₖ(Δσ_k+1 + Δσₖ))
-#     @. vert_diff_∇²_below = inv(Δσ[1:end-1]*vert_diff_Δσ)
-
-#     return nothing
-# end 

--- a/src/physics/vertical_diffusion.jl
+++ b/src/physics/vertical_diffusion.jl
@@ -150,7 +150,7 @@ function humidity_diffusion!(   column::ColumnVariables,
         # Fortran SPEEDY doc eq (71)
         if Δrel_humid > Γσ
             # Fortran SPEEDY doc eq (72)
-            # the σh[k] is not in the documentation, but it makes the diffusion
+            # the σ_half[k] is not in the documentation, but it makes the diffusion
             # weaker higher up, so it's maybe not bad after all
             flux_humid_upward[k+1] += Fstar*σ_half[k]*sat_humid[k]*Δrel_humid
         

--- a/test/netcdf_output.jl
+++ b/test/netcdf_output.jl
@@ -61,7 +61,8 @@ using NCDatasets, Dates
     @test simulation.model.feedback.nars_detected == false
 
     # OctaHEALPixGrid, as matrix, Float32, PrimitiveDry
-    spectral_grid = SpectralGrid(;NF=Float32,Grid=OctaHEALPixGrid)
+    # using T42 as T31 has stability issues in the first day
+    spectral_grid = SpectralGrid(;NF=Float32,trunc=42,Grid=OctaHEALPixGrid)
     output = OutputWriter(spectral_grid,PrimitiveDry,path=tmp_output_path,as_matrix=true)
     model = PrimitiveDryModel(;spectral_grid,output)
     simulation = initialize!(model)
@@ -69,7 +70,8 @@ using NCDatasets, Dates
     @test simulation.model.feedback.nars_detected == false
 
     # OctaHEALPixGrid, as matrix, Float32, but output Float64 PrimitiveDry
-    spectral_grid = SpectralGrid(;NF=Float32,Grid=OctaHEALPixGrid)
+    # using T42 as T31 has stability issues in the first day
+    spectral_grid = SpectralGrid(;NF=Float32,trunc=42,Grid=OctaHEALPixGrid)
     output = OutputWriter(spectral_grid,PrimitiveDry,path=tmp_output_path,as_matrix=true,NF=Float64)
     model = PrimitiveDryModel(;spectral_grid,output)
     simulation = initialize!(model)

--- a/test/spectral_gradients.jl
+++ b/test/spectral_gradients.jl
@@ -189,8 +189,8 @@ end
 
         # create initial conditions
         (;lmax,mmax) = m.spectral_transform
-        vor0 = randn(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
-        div0 = randn(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
+        vor0 = rand(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
+        div0 = rand(LowerTriangularMatrix{Complex{NF}},lmax+1,mmax+1)
         
         vor0[1,1] = 0                   # zero mean
         div0[1,1] = 0
@@ -234,8 +234,8 @@ end
         SpeedyWeather.divergence!(div1,u_coslat⁻¹,v_coslat⁻¹,S)
 
         for lm in SpeedyWeather.eachharmonic(vor0,vor1,div0,div1)
-            @test vor0[lm] ≈ vor1[lm] rtol=20*sqrt(eps(NF))
-            @test div0[lm] ≈ div1[lm] rtol=20*sqrt(eps(NF))
+            @test vor0[lm] ≈ vor1[lm] rtol=10*sqrt(eps(NF))
+            @test div0[lm] ≈ div1[lm] rtol=10*sqrt(eps(NF))
         end
     end
 end


### PR DESCRIPTION
Summary:

- hole filling: We now fill the "holes" (humidity < 0) for humidity in grid-point space by simply clipping those values via `max(x,0)`. The spectral space is unaffected, which therefore shouldn't cause conservation issues, basically only the grid-point tendencies are calculated from a slightly different field.
- models are now mutable
- vertical diffusion of humidity is added as in SPEEDY and its documentation (almost)
- static energy diffusion fluxes from the surface and not the layer below, which is how it's done in SPEEDY code too, although not in the documentation and meteorologically doesn't make as much sense to me, but it's good enough for now and much more stable than fluxing from the layer below.
- large scale condensation has now a flux limiter on condensation heating (caused instabilities)

@white-alistair 