### PR TITLE
Field trees

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,7 @@ makedocs(
             "Running SpeedyWeather" => [
                 "How to run SpeedyWeather"=>"how_to_run_speedy.md",
                 "Model setups"=>"setups.md",
+                "Tree structure"=>"structure.md",
                 "Particle advection"=>"particles.md",
                 "NetCDF output"=>"output.md",
             ],

--- a/docs/src/structure.md
+++ b/docs/src/structure.md
@@ -11,6 +11,7 @@ extended Julia's `show` function to give you an overview of its contents,
 e.g. a `clock::Clock` is printed as
 
 ```@example structure
+using SpeedyWeather
 clock = Clock()
 ```
 

--- a/docs/src/structure.md
+++ b/docs/src/structure.md
@@ -1,7 +1,8 @@
 # Tree structure
 
 At the top of SpeedyWeather's type tree sits the `Simulation`, containing
-variables and model, which in itself contains model components and so on.
+variables and model, which in itself contains model components with their
+own fields and so on.
 (Note that we are talking about the structure of structs within structs
 not the type hierarchy as defined by subtyping abstract types.)
 This can quickly get complicated with a lot of nested structs. The following
@@ -16,24 +17,27 @@ clock = Clock()
 ```
 
 illustrating the fields within a clock, their types and (unless they are an array)
-also their values. For structs within structs however, this information, however,
+also their values. For structs within structs however, this information,
 would not be printed by default. You could use Julia's autocomplete like
 `clock.<tab>` by hitting tab after the `.` to inspect the fields of an instance
 but that would require you to manually go down every branch of that tree.
 To better visualise this, we have defined a `tree(S)` function for any instance
-`S` that's defined in SpeedyWeather which will print every field, and also
+`S` defined in SpeedyWeather which will print every field, and also
 its containing fields if they are also defined within SpeedyWeather.
+The "if defined in SpeedyWeather" is important because otherwise
+the tree would also show you the contents of a complex number or other types
+defined in Julia Base itself that we aren't interested in here. 
 But let's start at the top.
 
 ## Simulation
 
-When creating a Simulation, it's fields are
+When creating a `Simulation`, its fields are
 ```@example structure
 model = BarotropicModel()
 simulation = initialize!(model)
 ```
 the `prognostic_variables`, the `diagnostic_variables` and the `model` (that we just
-initialized.) We could now do `tree(simulation)` but that gets very lengthy and
+initialized). We could now do `tree(simulation)` but that gets very lengthy and
 so will split things into `tree(simulation.prognostic_variables)`,
 `tree(simulation.diagnostic_variables)` and `tree(simulation.model)` for more
 digestible chunks. You can also provide the `with_types=true` keyword to get
@@ -63,6 +67,11 @@ tree(simulation.diagnostic_variables)
 
 The `BarotropicModel` is the simplest model we have, which will not have many of
 the model components that are needed to define the primitive equations for example.
+Note that forcing or drag aren't further branched which is because the default
+`BarotropicModel` has `NoForcing` and `NoDrag` which don't have any fields. 
+If you create a model with non-default conponents they will show up here. 
+`tree` dynamicallt inspects the current contents of a (mutable) struct and
+that tree may look different depending on what model you have constructed!
 
 ```@example structure
 model = BarotropicModel()

--- a/docs/src/structure.md
+++ b/docs/src/structure.md
@@ -1,0 +1,100 @@
+# Tree structure
+
+At the top of SpeedyWeather's type tree sits the `Simulation`, containing
+variables and model, which in itself contains model components and so on.
+(Note that we are talking about the structure of structs within structs
+not the type hierarchy as defined by subtyping abstract types.)
+This can quickly get complicated with a lot of nested structs. The following
+is to give users a better overview of how simulation, variables and model
+are structured within SpeedyWeather. Many types in SpeedyWeather have
+extended Julia's `show` function to give you an overview of its contents,
+e.g. a `clock::Clock` is printed as
+
+```@example structure
+clock = Clock()
+```
+
+illustrating the fields within a clock, their types and (unless they are an array)
+also their values. For structs within structs however, this information, however,
+would not be printed by default. You could use Julia's autocomplete like
+`clock.<tab>` by hitting tab after the `.` to inspect the fields of an instance
+but that would require you to manually go down every branch of that tree.
+To better visualise this, we have defined a `tree(S)` function for any instance
+`S` that's defined in SpeedyWeather which will print every field, and also
+its containing fields if they are also defined within SpeedyWeather.
+But let's start at the top.
+
+## Simulation
+
+When creating a Simulation, it's fields are
+```@example structure
+model = BarotropicModel()
+simulation = initialize!(model)
+```
+the `prognostic_variables`, the `diagnostic_variables` and the `model` (that we just
+initialized.) We could now do `tree(simulation)` but that gets very lengthy and
+so will will split things into `tree(simulation.prognostic_variables)`,
+`tree(simulation.diagnostic_variables)` and `tree(simulation.model)` for more
+digestible chunks. You can also provide the `with_types=true` keyword to get
+also the types of these fields printed, but we'll skip that here.
+
+## Prognostic variables
+
+The prognostic variables struct is parametric on the model type, `model_type(model)`
+(which strips away its parameters), but this is only to dispatch over it.
+The fields are for all models the same, just the barotropic model would not
+use temperature for example (but you could use nevertheless). 
+
+```@example structure
+tree(simulation.prognostic_variables)
+```
+
+## Diagnostic variables
+
+Similar for the diagnostic variables, regardless the model type, they contain the
+same fields but for the 2D models many will not be used for example.
+
+```@example structure
+tree(simulation.diagnostic_variables)
+```
+
+## BarotropicModel
+
+The `BarotropicModel` is the simplest model we have, which will not have many of
+the model components that are needed to define the primitive equations for example.
+
+```@example structure
+model = BarotropicModel()
+tree(model)
+```
+
+## ShallowWaterModel
+
+The `ShallowWaterModel` is similar to the `BarotropicModel`, but it contains for example
+orography, that the `BarotropicModel` doesn't have.
+
+```@example structure
+model = ShallowWaterModel()
+tree(model)
+```
+
+## PrimitiveDryModel
+
+The `PrimitiveDryModel` is a big jump in complexity compared to the 2D models, but
+because it doesn't contain humidity, several model components like evaporation
+aren't needed.
+
+```@example structure
+model = PrimitiveDryModel()
+tree(model)
+```
+
+## PrimitiveWetModel
+
+The `PrimitiveWetModel` is the most complex model we currently have, hence its
+field tree is the longest, defining many components for the physics parameterizations.
+
+```@example structure
+model = PrimitiveWetModel()
+tree(model)
+```

--- a/docs/src/structure.md
+++ b/docs/src/structure.md
@@ -34,7 +34,7 @@ simulation = initialize!(model)
 ```
 the `prognostic_variables`, the `diagnostic_variables` and the `model` (that we just
 initialized.) We could now do `tree(simulation)` but that gets very lengthy and
-so will will split things into `tree(simulation.prognostic_variables)`,
+so will split things into `tree(simulation.prognostic_variables)`,
 `tree(simulation.diagnostic_variables)` and `tree(simulation.model)` for more
 digestible chunks. You can also provide the `with_types=true` keyword to get
 also the types of these fields printed, but we'll skip that here.

--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -137,4 +137,5 @@ include("models/barotropic.jl")
 include("models/shallow_water.jl")
 include("models/primitive_dry.jl")
 include("models/primitive_wet.jl")
+include("models/tree.jl")
 end

--- a/src/models/tree.jl
+++ b/src/models/tree.jl
@@ -1,0 +1,96 @@
+export tree
+
+"""
+$(TYPEDSIGNATURES)
+Create a tree of fields inside a Simulation instance and fields within these fields
+as long as they are defined within the modules argument (default SpeedyWeather).
+Other keyword arguments are `max_level::Integer=10`, `with_types::Bool=false`."""
+function tree(S::Simulation{M}; modules=SpeedyWeather, kwargs...) where M
+    println("Simulation{$(model_type(M))}")
+    _tree(S, modules; kwargs...)
+end
+
+"""
+$(TYPEDSIGNATURES)
+Create a tree of fields inside a model and fields within these fields
+as long as they are defined within the modules argument (default SpeedyWeather).
+Other keyword arguments are `max_level::Integer=10`, `with_types::Bool=false`."""
+function tree(M::ModelSetup; modules=SpeedyWeather, kwargs...)
+    println("$(model_type(M)){...}")
+    _tree(M, modules; kwargs...)
+end
+
+"""
+$(TYPEDSIGNATURES)
+Create a tree of fields inside S and fields within these fields
+as long as they are defined within the modules argument (default SpeedyWeather).
+Other keyword arguments are `max_level::Integer=10`, `with_types::Bool=false`."""
+function tree(S; modules=SpeedyWeather, kwargs...)
+    println("$(typeof(S))")
+    _tree(S, modules; kwargs...)
+end
+
+function _tree(
+    S,
+    modules::Module...;         # fields within the modules are further inspected
+    max_level::Integer = 10,    # depth of the tree
+    with_types::Bool = false,   # print also the types of the fields?
+)
+    level = 0                   # starting level of depth tree
+    prevs = falses(max_level+2) # determine whether there's still a branch levels up
+                                # needed for │ printing of upper levels that continue
+    property_names = propertynames(S)
+    n_properties = length(property_names)
+
+    for (i,property_name) in enumerate(property_names)
+        last = i == n_properties    # last elements in branches are printed with └ not ├
+        prevs[level+1] = ~last
+        print_branch(property_name, S, level, max_level, last, prevs, with_types, modules...)
+    end
+end
+
+function print_branch(
+    property_name::Symbol,  # name of current field
+    S,                      # its parent struct
+    level::Integer,         # depth of tree we're on
+    max_level::Integer,     # maximum depth of tree
+    last::Bool,             # is that the last field in parent?
+    prevs::BitVector,       # branching of previous fields completed?
+    with_types::Bool,       # print also types
+    modules::Module...,     # in which modules to search
+ )
+    level == max_level && return nothing
+
+    property = getproperty(S,property_name)
+    child = parentmodule(typeof(property)) in modules
+
+    continue_branching = false
+    is_array = false
+    if child
+        continue_branching = true
+    elseif property isa AbstractArray
+        if length(property) > 0
+            property = property[1]      # unpack first element in array
+            continue_branching = parentmodule(typeof(property)) in modules
+            is_array = continue_branching
+        end
+    end
+
+    property_names = propertynames(property)
+    n_properties = length(property_names)
+    junction1 = (n_properties > 0 && child) || is_array ? "┐" : " "
+
+    vertical_lines = prod([b ? "│" : " " for b in prevs[1:level]])
+    junction2 = last ? "└" : "├"
+    print(vertical_lines, junction2, junction1, property_name)
+    s = ~with_types ? "" : "::$(typeof(property))"
+    println(s)
+
+    if continue_branching
+        for (i,branch) in enumerate(property_names)
+            last = i == n_properties
+            prevs[level+2] = ~last
+            print_branch(branch, property, level+1, max_level, last, prevs, with_types, modules...)
+        end
+    end
+end


### PR DESCRIPTION
One can now do

```julia
julia> tree(simulation)
Simulation{PrimitiveWetModel}
├┐prognostic_variables
│├ trunc
│├ nlat_half
│├ nlev
│├ n_steps
│├┐layers
││└┐timesteps
││ ├ trunc
││ ├ vor
││ ├ div
││ ├ temp
││ └ humid
│├┐surface
││└┐timesteps
││ ├ trunc
││ └ pres
│├┐ocean
││├ nlat_half
││├ time
││├ sea_surface_temperature
││└ sea_ice_concentration
│├┐land
││├ nlat_half
││├ time
││├ land_surface_temperature
...
```

to get a full field tree (a tree of all fields and their fields as long as they are defined in SpeedyWeather) printed. It's convenient to visualise nested structs. Also added to the docs to have that automatically documented. 

@natgeo-wong this is a first step towards "a more detailed explanation of modules" by which I think you mean the components of a SpeedyWeather simulation (avoiding the term "module" because of its use in Julia)