### PR TITLE
Jeevanjee longwave radiation

### DIFF
--- a/src/dynamics/diagnostic_variables.jl
+++ b/src/dynamics/diagnostic_variables.jl
@@ -129,18 +129,19 @@ Base.@kwdef struct SurfaceVariables{NF<:AbstractFloat, Grid<:AbstractGrid{NF}}
     pres_tend::LTM{Complex{NF}} = zeros(LTM{Complex{NF}}, trunc+2, trunc+1)
     pres_tend_grid::Grid = zeros(Grid, nlat_half)
 
-    ∇lnp_x::Grid = zeros(Grid, nlat_half)        # zonal gradient of log surf pressure
-    ∇lnp_y::Grid = zeros(Grid, nlat_half)        # meridional gradient of log surf pres
+    ∇lnp_x::Grid = zeros(Grid, nlat_half)           # zonal gradient of log surf pressure
+    ∇lnp_y::Grid = zeros(Grid, nlat_half)           # meridional gradient of log surf pres
 
-    u_mean_grid::Grid = zeros(Grid, nlat_half)   # vertical average of: zonal velocity *coslat
-    v_mean_grid::Grid = zeros(Grid, nlat_half)   # meridional velocity *coslat
-    div_mean_grid::Grid = zeros(Grid, nlat_half) # divergence
+    u_mean_grid::Grid = zeros(Grid, nlat_half)      # vertical average of: zonal velocity *coslat
+    v_mean_grid::Grid = zeros(Grid, nlat_half)      # meridional velocity *coslat
+    div_mean_grid::Grid = zeros(Grid, nlat_half)    # divergence
     div_mean::LTM{Complex{NF}} = zeros(LTM{Complex{NF}}, trunc+2, trunc+1)    # divergence (in spectral though)
     
-    precip_large_scale::Grid = zeros(Grid, nlat_half)    # large scale precipitation (for output)
-    precip_convection::Grid = zeros(Grid, nlat_half)     # convective precipitation (for output)
-    cloud_top::Grid = zeros(Grid, nlat_half)             # cloud top [hPa]
+    precip_large_scale::Grid = zeros(Grid, nlat_half)   # large scale precipitation (for output)
+    precip_convection::Grid = zeros(Grid, nlat_half)    # convective precipitation (for output)
+    cloud_top::Grid = zeros(Grid, nlat_half)            # cloud top [hPa]
     soil_moisture_availability::Grid = zeros(Grid, nlat_half)
+    cos_zenith::Grid = zeros(Grid, nlat_half)           # cosine of solar zenith angle
 end
 
 # generator function based on a SpectralGrid

--- a/src/dynamics/orography.jl
+++ b/src/dynamics/orography.jl
@@ -78,7 +78,7 @@ function initialize!(   orog::ZonalRidge,
 
     ηᵥ = (1-η₀)*π/2                     # ηᵥ-coordinate of the surface [1]
     A = u₀*cos(ηᵥ)^(3/2)                # amplitude [m/s]
-    RΩ = radius*rotation                # [m/s]
+    RΩ = radius*rotation                # [m/s]
     g⁻¹ = inv(gravity)                  # inverse gravity [s²/m]
 
     for ij in eachindex(φ, orography)
@@ -114,7 +114,7 @@ Base.@kwdef mutable struct EarthOrography{NF<:AbstractFloat, Grid<:AbstractGrid{
     scale::Float64 = 1
 
     "smooth the orography field?"
-    smoothing::Bool = true
+    smoothing::Bool = false
 
     "power of Laplacian for smoothing"
     smoothing_power::Float64 = 1.0

--- a/src/dynamics/planet.jl
+++ b/src/dynamics/planet.jl
@@ -39,7 +39,7 @@ Base.@kwdef mutable struct Earth{NF<:AbstractFloat} <: AbstractPlanet
     axial_tilt::NF = 23.4
 
     "Total solar irradiance at the distance of 1 AU [W/m²]"
-    solar_constant::NF = 1365
+    solar_constant::NF = 1365/4     # for testing
 end
 
 Earth(SG::SpectralGrid; kwargs...) = Earth{SG.NF}(; kwargs...)

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -395,7 +395,7 @@ function time_stepping!(
     
     # FIRST TIMESTEPS: EULER FORWARD THEN 1x LEAPFROG
     # considered part of the model initialisation
-    first_timesteps!(progn,diagn, model, output)
+    first_timesteps!(progn, diagn, model, output)
     
     # only now initialise feedback for benchmark accuracy
     initialize!(feedback, clock, model)
@@ -405,7 +405,7 @@ function time_stepping!(
         timestep!(progn, diagn, 2Δt, model) # calculate tendencies and leapfrog forward
         timestep!(clock, Δt_millisec)       # time of lf=2 and diagn after timestep!
 
-        progress!(feedback, progn)           # updates the progress meter bar
+        progress!(feedback, progn)          # updates the progress meter bar
         write_output!(output, clock.time, diagn)
         callback!(model.callbacks, progn, diagn, model)
     end

--- a/src/models/abstract_models.jl
+++ b/src/models/abstract_models.jl
@@ -30,7 +30,7 @@ model_class(::Type{<:PrimitiveDry}) = PrimitiveDry
 model_class(::Type{<:PrimitiveWet}) = PrimitiveWet
 model_class(model::ModelSetup) = model_class(typeof(model))
 
-# model type is the parameter-free type of a model
+# model type is the parameter-free type of a model
 # TODO what happens if we have several concrete types under each abstract type?
 model_type(::Type{<:Barotropic}) = BarotropicModel
 model_type(::Type{<:ShallowWater}) = ShallowWaterModel
@@ -44,7 +44,7 @@ function Base.show(io::IO, M::ModelSetup)
     n = length(properties)
     for (i, key) in enumerate(properties)
         val = getfield(M, key)
-        s = i == n ? "└" : "├"  # choose ending └ for last property
+        s = i == n ? "└" : "├"  # choose ending └ for last property
         p = i == n ? print : println
         p(io, "$s $key: $(typeof(val))")
     end

--- a/src/models/barotropic.jl
+++ b/src/models/barotropic.jl
@@ -79,8 +79,8 @@ function initialize!(model::Barotropic; time::DateTime = DEFAULT_DATE)
     # initial conditions
     prognostic_variables = PrognosticVariables(spectral_grid, model)
     initialize!(prognostic_variables, model.initial_conditions, model)
-    prognostic_variables.clock.time = time       # set the current time
-    prognostic_variables.clock.start = time      # and store the start time
+    prognostic_variables.clock.time = time       # set the current time
+    prognostic_variables.clock.start = time      # and store the start time
 
     # particle advection
     initialize!(model.particle_advection, model)

--- a/src/models/primitive_dry.jl
+++ b/src/models/primitive_dry.jl
@@ -75,8 +75,8 @@ Base.@kwdef mutable struct PrimitiveDryModel{
     surface_wind::SUW = SurfaceWind(spectral_grid)
     surface_heat_flux::SH = SurfaceSensibleHeat(spectral_grid)
     convection::CV = DryBettsMiller(spectral_grid)
-    shortwave_radiation::SW = NoShortwave(spectral_grid)
-    longwave_radiation::LW = NoLongwave(spectral_grid)
+    shortwave_radiation::SW = TransparentShortwave(spectral_grid)
+    longwave_radiation::LW = JeevanjeeRadiation(spectral_grid)
     
     # NUMERICS
     device_setup::DS = DeviceSetup(CPUDevice())

--- a/src/models/primitive_dry.jl
+++ b/src/models/primitive_dry.jl
@@ -1,9 +1,14 @@
 export PrimitiveDryModel
 
 """
-$(SIGNATURES)
-The PrimitiveDryModel struct holds all other structs that contain precalculated constants,
-whether scalars or arrays that do not change throughout model integration.
+The PrimitiveDryModel contains all model components (themselves structs) needed for the
+simulation of the primitive equations without humidity. To be constructed like
+
+    model = PrimitiveDryModel(; spectral_grid, kwargs...)
+
+with `spectral_grid::SpectralGrid` used to initalize all non-default components
+passed on as keyword arguments, e.g. `planet=Earth(spectral_grid)`. Fields, representing
+model components, are
 $(TYPEDFIELDS)"""
 Base.@kwdef mutable struct PrimitiveDryModel{
     NF<:AbstractFloat,

--- a/src/models/primitive_dry.jl
+++ b/src/models/primitive_dry.jl
@@ -25,6 +25,7 @@ Base.@kwdef mutable struct PrimitiveDryModel{
     OC<:AbstractOcean,
     LA<:AbstractLand,
     ZE<:AbstractZenith,
+    AL<:AbstractAlbedo,
     BL<:AbstractBoundaryLayer,
     TR<:AbstractTemperatureRelaxation,
     VD<:AbstractVerticalDiffusion,
@@ -63,6 +64,7 @@ Base.@kwdef mutable struct PrimitiveDryModel{
     ocean::OC = SeasonalOceanClimatology(spectral_grid)
     land::LA = SeasonalLandTemperature(spectral_grid)
     solar_zenith::ZE = WhichZenith(spectral_grid, planet)
+    albedo::AL = AlbedoClimatology(spectral_grid)
     
     # PHYSICS/PARAMETERIZATIONS
     physics::Bool = true
@@ -116,6 +118,7 @@ function initialize!(model::PrimitiveDry; time::DateTime = DEFAULT_DATE)
     initialize!(model.ocean, model)
     initialize!(model.land, model)
     initialize!(model.solar_zenith, time, model)
+    initialize!(model.albedo, model)
 
     # parameterizations
     initialize!(model.boundary_layer_drag, model)

--- a/src/models/primitive_wet.jl
+++ b/src/models/primitive_wet.jl
@@ -1,9 +1,14 @@
 export PrimitiveWetModel
 
 """
-$(SIGNATURES)
-The PrimitiveDryModel struct holds all other structs that contain precalculated constants,
-whether scalars or arrays that do not change throughout model integration.
+The PrimitiveWetModel contains all model components (themselves structs) needed for the
+simulation of the primitive equations with humidity. To be constructed like
+
+    model = PrimitiveWetModel(; spectral_grid, kwargs...)
+
+with `spectral_grid::SpectralGrid` used to initalize all non-default components
+passed on as keyword arguments, e.g. `planet=Earth(spectral_grid)`. Fields, representing
+model components, are
 $(TYPEDFIELDS)"""
 Base.@kwdef mutable struct PrimitiveWetModel{
     NF<:AbstractFloat,
@@ -142,8 +147,8 @@ function initialize!(model::PrimitiveWet; time::DateTime = DEFAULT_DATE)
     prognostic_variables = PrognosticVariables(spectral_grid, model)
     initialize!(prognostic_variables,model.initial_conditions, model)
     (;clock) = prognostic_variables
-    clock.time = time       # set the current time
-    clock.start = time      # and store the start time
+    clock.time = time       # set the current time
+    clock.start = time      # and store the start time
 
     # particle advection
     initialize!(model.particle_advection, model)

--- a/src/models/primitive_wet.jl
+++ b/src/models/primitive_wet.jl
@@ -25,6 +25,7 @@ Base.@kwdef mutable struct PrimitiveWetModel{
     OC<:AbstractOcean,
     LA<:AbstractLand,
     ZE<:AbstractZenith,
+    AL<:AbstractAlbedo,
     SO<:AbstractSoil,
     VG<:AbstractVegetation,
     CC<:AbstractClausiusClapeyron,
@@ -69,6 +70,7 @@ Base.@kwdef mutable struct PrimitiveWetModel{
     ocean::OC = SeasonalOceanClimatology(spectral_grid)
     land::LA = SeasonalLandTemperature(spectral_grid)
     solar_zenith::ZE = WhichZenith(spectral_grid, planet)
+    albedo::AL = AlbedoClimatology(spectral_grid)
     soil::SO = SeasonalSoilMoisture(spectral_grid)
     vegetation::VG = VegetationClimatology(spectral_grid)
     
@@ -84,8 +86,8 @@ Base.@kwdef mutable struct PrimitiveWetModel{
     evaporation::EV = SurfaceEvaporation(spectral_grid)
     large_scale_condensation::LSC = ImplicitCondensation(spectral_grid)
     convection::CV = SimplifiedBettsMiller(spectral_grid)
-    shortwave_radiation::SW = NoShortwave(spectral_grid)
-    longwave_radiation::LW = UniformCooling(spectral_grid)
+    shortwave_radiation::SW = TransparentShortwave(spectral_grid)
+    longwave_radiation::LW = JeevanjeeRadiation(spectral_grid)
     
     # NUMERICS
     device_setup::DS = DeviceSetup(CPUDevice())
@@ -130,6 +132,7 @@ function initialize!(model::PrimitiveWet; time::DateTime = DEFAULT_DATE)
     initialize!(model.soil, model)
     initialize!(model.vegetation, model)
     initialize!(model.solar_zenith, time, model)
+    initialize!(model.albedo, model)
 
     # parameterizations
     initialize!(model.boundary_layer_drag, model)

--- a/src/models/shallow_water.jl
+++ b/src/models/shallow_water.jl
@@ -82,8 +82,8 @@ function initialize!(model::ShallowWater; time::DateTime = DEFAULT_DATE)
     # initial conditions
     prognostic_variables = PrognosticVariables(spectral_grid, model)
     initialize!(prognostic_variables, model.initial_conditions, model)
-    prognostic_variables.clock.time = time       # set the current time
-    prognostic_variables.clock.start = time      # and store the start time
+    prognostic_variables.clock.time = time       # set the current time
+    prognostic_variables.clock.start = time      # and store the start time
 
     # particle advection
     initialize!(model.particle_advection, model)

--- a/src/models/tree.jl
+++ b/src/models/tree.jl
@@ -4,7 +4,8 @@ export tree
 $(TYPEDSIGNATURES)
 Create a tree of fields inside a Simulation instance and fields within these fields
 as long as they are defined within the modules argument (default SpeedyWeather).
-Other keyword arguments are `max_level::Integer=10`, `with_types::Bool=false`."""
+Other keyword arguments are `max_level::Integer=10`, `with_types::Bool=false`
+or `with_size::Bool=false."""
 function tree(
     S::Simulation{M};
     modules=SpeedyWeather,
@@ -21,7 +22,8 @@ end
 $(TYPEDSIGNATURES)
 Create a tree of fields inside a model and fields within these fields
 as long as they are defined within the modules argument (default SpeedyWeather).
-Other keyword arguments are `max_level::Integer=10`, `with_types::Bool=false`."""
+Other keyword arguments are `max_level::Integer=10`, `with_types::Bool=false`
+or `with_size::Bool=false."""
 function tree(
     M::ModelSetup;
     modules=SpeedyWeather,
@@ -38,7 +40,8 @@ end
 $(TYPEDSIGNATURES)
 Create a tree of fields inside S and fields within these fields
 as long as they are defined within the modules argument (default SpeedyWeather).
-Other keyword arguments are `max_level::Integer=10`, `with_types::Bool=false`."""
+Other keyword arguments are `max_level::Integer=10`, `with_types::Bool=false`
+or `with_size::Bool=false."""
 function tree(S; modules=SpeedyWeather, with_size::Bool = false, kwargs...)
     s = "$(typeof(S))"
     s = ~with_size ? s : s*" ($(prettymemory(Base.summarysize(S))))"

--- a/src/output/feedback.jl
+++ b/src/output/feedback.jl
@@ -72,7 +72,7 @@ $(TYPEDSIGNATURES)
 Initializes the a `Feedback` struct."""
 function initialize!(feedback::Feedback, clock::Clock, model::ModelSetup)
 
-    # set to false to recheck for NaRs
+    # set to false to recheck for NaRs
     feedback.nars_detected = false
 
     # hack: redefine element in global constant dt_in_sec
@@ -158,17 +158,12 @@ function nar_detection!(feedback::Feedback, progn::PrognosticVariables)
 
     feedback.nars_detected && return nothing    # escape immediately if nans already detected
     i = feedback.progress_meter.counter         # time step
-    nars_detected_here = false
-    (; vor ) = progn.layers[end].timesteps[2] # only check for surface vorticity
+    (; vor ) = progn.layers[end].timesteps[2]   # only check for surface vorticity
 
-    if ~nars_detected_here
-        nars_vor = ~isfinite(vor[1])    # just check first mode
-                                        # spectral transform propagates NaRs globally anyway
-        nars_vor && @warn "NaN or Inf detected at time step $i"
-        nars_detected_here |= nars_vor
-    end
-
-    feedback.nars_detected |= nars_detected_here
+    # just check first harmonic, spectral transform propagates NaRs globally anyway
+    nars_detected_here = ~isfinite(vor[1])
+    nars_detected_here && @warn "NaN or Inf detected at time step $i"
+    feedback.nars_detected = nars_detected_here
 end
 
 """

--- a/src/output/plot.jl
+++ b/src/output/plot.jl
@@ -1,5 +1,3 @@
 # to avoid ambiguity with exporting plot
 plot(L::LowerTriangularMatrix{T}; kwargs...) where T = LowerTriangularMatrices.plot(L; kwargs...)
 plot(G::AbstractGrid{T}; kwargs...) where T = RingGrids.plot(G; kwargs...)
-
-;

--- a/src/output/schedule.jl
+++ b/src/output/schedule.jl
@@ -51,7 +51,7 @@ happen only once if they coincide on a given time step."""
 function initialize!(scheduler::Schedule, clock::Clock)
     schedule = falses(clock.n_timesteps)    # initialize schedule as BitVector
 
-    # PERIODIC SCHEDULE, always AFTER scheduler.every time period has passed
+    # PERIODIC SCHEDULE, always AFTER scheduler.every time period has passed
     if scheduler.every.value < typemax(Int)
         every_n_timesteps = max(1,round(Int, scheduler.every/clock.Δt))
         schedule[every_n_timesteps:every_n_timesteps:end] .= true

--- a/src/physics/albedo.jl
+++ b/src/physics/albedo.jl
@@ -1,1 +1,61 @@
-abstract type AbstractAlbedo end
+abstract type AbstractAlbedo <: AbstractModelComponent end
+
+## GLOBAL CONSTANT ALBEDO
+
+export GlobalConstantAlbedo
+Base.@kwdef struct GlobalConstantAlbedo{NF,Grid} <: AbstractAlbedo
+    nlat_half::Int
+    α::NF = 0.8
+    albedo::Grid = zeros(Grid, nlat_half)
+end
+
+function GlobalConstantAlbedo(SG::SpectralGrid; kwargs...)
+    (;NF, Grid, nlat_half) = SG
+    GlobalConstantAlbedo{NF, Grid{NF}}(; nlat_half, kwargs...)
+end
+
+function initialize!(albedo::GlobalConstantAlbedo,::PrimitiveEquation)
+    albedo.albedo .= albedo.α
+end
+
+## ALEBDO CLIMATOLOGY
+
+export AlbedoClimatology
+Base.@kwdef struct AlbedoClimatology{NF,Grid} <: AbstractAlbedo
+    "number of latitudes on one hemisphere, Equator included"
+    nlat_half::Int
+
+    "[OPTION] path to the folder containing the albedo file, pkg path default"
+    path::String = "SpeedyWeather.jl/input_data"
+
+    "[OPTION] filename of albedo"
+    file::String = "albedo.nc"
+
+    "[OPTION] variable name in netcdf file"
+    varname::String = "alb"
+
+    "[OPTION] Grid the albedo file comes on"
+    file_Grid::Type{<:AbstractGrid} = FullGaussianGrid
+
+    "Albedo climatology"
+    albedo::Grid = zeros(Grid, nlat_half)
+end
+
+function AlbedoClimatology(SG::SpectralGrid; kwargs...)
+    (; NF, Grid, nlat_half) = SG
+    AlbedoClimatology{NF,Grid{NF}}(;nlat_half, kwargs...)
+end
+
+function initialize!(albedo::AlbedoClimatology, model::PrimitiveEquation)
+    
+    # LOAD NETCDF FILE
+    if albedo.path == "SpeedyWeather.jl/input_data"
+        path = joinpath(@__DIR__, "../../input_data", albedo.file)
+    else
+        path = joinpath(albedo.path, albedo.file)
+    end
+    ncfile = NCDataset(path)
+
+    a = albedo.file_Grid(ncfile[albedo.varname][:, :])
+    interpolate!(albedo.albedo, a)
+end

--- a/src/physics/column_variables.jl
+++ b/src/physics/column_variables.jl
@@ -7,22 +7,30 @@ function get_column!(
     jring::Integer,     # ring index 1 around North Pole to J around South Pole
     model::PrimitiveEquation,
 )
-    get_column!(C, D, P, ij, jring, model.geometry, model.planet, model.orography, model.land_sea_mask)
+    get_column!(C, D, P, ij, jring, 
+        model.geometry,
+        model.planet,
+        model.orography,
+        model.land_sea_mask,
+        model.albedo)
 end
 
 """
 $(TYPEDSIGNATURES)
 Update `C::ColumnVariables` by copying the prognostic variables from `D::DiagnosticVariables`
 at gridpoint index `ij`. Provide `G::Geometry` for coordinate information."""
-function get_column!(   C::ColumnVariables,
-                        D::DiagnosticVariables,
-                        P::PrognosticVariables,
-                        ij::Integer,        # grid point index
-                        jring::Integer,     # ring index 1 around North Pole to J around South Pole
-                        geometry::Geometry,
-                        planet::AbstractPlanet,
-                        orography::AbstractOrography,
-                        land_sea_mask::AbstractLandSeaMask)
+function get_column!(   
+    C::ColumnVariables,
+    D::DiagnosticVariables,
+    P::PrognosticVariables,
+    ij::Integer,        # grid point index
+    jring::Integer,     # ring index 1 around North Pole to J around South Pole
+    geometry::Geometry,
+    planet::AbstractPlanet,
+    orography::AbstractOrography,
+    land_sea_mask::AbstractLandSeaMask,
+    albedo::AbstractAlbedo,
+)
 
     (; σ_levels_full, ln_σ_levels_full) = geometry
 
@@ -55,7 +63,10 @@ function get_column!(   C::ColumnVariables,
     C.skin_temperature_sea = P.ocean.sea_surface_temperature[ij]
     C.skin_temperature_land = P.land.land_surface_temperature[ij]
     C.soil_moisture_availability = D.surface.soil_moisture_availability[ij]
+
+    # RADIATION
     C.cos_zenith = D.surface.cos_zenith[ij]
+    C.albedo = albedo.albedo[ij]
 end
 
 """Recalculate ring index if not provided."""

--- a/src/physics/column_variables.jl
+++ b/src/physics/column_variables.jl
@@ -55,6 +55,7 @@ function get_column!(   C::ColumnVariables,
     C.skin_temperature_sea = P.ocean.sea_surface_temperature[ij]
     C.skin_temperature_land = P.land.land_surface_temperature[ij]
     C.soil_moisture_availability = D.surface.soil_moisture_availability[ij]
+    C.cos_zenith = D.surface.cos_zenith[ij]
 end
 
 """Recalculate ring index if not provided."""

--- a/src/physics/define_column.jl
+++ b/src/physics/define_column.jl
@@ -74,6 +74,9 @@ Base.@kwdef mutable struct ColumnVariables{NF<:AbstractFloat} <: AbstractColumnV
     precip_convection::NF = 0               # Precipitation due to convection [m]
     precip_large_scale::NF = 0              # precipitation due to large-scale condensation [m]
 
+    # RADIATION
+    cos_zenith::NF = 0                      # cosine of solar zenith angle
+
     # WORK ARRAYS
     const a::Vector{NF} = zeros(NF, nlev)
     const b::Vector{NF} = zeros(NF, nlev)

--- a/src/physics/define_column.jl
+++ b/src/physics/define_column.jl
@@ -76,6 +76,7 @@ Base.@kwdef mutable struct ColumnVariables{NF<:AbstractFloat} <: AbstractColumnV
 
     # RADIATION
     cos_zenith::NF = 0                      # cosine of solar zenith angle
+    albedo::NF = 0                          # surface albedo
 
     # WORK ARRAYS
     const a::Vector{NF} = zeros(NF, nlev)

--- a/src/physics/longwave_radiation.jl
+++ b/src/physics/longwave_radiation.jl
@@ -100,10 +100,11 @@ function longwave_radiation!(
     
     Fₖ::NF = 0                      # flux into lowermost layer from below
 
-    @inbounds for k in nlev-1:-1:1
+    # integrate from surface up, skipping surface (k=nlev+1) and top-of-atmosphere flux (k=1)
+    @inbounds for k in nlev:-1:2    
         # Seeley and Wordsworth, 2023 eq (1)
-        Fₖ = Fₖ + (T[k] - T[k+1])*α*(Tₜ - T[k+1])   # upward flux from layer k+1 into k
-        F[k+1] += Fₖ                                # flux vector uses k+1 to store, accumulate
+        Fₖ += (T[k-1] - T[k]) * α * (Tₜ - T[k]) # upward flux from layer k into k-1
+        F[k] += Fₖ                              # accumulate fluxes
     end
 
     # Relax the uppermost level towards prescribed "tropopause temperature"

--- a/src/physics/longwave_radiation.jl
+++ b/src/physics/longwave_radiation.jl
@@ -4,13 +4,14 @@ export NoLongwave
 struct NoLongwave <: AbstractLongwave end
 NoLongwave(SG::SpectralGrid) = NoLongwave()
 initialize!(::NoLongwave, ::PrimitiveEquation) = nothing
+longwave_radiation!(::ColumnVariables, ::NoLongwave, ::PrimitiveEquation) = nothing
 
 # function barrier for all AbstractLongwave
 function longwave_radiation!(column::ColumnVariables, model::PrimitiveEquation)
     longwave_radiation!(column, model.longwave_radiation, model)
 end
 
-longwave_radiation!(::ColumnVariables, ::NoLongwave, ::PrimitiveEquation) = nothing
+## UNIFORM COOLING
 
 export UniformCooling
 Base.@kwdef struct UniformCooling{NF} <: AbstractLongwave
@@ -44,4 +45,67 @@ function longwave_radiation!(
     @inbounds for k in eachlayer(column)
         temp_tend[k] += temp[k] > temp_min ? cooling : (temp_stratosphere - temp[k])*τ⁻¹
     end
+end
+
+## JEEVANJEE TEMPERATURE FLUX
+
+export JeevanjeeRadiation
+"""
+Temperature flux longwave radiation from Jeevanjee and Romps, 2018,
+following Seeley and Wordsworth, 2023, eq (1)
+
+    dF/dT = α*(T_t - T)
+
+with `F` the upward temperature flux between two layers with temperature
+difference `dT`, `α = 0.025 W/m²/K²` and `T_t = 200K` a prescribed tropopause
+temperature. Flux into the lowermost layer is 0. Flux out of uppermost
+layer also 0, but `dT/dt = (T_t - T)/τ` is added to relax the uppermost
+layer towards the tropopause temperature `T_t` with time scale `τ = 24h`
+(Seeley and Wordsworth, 2023 use 6h, which is unstable a low resolutions here).
+Fields are
+$(TYPEDFIELDS)"""
+Base.@kwdef struct JeevanjeeRadiation{NF} <: AbstractLongwave
+    "Radiative forcing constant (W/m²/K²)"
+    α::NF = 0.025
+
+    "Tropopause temperature [K]"
+    temp_tropopause::NF = 200
+
+    "Tropopause relaxation time scale to temp_tropopause"
+    time_scale::Second = Hour(24)
+end
+
+JeevanjeeRadiation(SG::SpectralGrid; kwargs...) = JeevanjeeRadiation{SG.NF}(; kwargs...)
+initialize!(scheme::JeevanjeeRadiation, model::PrimitiveEquation) = nothing
+
+# function barrier
+function longwave_radiation!(
+    column::ColumnVariables,
+    scheme::JeevanjeeRadiation,
+    model::PrimitiveEquation,
+)
+    longwave_radiation!(column, scheme)
+end
+
+function longwave_radiation!(
+    column::ColumnVariables{NF},
+    scheme::JeevanjeeRadiation,
+) where NF
+
+    (; nlev, temp_tend) = column
+    T = column.temp                 # to match Seeley, 2023 notation
+    F = column.flux_temp_upward
+    (; α, time_scale) = scheme
+    Tₜ = scheme.temp_tropopause
+    
+    Fₖ::NF = 0                      # flux into lowermost layer from below
+
+    @inbounds for k in nlev-1:-1:1
+        # Seeley and Wordsworth, 2023 eq (1)
+        Fₖ = Fₖ + (T[k] - T[k+1])*α*(Tₜ - T[k+1])   # upward flux from layer k+1 into k
+        F[k+1] += Fₖ                                # flux vector uses k+1 to store, accumulate
+    end
+
+    # Relax the uppermost level towards prescribed "tropopause temperature"
+    temp_tend[1] += (Tₜ - T[1])/time_scale.value
 end

--- a/src/physics/shortwave_radiation.jl
+++ b/src/physics/shortwave_radiation.jl
@@ -1,47 +1,42 @@
 abstract type AbstractRadiation <: AbstractParameterization end
 abstract type AbstractShortwave <: AbstractRadiation end
 
-export NoShortwave
-struct NoShortwave <: AbstractShortwave end
-NoShortwave(SG::SpectralGrid) = NoShortwave()
-initialize!(::NoShortwave, ::PrimitiveEquation) = nothing
-
 # function barrier for all AbstractShortwave
 function shortwave_radiation!(column::ColumnVariables, model::PrimitiveEquation)
     shortwave_radiation!(column, model.shortwave_radiation, model)
 end
 
+## NO SHORTWAVE RADIATION
+export NoShortwave
+struct NoShortwave <: AbstractShortwave end
+NoShortwave(SG::SpectralGrid) = NoShortwave()
+initialize!(::NoShortwave, ::PrimitiveEquation) = nothing
 shortwave_radiation!(::ColumnVariables, ::NoShortwave, ::PrimitiveEquation) = nothing
 
+## SHORTWAVE RADIATION FOR A FULLY TRANSPARENT ATMOSPHERE
 export TransparentShortwave
 Base.@kwdef struct TransparentShortwave{NF} <: AbstractShortwave
-    albedo::NF = 0.3
-    S::Base.RefValue{NF} = Ref(zero(NF))
+    albedo::NF = 0.8
 end
 
-TransparentShortwave(SG::SpectralGrid) = TransparentShortwave{SG.NF}()
-
-function initialize!(scheme::TransparentShortwave, model::PrimitiveEquation)
-    (; solar_constant, gravity) = model.planet
-    (; pres_ref) = model.atmosphere
-    cₚ = model.atmosphere.heat_capacity
-    Δσ = model.geometry.σ_levels_thick
-    scheme.S[] = (1 - scheme.albedo) * solar_constant * gravity / (Δσ[end] * pres_ref * cₚ)
-end
+TransparentShortwave(SG::SpectralGrid; kwargs...) = TransparentShortwave{SG.NF}(; kwargs...)
+initialize!(::TransparentShortwave, ::PrimitiveEquation) = nothing
 
 function shortwave_radiation!(
     column::ColumnVariables,
     scheme::TransparentShortwave,
     model::PrimitiveEquation,
 )
-    shortwave_radiation!(column, scheme, model.solar_zenith)
+    shortwave_radiation!(column, scheme, model.planet)
 end
 
 function shortwave_radiation!(
     column::ColumnVariables,
     scheme::TransparentShortwave,
-    solar_zenith::AbstractZenith,
+    planet::AbstractPlanet,
 )
-    cos_zenith = solar_zenith.cos_zenith[column.ij]
-    column.temp_tend[end] += cos_zenith*scheme.S[]
+    (; cos_zenith) = column
+    (; albedo) = scheme
+    (; solar_constant) = planet
+    column.flux_temp_upward[end] += (1-albedo) * solar_constant * cos_zenith
 end

--- a/src/physics/shortwave_radiation.jl
+++ b/src/physics/shortwave_radiation.jl
@@ -15,11 +15,8 @@ shortwave_radiation!(::ColumnVariables, ::NoShortwave, ::PrimitiveEquation) = no
 
 ## SHORTWAVE RADIATION FOR A FULLY TRANSPARENT ATMOSPHERE
 export TransparentShortwave
-Base.@kwdef struct TransparentShortwave{NF} <: AbstractShortwave
-    albedo::NF = 0.8
-end
-
-TransparentShortwave(SG::SpectralGrid; kwargs...) = TransparentShortwave{SG.NF}(; kwargs...)
+struct TransparentShortwave <: AbstractShortwave end
+TransparentShortwave(SG::SpectralGrid) = TransparentShortwave()
 initialize!(::TransparentShortwave, ::PrimitiveEquation) = nothing
 
 function shortwave_radiation!(
@@ -35,8 +32,7 @@ function shortwave_radiation!(
     scheme::TransparentShortwave,
     planet::AbstractPlanet,
 )
-    (; cos_zenith) = column
-    (; albedo) = scheme
+    (; cos_zenith, albedo) = column
     (; solar_constant) = planet
     column.flux_temp_upward[end] += (1-albedo) * solar_constant * cos_zenith
 end

--- a/src/physics/tendencies.jl
+++ b/src/physics/tendencies.jl
@@ -13,7 +13,7 @@ function parameterization_tendencies!(
     model::PrimitiveEquation,
 )
     # TODO move into shortwave radiation code?
-    cos_zenith!(time, model)
+    cos_zenith!(diagn, time, model)
 
     G = model.geometry
     rings = eachring(G.Grid, G.nlat_half)

--- a/src/physics/tendencies.jl
+++ b/src/physics/tendencies.jl
@@ -12,7 +12,7 @@ function parameterization_tendencies!(
     time::DateTime,
     model::PrimitiveEquation,
 )
-    # TODO move into shortwave radiation code
+    # TODO move into shortwave radiation code?
     cos_zenith!(time, model)
 
     G = model.geometry
@@ -91,7 +91,7 @@ function fluxes_to_tendencies!(
     # fluxes are defined on half levels including top k=1/2 and surface k=nlev+1/2
     @inbounds for k in 1:nlev
 
-        # Absorbed flux in a given layer, i.e. flux in minus flux out from above and below
+        # Absorbed flux in a given layer, i.e. flux in minus flux out from above and below
         # Fortran SPEEDY documentation eq. (2)
         ΔF_u = (flux_u_upward[k+1] - flux_u_upward[k]) +
             (flux_u_downward[k] - flux_u_downward[k+1])

--- a/src/physics/zenith.jl
+++ b/src/physics/zenith.jl
@@ -140,10 +140,10 @@ export SolarZenith
 """Solar zenith angle varying with daily and seasonal cycle.
 $(TYPEDFIELDS)"""
 Base.@kwdef struct SolarZenith{NF<:AbstractFloat, Grid<:AbstractGrid{NF}} <: AbstractZenith{NF, Grid}
-    # DIMENSIONS
+    # DIMENSIONS
     nlat_half::Int
 
-    # OPTIONS
+    # OPTIONS
     length_of_day::Second = Hour(24)
     length_of_year::Second = Day(365.25)
     equation_of_time::Bool = true
@@ -243,10 +243,10 @@ export SolarZenithSeason
 """Solar zenith angle varying with seasonal cycle only.
 $(TYPEDFIELDS)"""
 Base.@kwdef struct SolarZenithSeason{NF<:AbstractFloat, Grid<:AbstractGrid{NF}} <: AbstractZenith{NF, Grid}
-    # DIMENSIONS
+    # DIMENSIONS
     nlat_half::Int
 
-    # OPTIONS
+    # OPTIONS
     length_of_day::Second = Hour(24)
     length_of_year::Second = Day(365.25)
     seasonal_cycle::Bool = true
@@ -291,7 +291,7 @@ function cos_zenith!(
             
         ϕ = lat[j]
         h₀ = abs(δ) + abs(ϕ) < π/2 ?        # polar day/night?
-        acos(-tan(ϕ) * tan(δ)) :            # if not: calculate length of day
+        acos(-tan(ϕ) * tan(δ)) :            # if not: calculate length of day
         ϕ*δ > 0 ? π : 0                     # polar day if signs are equal, otherwise polar night
         
         sinϕ, cosϕ = sinlat[j], coslat[j]

--- a/src/physics/zenith.jl
+++ b/src/physics/zenith.jl
@@ -1,6 +1,6 @@
 abstract type AbstractSolarDeclination end
 abstract type AbstractSolarTimeCorrection end
-abstract type AbstractZenith{NF, Grid} end
+abstract type AbstractZenith end
 
 """Coefficients to calculate the solar declination angle δ [radians] based on a simple
 sine function, with Earth's axial tilt as amplitude, equinox as phase shift.
@@ -109,24 +109,25 @@ given the parameters in model.planet. In both cases the seasonal cycle can
 be disabled, calculating the solar declination from the initial time
 instead of current time."""
 function WhichZenith(SG::SpectralGrid, P::AbstractPlanet; kwargs...)
-    (; NF, Grid, nlat_half) = SG
+    (; NF) = SG
     (; daily_cycle, seasonal_cycle, length_of_day, length_of_year) = P
     solar_declination = SinSolarDeclination(SG, P)
 
     if daily_cycle
-        return SolarZenith{NF, Grid{NF}}(;
-            nlat_half, length_of_day, length_of_year, solar_declination, seasonal_cycle, kwargs...)
+        return SolarZenith{NF}(;
+            length_of_day, length_of_year, solar_declination, seasonal_cycle, kwargs...)
 
     else
-        return SolarZenithSeason{NF, Grid{NF}}(;
-            nlat_half, length_of_day, length_of_year, solar_declination, seasonal_cycle, kwargs...)
+        return SolarZenithSeason{NF}(;
+            length_of_day, length_of_year, solar_declination, seasonal_cycle, kwargs...)
     end
 end
 
 # function barrier
-function cos_zenith!(time::DateTime, model::PrimitiveEquation)
+function cos_zenith!(diagn::DiagnosticVariables, time::DateTime, model::PrimitiveEquation)
     (; solar_zenith, geometry) = model
-    cos_zenith!(solar_zenith, time, geometry)
+    (; cos_zenith) = diagn.surface
+    cos_zenith!(cos_zenith, solar_zenith, time, geometry)
 end
 
 function Base.show(io::IO, L::AbstractZenith)
@@ -139,10 +140,7 @@ export SolarZenith
 
 """Solar zenith angle varying with daily and seasonal cycle.
 $(TYPEDFIELDS)"""
-Base.@kwdef struct SolarZenith{NF<:AbstractFloat, Grid<:AbstractGrid{NF}} <: AbstractZenith{NF, Grid}
-    # DIMENSIONS
-    nlat_half::Int
-
+Base.@kwdef struct SolarZenith{NF<:AbstractFloat} <: AbstractZenith
     # OPTIONS
     length_of_day::Second = Hour(24)
     length_of_year::Second = Day(365.25)
@@ -153,9 +151,7 @@ Base.@kwdef struct SolarZenith{NF<:AbstractFloat, Grid<:AbstractGrid{NF}} <: Abs
     solar_declination::SinSolarDeclination{NF} = SinSolarDeclination{NF}()
     time_correction::SolarTimeCorrection{NF} = SolarTimeCorrection{NF}()
 
-    # WORK ARRAYS
     initial_time::Base.RefValue{DateTime} = Ref(DEFAULT_DATE)
-    cos_zenith::Grid = zeros(Grid, nlat_half)
 end
 
 function initialize!(
@@ -164,7 +160,6 @@ function initialize!(
     model::ModelSetup
 )
     S.initial_time[] = initial_time     # to fix the season if no seasonal cycle
-    cos_zenith!(S, initial_time, model.geometry)
 end
 
 """
@@ -201,14 +196,15 @@ Calculate cos of solar zenith angle with a daily cycle
 at time `time`. Seasonal cycle or time correction may be disabled,
 depending on parameters in SolarZenith."""
 function cos_zenith!(
-    S::SolarZenith{NF},
+    cos_zenith::AbstractGrid{NF},
+    S::SolarZenith,
     time::DateTime,
     geometry::AbstractGeometry,
 ) where NF
 
     (; sinlat, coslat, lons) = geometry
-    (; cos_zenith, length_of_day, length_of_year) = S
-    @boundscheck geometry.nlat_half == S.nlat_half || throw(BoundsError)
+    (; length_of_day, length_of_year) = S
+    @boundscheck geometry.nlat_half == cos_zenith.nlat_half || throw(BoundsError)
 
     # g: angular fraction of year [0...2π] for Jan-01 to Dec-31
     time_of_year = S.seasonal_cycle ? time : S.initial_time[]
@@ -242,10 +238,7 @@ export SolarZenithSeason
 
 """Solar zenith angle varying with seasonal cycle only.
 $(TYPEDFIELDS)"""
-Base.@kwdef struct SolarZenithSeason{NF<:AbstractFloat, Grid<:AbstractGrid{NF}} <: AbstractZenith{NF, Grid}
-    # DIMENSIONS
-    nlat_half::Int
-
+Base.@kwdef struct SolarZenithSeason{NF<:AbstractFloat} <: AbstractZenith
     # OPTIONS
     length_of_day::Second = Hour(24)
     length_of_year::Second = Day(365.25)
@@ -254,9 +247,7 @@ Base.@kwdef struct SolarZenithSeason{NF<:AbstractFloat, Grid<:AbstractGrid{NF}} 
     # COEFFICIENTS
     solar_declination::SinSolarDeclination{NF} = SinSolarDeclination{NF}()
 
-    # WORK ARRAYS
     initial_time::Base.RefValue{DateTime} = Ref(DEFAULT_DATE)
-    cos_zenith::Grid = zeros(Grid, nlat_half)
 end
 
 """
@@ -265,14 +256,15 @@ Calculate cos of solar zenith angle as daily average
 at time `time`. Seasonal cycle or time correction may be disabled,
 depending on parameters in SolarZenithSeason."""
 function cos_zenith!(
-    S::SolarZenithSeason{NF},
+    cos_zenith::AbstractGrid{NF},
+    S::SolarZenithSeason,
     time::DateTime,
     geometry::AbstractGeometry,
 ) where NF
 
     (; sinlat, coslat, lat) = geometry
-    (; cos_zenith, length_of_day, length_of_year) = S
-    @boundscheck geometry.nlat_half == S.nlat_half || throw(BoundsError)
+    (; length_of_day, length_of_year) = S
+    @boundscheck geometry.nlat_half == cos_zenith.nlat_half || throw(BoundsError)
 
     # g: angular fraction of year [0...2π] for Jan-01 to Dec-31
     time_of_year = S.seasonal_cycle ? time : S.initial_time[]

--- a/test/radiation.jl
+++ b/test/radiation.jl
@@ -1,0 +1,20 @@
+@testset "Longwave radiation" begin
+
+    spectral_grid = SpectralGrid(trunc=31, nlev=5)
+
+    for Radiation in (NoLongwave,
+                        UniformCooling,
+                        JeevanjeeRadiation)
+
+        longwave_radiation = Radiation(spectral_grid)
+        
+        for Model in (PrimitiveDryModel,
+                        PrimitiveWetModel)
+            model = Model(;spectral_grid, longwave_radiation)
+            model.feedback.verbose = false
+            simulation = initialize!(model)
+            run!(simulation, period=Day(3))
+            @test model.feedback.nars_detected == false
+        end
+    end     
+end


### PR DESCRIPTION
Implements the longwave radiation from [Seeley and Wordsworth, 2023](https://www.jacobtseeley.com/files/seeley2023.pdf) originally Jeevanjee and Romps, 2018 as outlined in #456. 

Changes the timescale of tropopause relexation from 6hours to 24hours as 6 hours seems to be unstable at low resolutions. 24h is totally sufficient to prevent a pile-up of radiation in the top-most layer which would otherwise be the case because layer 1 cannot radiate into outer space with 0-flux boundary conditions at top and surface.