### PR TITLE
Broadcasting for RingGrids

### DIFF
--- a/docs/src/analysis.md
+++ b/docs/src/analysis.md
@@ -338,19 +338,14 @@ We define a function ``total_enstrophy`` for this
 
 ```@example analysis
 function total_enstrophy(ζ, η, model)
-    h = zero(ζ)
-    q = zero(ζ)
-    Q = zero(ζ)
-    
-    # constants used by Speedy model
+    # constants from model
     H = model.atmosphere.layer_thickness
     Hb = model.orography.orography
-
-    f = coriolis(u)        # create f on that grid
+    f = coriolis(ζ)     # create f on the grid
     
-    @. h = η + H - Hb   # thickness
-    @. q = (ζ + f) / h  # Potential vorticity
-    @. Q = q^2 / 2      # Potential enstrophy
+    h = @. η + H - Hb   # thickness
+    q = @. (ζ + f) / h  # Potential vorticity
+    Q = @. q^2 / 2      # Potential enstrophy
 
     # transform to spectral, take l=m=0 mode at [1] and normalize for mean
     return Q_mean = real(spectral(Q)[1]) / model.spectral_transform.norm_sphere

--- a/docs/src/analysis.md
+++ b/docs/src/analysis.md
@@ -138,16 +138,12 @@ space for the global integral as before. Let us define a `total_energy` function
 ```@example analysis
 using SpeedyWeather
 function total_energy(u, v, η, model)
-    # allocate grid variable
-    h = zero(u)
-    E = zero(u)
-    
     H = model.atmosphere.layer_thickness
     Hb = model.orography.orography
     g = model.planet.gravity
     
-    @. h = η + H - Hb               # layer thickness between the bottom and free surface
-    @. E = h/2*(u^2 + v^2) + g*h^2  # vertically-integrated mechanical energy
+    h = @. η + H - Hb               # layer thickness between the bottom and free surface
+    E = @. h/2*(u^2 + v^2) + g*h^2  # vertically-integrated mechanical energy
 
     # transform to spectral, take l=m=0 mode at [1] and normalize for mean
     return E_mean = real(spectral(E)[1]) / model.spectral_transform.norm_sphere
@@ -218,14 +214,12 @@ f = coriolis(ζ)     # create f on that grid
 
 # layer thickness
 η = simulation.diagnostic_variables.surface.pres_grid
-h = zero(η)
 H = model.atmosphere.layer_thickness
 Hb = model.orography.orography
-@. h = η + H - Hb
+h = @. η + H - Hb
 
 # potential vorticity
-q = zero(ζ)
-@. q = (f + ζ) / h
+q = @. (f + ζ) / h
 nothing # hide
 ```
 
@@ -257,10 +251,6 @@ Following previous examples, let us define a `total_angular_momentum` function a
 using SpeedyWeather
 
 function total_angular_momentum(u, η, model)
-    # allocate grid variable
-    h = zero(u)
-    Λ = zero(u)
-    
     H = model.atmosphere.layer_thickness
     Hb = model.orography.orography
     R = model.spectral_grid.radius
@@ -268,8 +258,8 @@ function total_angular_momentum(u, η, model)
 
     r = R * cos.(model.geometry.lats)       # momentum arm for every grid point
     
-    @. h = η + H - Hb           # layer thickness between the bottom and free surface
-    @. Λ = (u*r + Ω*r^2) * h    # vertically-integrated AAM
+    h = @. η + H - Hb           # layer thickness between the bottom and free surface
+    Λ = @. (u*r + Ω*r^2) * h    # vertically-integrated AAM
 
     # transform to spectral, take l=m=0 mode at [1] and normalize for mean
     return Λ_mean = real(spectral(Λ)[1]) / model.spectral_transform.norm_sphere
@@ -306,10 +296,8 @@ Following previous fashion, we define a function `total_circulation` for this
 
 ```@example analysis
 function total_circulation(ζ, model)
-    f = coriolis(ζ)  # create f on that grid
-    C = zero(ζ)
-    @. C = ζ + f
-
+    f = coriolis(ζ)         # create f on the grid of ζ
+    C = ζ .+ f              # absolute vorticity
     # transform to spectral, take l=m=0 mode at [1] and normalize for mean
     return C_mean = real(spectral(C)[1]) / model.spectral_transform.norm_sphere
 end
@@ -385,9 +373,7 @@ to show how to global integral ``\iint dV`` can be written more efficiently
 # define a global integral, reusing a precomputed SpectralTransform S
 # times surface area of sphere omitted
 function ∬dA(v, h, S::SpectralTransform)
-    vh = zero(h)
-    @. vh = v * h
-    return real(spectral(vh, S)[1]) / S.norm_sphere
+    return real(spectral(v .* h, S)[1]) / S.norm_sphere
 end
 
 # use SpectralTransform from model
@@ -403,13 +389,6 @@ Now the `global_diagnostics` function is defined as
 
 ```@example analysis
 function global_diagnostics(u, v, ζ, η, model)
-    h = zero(u)     # preallocate grids of same size
-    q = zero(u)
-    λ = zero(u)
-    k = zero(u)
-    p = zero(u)
-    z = zero(u)
-
     # constants from model
     H = model.atmosphere.layer_thickness
     Hb = model.orography.orography
@@ -420,12 +399,12 @@ function global_diagnostics(u, v, ζ, η, model)
     r = R * cos.(model.geometry.lats)   # create r on that grid
     f = coriolis(u)                     # create f on that grid
     
-    @. h = η + H - Hb           # thickness
-    @. q = (ζ + f) / h          # potential vorticity
-    @. λ = u * r + Ω * r^2      # angular momentum
-    @. k = 1/2 * (u^2 + v^2)    # kinetic energy
-    @. p = 1/2 * g * h          # potential energy
-    @. z = q^2/2                # potential enstrophy
+    h = @. η + H - Hb           # thickness
+    q = @. (ζ + f) / h          # potential vorticity
+    λ = @. u * r + Ω * r^2      # angular momentum
+    k = @. 1/2 * (u^2 + v^2)    # kinetic energy
+    p = @. 1/2 * g * h          # potential energy
+    z = @. q^2/2                # potential enstrophy
 
     M = ∬dA(1, h, model)        # mean mass
     C = ∬dA(q, h, model)        # mean circulation
@@ -445,8 +424,7 @@ function global_diagnostics(diagn::DiagnosticVariables, model::ModelSetup)
     η = diagn.surface.pres_grid
     
     # vorticity during simulation is scaled by radius R, unscale here
-    ζ = zero(ζR)
-    @. ζ = ζR / diagn.scale[]
+    ζ = ζR ./ diagn.scale[]
 
     return global_diagnostics(u, v, ζ, η, model)
 end
@@ -526,7 +504,7 @@ function SpeedyWeather.callback!(
     
     M, C, Λ, K, P, Q = global_diagnostics(diagn, model)
     
-    # store current time and diagnostics for timestep i
+    # store current time and diagnostics for timestep i
     callback.time[i] = progn.clock.time
     callback.M[i] = M 
     callback.C[i] = C 
@@ -550,7 +528,7 @@ function SpeedyWeather.finish!(
     # create a netCDF file in current path
     ds = NCDataset(joinpath(pwd(), "global_diagnostics.nc"), "c")
     
-    # save diagnostics variables within
+    # save diagnostics variables within
     defDim(ds, "time", n_timesteps)
     defVar(ds, "time",                  callback.time,  ("time",))
     defVar(ds, "mass",                  callback.M,     ("time",))

--- a/docs/src/speedytransforms.md
+++ b/docs/src/speedytransforms.md
@@ -381,13 +381,9 @@ is obtained, and we do the following for ``f\zeta/g``.
 vor_grid = gridded(vor, Grid=spectral_grid.Grid)
 f = coriolis(vor_grid)      # create Coriolis parameter f on same grid with default rotation
 g = model.planet.gravity
-fζ_g = zero(f)              # preallocate on same grid
-@. fζ_g = vor_grid * f / g  # in-place and element-wise
+fζ_g = @. vor_grid * f / g  # in-place and element-wise
 nothing # hide
 ```
-The last two lines are a bit awkward for now, as the element-wise multiplication between
-two grids would escapes the grid and returns a vector that we wrap again into a Grid.
-However, by preallocating the new variable with `zero` we guarantee to stay on that grid.
 Now we need to apply the inverse Laplace operator to ``f\zeta/g`` which we do as follows
 
 ```@example speedytransforms

--- a/src/RingGrids/RingGrids.jl
+++ b/src/RingGrids/RingGrids.jl
@@ -7,6 +7,7 @@ import UnicodePlots
 # NUMERICS
 import Statistics: mean
 import FastGaussQuadrature
+import LinearAlgebra
 
 # GRIDS
 export  AbstractGrid,

--- a/src/RingGrids/full_grids.jl
+++ b/src/RingGrids/full_grids.jl
@@ -94,6 +94,8 @@ struct FullClenshawGrid{T} <: AbstractFullGrid{T}
         "L$nlat_half ($(4nlat_half)x$(2nlat_half - 1)) FullClenshawGrid{$T}.")
 end
 
+nonparametric_type(::Type{<:FullClenshawGrid}) = FullClenshawGrid
+
 # subtract the otherwise double-counted 4nlat_half equator points
 npoints_clenshaw(nlat_half::Integer) = 8nlat_half^2 - 4nlat_half
 nlat_half_clenshaw(npoints::Integer) = round(Int, 1/4 + sqrt(1/16 + npoints/8))  # inverse
@@ -123,6 +125,8 @@ struct FullGaussianGrid{T} <: AbstractFullGrid{T}
     new(data, nlat_half) : error("$(length(data))-element Vector{$(eltype(data))} cannot be used to create a "*
         "F$nlat_half ($(4nlat_half)x$(2nlat_half)) FullGaussianGrid{$T}.")
 end
+
+nonparametric_type(::Type{<:FullGaussianGrid}) = FullGaussianGrid
 
 npoints_gaussian(nlat_half::Integer) = 8nlat_half^2
 nlat_half_gaussian(npoints::Integer) = round(Int, sqrt(npoints/8))
@@ -154,6 +158,8 @@ struct FullHEALPixGrid{T} <: AbstractFullGrid{T}
         "H$nlat_half ($(4nlat_half)x$(2nlat_half-1)) FullHEALPixGrid{$T}.")
 end
 
+nonparametric_type(::Type{<:FullHEALPixGrid}) = FullHEALPixGrid
+
 npoints_fullhealpix(nlat_half::Integer) = 4nlat_half*(2nlat_half-1)
 nlat_half_fullhealpix(npoints::Integer) = round(Int, 1/4 + sqrt(1/16 + npoints/8))
 
@@ -181,6 +187,9 @@ struct FullOctaHEALPixGrid{T} <: AbstractFullGrid{T}
     new(data, nlat_half) : error("$(length(data))-element Vector{$(eltype(data))} cannot be used to create a "*
         "F$nlat_half ($(4nlat_half)x$(2nlat_half - 1)) FullOctaHEALPixGrid{$T}.")
 end
+
+nonparametric_type(::Type{<:FullOctaHEALPixGrid}) = FullOctaHEALPixGrid
+
 npoints_fulloctahealpix(nlat_half::Integer) = 8nlat_half^2 - 4nlat_half
 nlat_half_fulloctahealpix(npoints::Integer) = round(Int, 1/4 + sqrt(1/16 + npoints/8))
 

--- a/src/RingGrids/grids_general.jl
+++ b/src/RingGrids/grids_general.jl
@@ -234,12 +234,21 @@ get_nlon_max(grid::Grid) where {Grid<:AbstractGrid} = get_nlon_max(Grid, grid.nl
 ## BROADCASTING
 # following https://docs.julialang.org/en/v1/manual/interfaces/#man-interfaces-broadcasting
 import Base.Broadcast: BroadcastStyle, Broadcasted
-struct AbstractGridStyle{Grid} <: Broadcast.AbstractArrayStyle{1} end
-Base.BroadcastStyle(::Type{Grid}) where {Grid<:AbstractGrid} = AbstractGridStyle{nonparametric_type(Grid)}()
 
+# {1} as grids are <:AbstractVector, Grid here is the non-parameteric Grid type!
+struct AbstractGridStyle{Grid} <: Broadcast.AbstractArrayStyle{1} end
+
+# important to remove Grid{T} parameter T (eltype/number format) here to broadcast
+# automatically across the same grid type but with different T
+# e.g. FullGaussianGrid{Float32} and FullGaussianGrid{Float64}
+Base.BroadcastStyle(::Type{Grid}) where {Grid<:AbstractGrid} =
+    AbstractGridStyle{nonparametric_type(Grid)}()
+
+# allocation for broadcasting, create a new Grid with undef of type/number format T
 function Base.similar(bc::Broadcasted{AbstractGridStyle{Grid}}, ::Type{T}) where {Grid, T}
     Grid(Vector{T}(undef,length(bc)))
 end
 
+# ::Val{0} for broadcasting with 0-dimensional, ::Val{1} for broadcasting with vectors
 AbstractGridStyle{Grid}(::Val{0}) where Grid = AbstractGridStyle{Grid}()
 AbstractGridStyle{Grid}(::Val{1}) where Grid = AbstractGridStyle{Grid}()

--- a/src/RingGrids/grids_general.jl
+++ b/src/RingGrids/grids_general.jl
@@ -230,3 +230,16 @@ function get_nlons(Grid::Type{<:AbstractGrid}, nlat_half::Integer; both_hemisphe
 end
 
 get_nlon_max(grid::Grid) where {Grid<:AbstractGrid} = get_nlon_max(Grid, grid.nlat_half)
+
+## BROADCASTING
+# following https://docs.julialang.org/en/v1/manual/interfaces/#man-interfaces-broadcasting
+import Base.Broadcast: BroadcastStyle, Broadcasted
+struct AbstractGridStyle{Grid} <: Broadcast.AbstractArrayStyle{1} end
+Base.BroadcastStyle(::Type{Grid}) where {Grid<:AbstractGrid} = AbstractGridStyle{nonparametric_type(Grid)}()
+
+function Base.similar(bc::Broadcasted{AbstractGridStyle{Grid}}, ::Type{T}) where {Grid, T}
+    Grid(Vector{T}(undef,length(bc)))
+end
+
+AbstractGridStyle{Grid}(::Val{0}) where Grid = AbstractGridStyle{Grid}()
+AbstractGridStyle{Grid}(::Val{1}) where Grid = AbstractGridStyle{Grid}()

--- a/src/RingGrids/healpix.jl
+++ b/src/RingGrids/healpix.jl
@@ -123,6 +123,8 @@ struct HEALPixGrid{T} <: AbstractHEALPixGrid{T}
     "cannot be used to create an H$nlat_half HEALPixGrid{$T}.")
 end
 
+nonparametric_type(::Type{<:HEALPixGrid}) = HEALPixGrid
+
 # infer nlat_half from data vector length, infer parametric type from eltype of data
 HEALPixGrid{T}(data::AbstractVector) where T = HEALPixGrid{T}(data, nlat_half_healpix(length(data)))
 HEALPixGrid(data::AbstractVector, n::Integer...) = HEALPixGrid{eltype(data)}(data, n...)

--- a/src/RingGrids/octahealpix.jl
+++ b/src/RingGrids/octahealpix.jl
@@ -96,6 +96,8 @@ struct OctaHEALPixGrid{T} <: AbstractOctaHEALPixGrid{T}
     "cannot be used to create an H$nlat_half OctaHEALPixGrid{$T}.")
 end
 
+nonparametric_type(::Type{<:OctaHEALPixGrid}) = OctaHEALPixGrid
+
 npoints_octahealpix(nlat_half::Integer) = 4nlat_half^2
 nlat_half_octahealpix(npoints::Integer) = round(Int, sqrt(npoints/4))  # inverse of npoints_octahealpix
 nlat_octahealpix(nlat_half::Integer) = 2nlat_half-1

--- a/src/RingGrids/octahedral.jl
+++ b/src/RingGrids/octahedral.jl
@@ -98,6 +98,8 @@ struct OctahedralGaussianGrid{T} <: AbstractOctahedralGrid{T}
     "cannot be used to create a O$(nlat_half) OctahedralGaussianGrid{$T}.")
 end
 
+nonparametric_type(::Type{<:OctahedralGaussianGrid}) = OctahedralGaussianGrid
+
 # number of points and longitudes per ring on the octahedral grid
 npoints_octahedral(nlat_half::Integer, nlat_oddp::Bool) =
     nlat_oddp ? max(0, 4nlat_half^2 + 32nlat_half - 16) : 4nlat_half^2 + 36nlat_half # max(0, ...) needed to avoid negative array size when nlat_half==0
@@ -135,6 +137,8 @@ struct OctahedralClenshawGrid{T} <: AbstractOctahedralGrid{T}
     new(data, nlat_half) : error("$(length(data))-element Vector{$(eltype(data))}"*
     "cannot be used to create a O$(nlat_half) OctahedralClenshawGrid{$T}.")
 end
+
+nonparametric_type(::Type{<:OctahedralClenshawGrid}) = OctahedralClenshawGrid
 
 # infer nlat_half from data vector length, infer parametric type from eltype of data
 OctahedralClenshawGrid{T}(data::AbstractVector) where T = OctahedralClenshawGrid{T}(data,

--- a/src/dynamics/tendencies.jl
+++ b/src/dynamics/tendencies.jl
@@ -26,14 +26,14 @@ function dynamics_tendencies!(
 
     # for compatibility with other ModelSetups pressure pres = interface displacement η here
     forcing!(diagn, progn, forcing, time, model)    # = (Fᵤ, Fᵥ, Fₙ) forcing for u, v, η
-    drag!(diagn, progn, drag, time, model)          # drag term for momentum u, v
+    drag!(diagn, progn, drag, time, model)          # drag term for momentum u, v
     
     # = ∇×(v(ζ+f) + Fᵤ, -u(ζ+f) + Fᵥ), tendency for vorticity
     # = ∇⋅(v(ζ+f) + Fᵤ, -u(ζ+f) + Fᵥ), tendency for divergence
     vorticity_flux!(diagn, model)
                                            
     geopotential!(diagn, pres, planet)              # geopotential Φ = gη in shallow water
-    bernoulli_potential!(diagn, spectral_transform) # = -∇²(E+Φ), tendency for divergence
+    bernoulli_potential!(diagn, spectral_transform) # = -∇²(E+Φ), tendency for divergence
     
     # = -∇⋅(uh, vh), tendency for "pressure" η
     volume_flux_divergence!(diagn, surface, orography, atmosphere, geometry, spectral_transform)
@@ -60,33 +60,33 @@ function dynamics_tendencies!(  diagn::DiagnosticVariables,
     # nonlinear terms and parameterizations are always evaluated at lf
     lf_implicit = model.implicit.α == 0 ? lf : 1
 
-    pressure_gradient!(diagn, progn, lf, S)            # calculate ∇ln(pₛ)
+    pressure_gradient!(diagn, progn, lf, S)         # calculate ∇ln(pₛ)
 
     @floop for (diagn_layer, progn_layer) in zip(diagn.layers, progn.layers)
-        pressure_flux!(diagn_layer, surface)         # calculate (uₖ, vₖ)⋅∇ln(pₛ)
+        pressure_flux!(diagn_layer, surface)        # calculate (uₖ, vₖ)⋅∇ln(pₛ)
 
         # calculate Tᵥ = T + Tₖμq in spectral as a approxmation to Tᵥ = T(1+μq) used for geopotential
         linear_virtual_temperature!(diagn_layer, progn_layer, model, lf_implicit)
-        temperature_anomaly!(diagn_layer, I)         # temperature relative to profile
+        temperature_anomaly!(diagn_layer, I)        # temperature relative to profile
     end
 
-    geopotential!(diagn, GP, O)                       # from ∂Φ/∂ln(pₛ) = -RTᵥ, used in bernoulli_potential!
-    vertical_integration!(diagn, progn, lf_implicit, G)# get ū, v̄, D̄ on grid; and and D̄ in spectral
-    surface_pressure_tendency!(surface, S)           # ∂ln(pₛ)/∂t = -(ū, v̄)⋅∇ln(pₛ) - D̄
+    geopotential!(diagn, GP, O)                     # from ∂Φ/∂ln(pₛ) = -RTᵥ for bernoulli_potential!
+    vertical_integration!(diagn, progn, lf_implicit, G)# get ū, v̄, D̄ on grid; D̄ in spectral
+    surface_pressure_tendency!(surface, S)          # ∂ln(pₛ)/∂t = -(ū, v̄)⋅∇ln(pₛ) - D̄
 
     @floop for layer in diagn.layers
-        vertical_velocity!(layer, surface, G)         # calculate σ̇ for the vertical mass flux M = pₛσ̇
+        vertical_velocity!(layer, surface, G)       # calculate σ̇ for the vertical mass flux M = pₛσ̇
                                                     # add the RTₖlnpₛ term to geopotential
         linear_pressure_gradient!(layer, progn.surface, lf_implicit, A, I)
     end                                             # wait all because vertical_velocity! needs to
                                                     # finish before vertical_advection!
     @floop for layer in diagn.layers
-        vertical_advection!(layer, diagn, model)      # use σ̇ for the vertical advection of u, v, T, q
+        vertical_advection!(layer, diagn, model)    # use σ̇ for the vertical advection of u, v, T, q
 
-        vordiv_tendencies!(layer, surface, model)     # vorticity advection, pressure gradient term
-        temperature_tendency!(layer, model)          # hor. advection + adiabatic term
-        humidity_tendency!(layer, model)             # horizontal advection of humidity (nothing for wetcore)
-        bernoulli_potential!(layer, S)               # add -∇²(E+ϕ+RTₖlnpₛ) term to div tendency
+        vordiv_tendencies!(layer, surface, model)   # vorticity advection, pressure gradient term
+        temperature_tendency!(layer, model)         # hor. advection + adiabatic term
+        humidity_tendency!(layer, model)            # horizontal advection of humidity (nothing for wetcore)
+        bernoulli_potential!(layer, S)              # add -∇²(E+ϕ+RTₖlnpₛ) term to div tendency
     end
 end
 
@@ -287,7 +287,7 @@ function vertical_velocity!(
     surf::SurfaceVariables,
     G::Geometry,
 )
-    (; k) = diagn                                # vertical level
+    (; k) = diagn                               # vertical level
     Δσₖ = G.σ_levels_thick[k]                   # σ level thickness at k
     σk_half = G.σ_levels_half[k+1]              # σ at k+1/2
     σ̇ = diagn.dynamics_variables.σ_tend         # vertical mass flux M = pₛσ̇ at k+1/2
@@ -347,7 +347,7 @@ function vordiv_tendencies!(
     geometry::AbstractGeometry,
     S::SpectralTransform,
 )
-    (; R_dry) = atmosphere                      # gas constant for dry air
+    (; R_dry) = atmosphere                      # gas constant for dry air
     (; f) = coriolis                            # coriolis parameter
     (; coslat⁻¹) = geometry
 
@@ -472,13 +472,13 @@ function temperature_tendency!(
     
     # coefficients from Simmons and Burridge 1981
     σ_lnp_A = adiabatic_conversion.σ_lnp_A[diagn.k]         # eq. 3.12, -1/Δσₖ*ln(σ_k+1/2/σ_k-1/2)
-    σ_lnp_B = adiabatic_conversion.σ_lnp_B[diagn.k]         # eq. 3.12 -αₖ
+    σ_lnp_B = adiabatic_conversion.σ_lnp_B[diagn.k]         # eq. 3.12 -αₖ
     
     # semi-implicit: terms here are explicit+implicit evaluated at time step i
     # implicit_correction! then calculated the implicit terms from Vi-1 minus Vi
     # to move the implicit terms to i-1 which is cheaper then the alternative below
 
-    # Adiabatic conversion term following Simmons and Burridge 1981 but for σ coordinates 
+    # Adiabatic conversion term following Simmons and Burridge 1981 but for σ coordinates 
     # += as tend already contains parameterizations + vertical advection
     @. temp_tend_grid += temp_grid*div_grid +       # +T'D term of hori advection
         κ*(Tᵥ+Tₖ)*(                                 # +κTᵥ*Dlnp/Dt, adiabatic term
@@ -502,7 +502,7 @@ function humidity_tendency!(diagn::DiagnosticVariablesLayer,
     (; humid_tend, humid_tend_grid ) = diagn.tendencies
     (; humid_grid ) = diagn.grid_variables
 
-    # add horizontal advection to parameterization + vertical advection tendencies
+    # add horizontal advection to parameterization + vertical advection tendencies
     horizontal_advection!(humid_tend, humid_tend_grid, humid_grid, diagn, G, S, add=true)
 end
 
@@ -699,9 +699,9 @@ function bernoulli_potential!(  diagn::DiagnosticVariablesLayer{NF},
  
     half = convert(NF, 0.5)
     @. bernoulli_grid = half*(u_grid^2 + v_grid^2)          # = ½(u² + v²) on grid
-    spectral!(bernoulli, bernoulli_grid, S)                   # to spectral space
+    spectral!(bernoulli, bernoulli_grid, S)                 # to spectral space
     bernoulli .+= geopot                                    # add geopotential Φ
-    ∇²!(div_tend, bernoulli, S, add=true, flipsign=true)        # add -∇²(½(u² + v²) + ϕ)
+    ∇²!(div_tend, bernoulli, S, add=true, flipsign=true)    # add -∇²(½(u² + v²) + ϕ)
 end
 
 """
@@ -749,9 +749,9 @@ function volume_flux_divergence!(   diagn::DiagnosticVariablesLayer,
 
     # compute dynamic layer thickness h on the grid
     # pres_grid is η, the interface displacement, update to
-    # layer thickness h = η + H - Hb
-    # H is the layer thickness at rest without mountains
-    # Hb the orography
+    # layer thickness h = η + H - Hb
+    # H is the layer thickness at rest without mountains
+    # Hb the orography
     pres_grid .+= H .- orography
     
     # now do -∇⋅(uh, vh) and store in pres_tend
@@ -802,7 +802,7 @@ function SpeedyTransforms.gridded!( diagn::DiagnosticVariablesLayer,
     
     # get spectral U, V from spectral vorticity via stream function Ψ
     # U = u*coslat = -coslat*∂Ψ/∂lat
-    # V = v*coslat = ∂Ψ/∂lon, radius omitted in both cases
+    # V = v*coslat = ∂Ψ/∂lon, radius omitted in both cases
     UV_from_vor!(U, V, vor, S)
 
     # transform from U, V in spectral to u, v on grid (U, V = u, v*coslat)

--- a/test/grids.jl
+++ b/test/grids.jl
@@ -211,3 +211,48 @@ end
         end
     end
 end
+
+@testset "Grid broadcasting" begin
+    n = 2
+    @testset for G in ( FullClenshawGrid,
+                        FullGaussianGrid,
+                        OctahedralGaussianGrid,
+                        OctahedralClenshawGrid,
+                        HEALPixGrid,
+                        OctaHEALPixGrid,
+                        FullHEALPixGrid,
+                        FullOctaHEALPixGrid,
+                        )
+
+        @test zeros(G, n) .+ 1 == ones(G, n)
+        @test ones(G, n)  .- 1 == zeros(G, n)
+        @test ones(G, n)/1 == ones(G, n)
+        @test zeros(G, n) + ones(G, n) == ones(G, n)
+        @test 2ones(G, n) == ones(G, n) + ones(G, n)
+
+        # promote types, Grid{Float16} -> Grid{Float64} etc
+        @test all(ones(G{Float16}, n)*2.0 .=== 2.0)
+        @test all(ones(G{Float16}, n)*2f0 .=== 2f0)
+        @test all(ones(G{Float32}, n)*2.0 .=== 2.0)
+
+        # promote types across grids
+        @test all(ones(G{Float16}, n) + ones(G{Float32}, n) .=== 2f0)
+        @test all(ones(G{Float16}, n) + ones(G{Float64}, n) .=== 2.0)
+        @test all(ones(G{Float32}, n) + ones(G{Float64}, n) .=== 2.0)
+
+        # promote types across grids
+        @test all(ones(G{Float16}, n) - ones(G{Float32}, n) .=== 0f0)
+        @test all(ones(G{Float16}, n) - ones(G{Float64}, n) .=== 0.0)
+        @test all(ones(G{Float32}, n) - ones(G{Float64}, n) .=== 0.0)
+
+        # promote types across grids
+        @test all(ones(G{Float16}, n) .* ones(G{Float32}, n) .=== 1f0)
+        @test all(ones(G{Float16}, n) .* ones(G{Float64}, n) .=== 1.0)
+        @test all(ones(G{Float32}, n) .* ones(G{Float64}, n) .=== 1.0)
+
+        # promote types across grids
+        @test all(ones(G{Float16}, n) ./ ones(G{Float32}, n) .=== 1f0)
+        @test all(ones(G{Float16}, n) ./ ones(G{Float64}, n) .=== 1.0)
+        @test all(ones(G{Float32}, n) ./ ones(G{Float64}, n) .=== 1.0)
+    end 
+end


### PR DESCRIPTION
Previously we had broadcasting operations with RingGrids escaping the grid and returning just the underlying `Vector`
```julia
julia> G = ones(OctahedralGaussianGrid,1);

julia> G+G
40-element Vector{Float64}:
 2.0
 2.0
 ⋮
 2.0
 2.0
```
which was really annoying. While we don't use these operations inside the dynamical core (all in-place) in the documentation for example we always had allocate first and then in-place
```julia
A = zero(B)
@. A = B + 1
```
because otherwise the `B+1` operation would just return a vector again and so you lost the information of the grid.

Now this PR implements broadcasting for all `AbstractGrid`, meaning that `A+B`, `A-B`, `A.*B`, `A./B`, `A+1`, `A-1`, `2A`, `A*2.0`, `A/2` etc are all possible and a grid is returned again. This also works with type promotion, i.e. `FullGaussianGrid{Float32}` + `FullGaussianGrid{Float64}` will return that grid with eltype Float64 and same for the operations with scalars - like it also works with `Vector{T}`.

@miniufo In practice, this means that while previously we had to do
```julia
    h = zero(ζ)
    q = zero(ζ)
    
    H = model.atmosphere.layer_thickness
    Hb = model.orography.orography
    f = coriolis(ζ)        # create f on that grid
    
    @. h = η + H - Hb   # thickness
    @. q = (ζ + f) / h  # Potential vorticity
```
to calculate the potential vorticity, now you can just do
```julia
    H = model.atmosphere.layer_thickness
    Hb = model.orography.orography
    h = @. η + H - Hb   # thickness

    f = coriolis(ζ)     # create f on that grid
    q = @. (ζ + f) / h  # Potential vorticity
```