### PR TITLE
LowerTriangularMatrix copyto! range bug

### DIFF
--- a/src/LowerTriangularMatrices/lower_triangular_matrix.jl
+++ b/src/LowerTriangularMatrices/lower_triangular_matrix.jl
@@ -159,7 +159,7 @@ function Base.copyto!(  L1::LowerTriangularMatrix{T},   # copy to L1
 
     lmax, mmax = size(L1)        # but the size of L1 to loop
     lm = 0
-    @inbounds for m in 1:maximum(ms)
+    @inbounds for m in 1:mmax
         for l in m:lmax
             lm += 1
             L1[lm] = (l in ls) && (m in ms) ? convert(T, L2[l, m]) : L1[lm]

--- a/test/lower_triangular_matrix.jl
+++ b/test/lower_triangular_matrix.jl
@@ -129,6 +129,20 @@ end
         copyto!(L2, L1)
 
         @test L2 == L2c
+
+        # with ranges
+        L1 = zeros(LowerTriangularMatrix{NF}, 33, 32);
+        L2 = randn(LowerTriangularMatrix{NF}, 65, 64);
+        L2T = spectral_truncation(L2,(size(L1) .- 1)...)
+
+        copyto!(L1, L2, 1:33, 1:32)     # size of smaller matrix
+        @test L1 == L2T
+
+        copyto!(L1, L2, 1:65, 1:64)     # size of bigger matrix
+        @test L1 == L2T
+
+        copyto!(L1, L2, 1:50, 1:50)     # in between
+        @test L1 == L2T
     end
 end
 


### PR DESCRIPTION
Just pointed out by Maximilian, never occurred because only ever called with correct ranges from function above but other ranges do throw when `@inbounds` removed

```julia
julia> L1 = zeros(LowerTriangularMatrix,33,32);

julia> L2 = zeros(LowerTriangularMatrix,65,64);


julia> copyto!(L1,L2,1:5,1:64);
ERROR: BoundsError: attempt to access 33×32 LowerTriangularMatrix{Float64} at index [561]
Stacktrace:
 [1] getindex
   @ ~/git/SpeedyWeather.jl/src/LowerTriangularMatrices/lower_triangular_matrix.jl:63 [inlined]
 [2] copyto!(L1::LowerTriangularMatrix{…}, L2::LowerTriangularMatrix{…}, ls::UnitRange{…}, ms::UnitRange{…})
   @ Main.SpeedyWeather.LowerTriangularMatrices ~/git/SpeedyWeather.jl/src/LowerTriangularMatrices/lower_triangular_matrix.jl:165
 [3] top-level scope
   @ REPL[4]:1
Some type information was truncated. Use `show(err)` to see complete types.
```