### PR TITLE
Flux limiters for surface drag and heat fluxes

### DIFF
--- a/src/dynamics/models.jl
+++ b/src/dynamics/models.jl
@@ -164,7 +164,7 @@ Base.@kwdef mutable struct PrimitiveDryModel{NF<:AbstractFloat, D<:AbstractDevic
     # PHYSICS/PARAMETERIZATIONS
     physics::Bool = true
     boundary_layer_drag::BoundaryLayerDrag{NF} = NoBoundaryLayerDrag(spectral_grid)
-    temperature_relaxation::TemperatureRelaxation{NF} = HeldSuarez(spectral_grid)
+    temperature_relaxation::TemperatureRelaxation{NF} = NoTemperatureRelaxation(spectral_grid)
     static_energy_diffusion::VerticalDiffusion{NF} = StaticEnergyDiffusion(spectral_grid)
     surface_thermodynamics::AbstractSurfaceThermodynamics{NF} = SurfaceThermodynamicsConstant(spectral_grid)
     surface_wind::AbstractSurfaceWind{NF} = SurfaceWind(spectral_grid)
@@ -257,7 +257,7 @@ Base.@kwdef mutable struct PrimitiveWetModel{NF<:AbstractFloat, D<:AbstractDevic
     physics::Bool = true
     thermodynamics::Thermodynamics{NF} = Thermodynamics(spectral_grid,atmosphere)
     boundary_layer_drag::BoundaryLayerDrag{NF} = NoBoundaryLayerDrag(spectral_grid)
-    temperature_relaxation::TemperatureRelaxation{NF} = HeldSuarez(spectral_grid)
+    temperature_relaxation::TemperatureRelaxation{NF} = NoTemperatureRelaxation(spectral_grid)
     static_energy_diffusion::VerticalDiffusion{NF} = StaticEnergyDiffusion(spectral_grid)
     humidity_diffusion::VerticalDiffusion{NF} = HumidityDiffusion(spectral_grid)
     large_scale_condensation::AbstractCondensation{NF} = SpeedyCondensation(spectral_grid)

--- a/src/dynamics/vertical_coordinates.jl
+++ b/src/dynamics/vertical_coordinates.jl
@@ -32,7 +32,14 @@ Vertical sigma coordinates defined by their nlev+1 half levels `σ_levels_half`.
 fraction of surface pressure (p/p0) and are sorted from top (stratosphere) to bottom (surface).
 The first half level is at 0 the last at 1. Default levels are equally spaced from 0 to 1 (including)."""
 function default_sigma_coordinates(nlev::Integer)
-    σ_half = collect(range(0,1,nlev+1))     # equi-distant in σ
+
+    # equi-distant in σ
+    # σ_half = collect(range(0,1,nlev+1))
+
+    # Frierson 2006 spacing, higher resolution in surface boundary layer and in stratosphere
+    z = collect(range(1,0,nlev+1))
+    σ_half = @. exp(-5*(0.05*z + 0.95*z^3))
+    σ_half[1] = 0
     return σ_half
 end
 

--- a/src/dynamics/vertical_coordinates.jl
+++ b/src/dynamics/vertical_coordinates.jl
@@ -34,12 +34,12 @@ The first half level is at 0 the last at 1. Default levels are equally spaced fr
 function default_sigma_coordinates(nlev::Integer)
 
     # equi-distant in σ
-    # σ_half = collect(range(0,1,nlev+1))
+    σ_half = collect(range(0,1,nlev+1))
 
     # Frierson 2006 spacing, higher resolution in surface boundary layer and in stratosphere
-    z = collect(range(1,0,nlev+1))
-    σ_half = @. exp(-5*(0.05*z + 0.95*z^3))
-    σ_half[1] = 0
+    # z = collect(range(1,0,nlev+1))
+    # σ_half = @. exp(-5*(0.05*z + 0.95*z^3))
+    # σ_half[1] = 0
     return σ_half
 end
 

--- a/src/physics/surface_fluxes.jl
+++ b/src/physics/surface_fluxes.jl
@@ -54,12 +54,12 @@ Base.@kwdef struct SurfaceWind{NF<:AbstractFloat} <: AbstractSurfaceWind{NF}
     # TODO make this orography dependent
     "Drag coefficient over land (orography = 0) [1]"
     drag_land::NF = 2.4e-3
-
+    
     "Drag coefficient over sea [1]"
     drag_sea::NF = 1.8e-3
 
-    # "Flux limiter [kg/m/s²]"
-    # max_flux::NF = 1.5
+    "Flux limiter [kg/m/s²]"
+    max_flux::NF = 0.1
 end
 
 SurfaceWind(SG::SpectralGrid;kwargs...) = SurfaceWind{SG.NF}(;kwargs...)
@@ -69,7 +69,7 @@ function surface_wind_stress!(  column::ColumnVariables{NF},
 
     (;land_fraction) = column
     (;f_wind, V_gust, drag_land, drag_sea) = surface_wind
-    # (;max_flux) = surface_wind
+    (;max_flux) = surface_wind
 
     # SPEEDY documentation eq. 49
     column.surface_u = f_wind*column.u[end] 
@@ -84,22 +84,23 @@ function surface_wind_stress!(  column::ColumnVariables{NF},
     V₀ = column.surface_wind_speed
     drag = land_fraction*drag_land + (1-land_fraction)*drag_sea
 
-    # add flux limiter to avoid heavy drag in initial shock
-    # u_flux = sign(u[end])*min(abs(ρdragV₀*u[end]),max_flux)
-    # v_flux = sign(v[end])*min(abs(ρdragV₀*v[end]),max_flux)
-    # column.flux_u_upward[end] -= u_flux
-    # column.flux_v_upward[end] -= v_flux
-    
+    # add flux limiter to avoid heavy drag in (initial) shock
+    u_flux = ρ*drag*V₀*surface_u
+    v_flux = ρ*drag*V₀*surface_v
+    column.flux_u_upward[end] -= clamp(u_flux,-max_flux,max_flux)
+    column.flux_v_upward[end] -= clamp(v_flux,-max_flux,max_flux)
+
     # SPEEDY documentation eq. 52, 53, accumulate fluxes with +=
-    column.flux_u_upward[end] -= ρ*drag*V₀*surface_u
-    column.flux_v_upward[end] -= ρ*drag*V₀*surface_v
+    # column.flux_u_upward[end] -= ρ*drag*V₀*surface_u
+    # column.flux_v_upward[end] -= ρ*drag*V₀*surface_v
     
     return nothing
 end
 
 Base.@kwdef struct SurfaceSensibleHeat{NF<:AbstractFloat} <: AbstractSurfaceHeat{NF}
-    heat_exchange_land::Float64 = 1.2e-3    # for neutral stability
-    heat_exchange_sea::Float64 = 0.9e-3
+    heat_exchange_land::NF = 1.2e-3    # for neutral stability
+    heat_exchange_sea::NF = 0.9e-3
+    max_flux::NF = 100
 end
 
 SurfaceSensibleHeat(SG::SpectralGrid;kwargs...) = SurfaceSensibleHeat{SG.NF}(;kwargs...)
@@ -108,8 +109,7 @@ function sensible_heat_flux!(   column::ColumnVariables{NF},
                                 heat_flux::SurfaceSensibleHeat,
                                 C::DynamicsConstants) where NF
     (;cₚ) = C
-    heat_exchange_land = convert(NF,heat_flux.heat_exchange_land)
-    heat_exchange_sea  = convert(NF,heat_flux.heat_exchange_sea)
+    (;heat_exchange_land, heat_exchange_sea, max_flux) = heat_flux
 
     ρ = column.surface_air_density
     V₀ = column.surface_wind_speed
@@ -121,6 +121,10 @@ function sensible_heat_flux!(   column::ColumnVariables{NF},
     # SPEEDY documentation Eq. 54 and 56
     flux_land = ρ*heat_exchange_land*V₀*cₚ*(T_skin_land - T)
     flux_sea  = ρ*heat_exchange_sea*V₀*cₚ*(T_skin_sea  - T)
+
+    # flux limiter
+    flux_land = clamp(flux_land,-max_flux,max_flux)
+    flux_sea = clamp(flux_sea,-max_flux,max_flux)
 
     # mix fluxes for fractional land-sea mask
     land_available = isfinite(T_skin_land)
@@ -144,8 +148,8 @@ function sensible_heat_flux!(   column::ColumnVariables{NF},
 end
 
 Base.@kwdef struct SurfaceEvaporation{NF<:AbstractFloat} <: AbstractEvaporation{NF}
-    moisture_exchange_land::Float64 = 1.2e-3    # for neutral stability
-    moisture_exchange_sea::Float64 = 0.9e-3
+    moisture_exchange_land::NF = 1.2e-3    # for neutral stability
+    moisture_exchange_sea::NF = 0.9e-3
 end
 
 SurfaceEvaporation(SG::SpectralGrid;kwargs...) = SurfaceEvaporation{SG.NF}(;kwargs...)
@@ -166,9 +170,8 @@ function evaporation!(  column::ColumnVariables{NF},
                         evaporation::SurfaceEvaporation,
                         thermodynamics::Thermodynamics) where NF
 
-    (;skin_temperature_sea, skin_temperature_land, pres, humid) = column
-    moisture_exchange_land = convert(NF,evaporation.moisture_exchange_land)
-    moisture_exchange_sea  = convert(NF,evaporation.moisture_exchange_sea)
+    (;skin_temperature_sea, skin_temperature_land, pres) = column
+    (;moisture_exchange_land, moisture_exchange_sea) = evaporation
     α = column.soil_moisture_availability
 
     # SATURATION HUMIDITY OVER LAND AND OCEAN

--- a/src/physics/tendencies.jl
+++ b/src/physics/tendencies.jl
@@ -12,7 +12,6 @@ function parameterization_tendencies!(
     time::DateTime,
     model::PrimitiveEquation,
 )
-
     cos_zenith!(time,model)
 
     G = model.geometry


### PR DESCRIPTION
After testing a new vertical sigma spacing from Frierson 2006

![image](https://github.com/SpeedyWeather/SpeedyWeather.jl/assets/25530332/41977586-bbdf-469a-b27d-d4fd9240e513)

I've realised that many surface fluxes are at the edge of numerical stability, particularly a flickering of the wind on Antarctica that's caused by a strong drag term. Maybe we should revert to linear sigma spacing but that was a good stability test