### PR TITLE
rand(Particle) cos-distribution corrected

### DIFF
--- a/src/dynamics/particle_advection.jl
+++ b/src/dynamics/particle_advection.jl
@@ -97,6 +97,8 @@ function particle_advection!(
 
     for i in eachindex(particles, u_old, v_old)
         # sum up Heun's first term in 1/2*Δt*(uv_old + uv_new) on the fly
+        # on first time step old u=v=0, so we just modulo all particles
+        # so that one could start with a particle at -120˚E => 240˚E here 
         particles[i] = advect_2D(particles[i], u_old[i], v_old[i], Δt_half)
         
         # predictor step, used to evaluate u_new, v_new 

--- a/src/dynamics/particles.jl
+++ b/src/dynamics/particles.jl
@@ -49,9 +49,8 @@ Base.rand(rng::Random.AbstractRNG, ::Random.Sampler{Particle{NF}}) where NF = ra
 
 # rand uniformly distributed over the globe with cos-distribution for poles
 function Base.rand(rng::Random.AbstractRNG, ::Random.Sampler{Particle{NF,isactive}}) where {NF,isactive}
-    lon = 360*rand(rng,NF)
-    yπ = convert(NF,π)*(2rand(rng,NF)-1)    # yπ ∈ [-1,1]*π
-    lat = sign(yπ)*acosd((1 + cos(yπ))/2)   # cos-distributed latitude
+    lon = 360*rand(rng,NF)                  # ∈ [0,360˚E]
+    lat = asind(2rand(rng,NF)-1)            # cos-distributed latitude
     σ = rand(rng,NF)
     return Particle{NF,isactive}(lon,lat,σ)
 end


### PR DESCRIPTION
We had too many particles around the poles

![image](https://github.com/SpeedyWeather/SpeedyWeather.jl/assets/25530332/52964274-0bf7-42e1-a7c8-0374985f26e9)

now corrected to

![image](https://github.com/SpeedyWeather/SpeedyWeather.jl/assets/25530332/aaf1fbc6-05db-4012-952b-864b6312e384)

because the cos distribution can be transformed from uniform distribution via `asin(2rand()-1)` and not the incorrect stuff we had before

![image](https://github.com/SpeedyWeather/SpeedyWeather.jl/assets/25530332/6a12439b-0715-451e-8123-c2bbac006ca0)
