### PR TITLE
Collapse levels to streamline the documentation navigation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, SpeedyWeather
 
 makedocs(
     format = Documenter.HTML(prettyurls=get(ENV, "CI", nothing)=="true",
-                             ansicolor=true,
+                             ansicolor=true, collapselevel=1,
                              size_threshold = 600_000),      # in bytes
     sitename = "SpeedyWeather.jl",
     authors = "M Klöwer and SpeedyWeather contributors",


### PR DESCRIPTION
Collapse levels to streamline the documentation.

Nice work on the restructuring of the docs too!