### PR TITLE
Particle advection time stepping corrected

### DIFF
--- a/src/dynamics/particle_advection.jl
+++ b/src/dynamics/particle_advection.jl
@@ -87,9 +87,6 @@ function initialize!(
     v0 = diagn.particles.v
     interpolate!(u0, u_grid, interpolator)
     interpolate!(v0, v_grid, interpolator)
-
-    print("PA: Initial velocities interpolated on initial locations")
-    @info (progn.clock.timestep_counter, progn.clock.time)
 end
 
 
@@ -116,9 +113,6 @@ function particle_advection!(
     # escape immediately if advection not on this timestep
     n = particle_advection.every_n_timesteps
     clock.timestep_counter % n == (n-1) || return nothing   
-
-    print("PA: ")
-    @info (clock.timestep_counter, clock.time + clock.Δt)
 
     # also escape if no particle is active
     any_active::Bool = false 

--- a/src/dynamics/particle_advection.jl
+++ b/src/dynamics/particle_advection.jl
@@ -1,10 +1,12 @@
 abstract type AbstractParticleAdvection <: AbstractModelComponent end
 
+# dummy no particle advection type
 export NoParticleAdvection
 struct NoParticleAdvection <: AbstractParticleAdvection end
 NoParticleAdvection(::SpectralGrid) = NoParticleAdvection()
 initialize!(::NoParticleAdvection, ::ModelSetup) = nothing
-particle_advection!(progn, diagn, lf, ::NoParticleAdvection) = nothing
+initialize!(particles, progn, diagn, ::NoParticleAdvection) = nothing
+particle_advection!(progn, diagn, ::NoParticleAdvection) = nothing
 
 export ParticleAdvection2D
 Base.@kwdef struct ParticleAdvection2D{NF} <: AbstractParticleAdvection

--- a/src/dynamics/particle_advection.jl
+++ b/src/dynamics/particle_advection.jl
@@ -108,10 +108,14 @@ function particle_advection!(
     length(particles) == 0 && return nothing
 
     # decide whether to execute on this time step:
-    # execute always on last time step *before* time step iscdivisible by
+    # execute always on last time step *before* time step is divisible by
     # `particle_advection.every_n_timesteps`, e.g. 7, 15, 23, ... for n=8 which
     # already contains u, v at i=8, 16, 24, etc as executed after `gridded!`
     # even though the clock hasn't be step forward yet, this means time = time + Δt here
+
+    # should not be called on the 1st step in first_timesteps, which is excluded
+    # with a lf2 == 2 check before this function is called
+        
     # escape immediately if advection not on this timestep
     n = particle_advection.every_n_timesteps
     clock.timestep_counter % n == (n-1) || return nothing   

--- a/src/dynamics/particles.jl
+++ b/src/dynamics/particles.jl
@@ -32,7 +32,7 @@ Particle{NF}(lon, lat) where NF = Particle{NF,true}(lon, lat, 0)
 Particle{NF, isactive}(lon, lat) where {NF, isactive} = Particle{NF, isactive}(lon, lat, 0)
 Particle{NF}(lon, lat, σ) where NF = Particle{NF,true}(lon, lat, σ)
 
-# promotion of arguments if NF not provided
+# promotion of arguments if NF not provided
 Particle(lon, lat) = Particle(lon, lat, 0)
 Particle(lon, lat, σ) = Particle{promote_type(typeof.((lon, lat, σ))...), true}(lon, lat, σ)
 Particle(lon::Integer, lat::Integer) = Particle(lon,lat,0)
@@ -57,10 +57,10 @@ end
 
 # equality with same location and same activity
 function Base.:(==)(p1::Particle{NF1,active1},p2::Particle{NF2,active2}) where {NF1,active1,NF2,active2}
-    return  (active1 == active2) &&     # both active or both inactive
-            (p1.lat == p2.lat) &&       # same latitude
+    return  (active1 == active2) &&     # both active or both inactive
+            (p1.lat == p2.lat) &&       # same latitude
             (p1.σ == p2.σ) &&           # same elevation
-            ((p1.lon == p2.lon) ||      # same longitude OR
+            ((p1.lon == p2.lon) ||      # same longitude OR
             (p1.lat*p2.lat == 8100))    # both at the north/south pole, because 90˚N, 0˚E == 90˚N, 10˚E
 end
 
@@ -69,10 +69,10 @@ function Base.isapprox(
     p2::Particle{NF2,active2};
     kwargs...,
 ) where {NF1,active1,NF2,active2}
-    b = (active1 == active2)                    # both active or both inactive
-    b &= isapprox(p1.lat, p2.lat; kwargs...)    # same latitude
+    b = (active1 == active2)                    # both active or both inactive
+    b &= isapprox(p1.lat, p2.lat; kwargs...)    # same latitude
     b &= isapprox(p1.σ, p2.σ; kwargs...)        # same elevation
-    c =  isapprox(p1.lon, p2.lon; kwargs...)    # same longitude OR
+    c =  isapprox(p1.lon, p2.lon; kwargs...)    # same longitude OR
     b &= c | isapprox(p1.lat * p2.lat, 8100; kwargs...) # both at the north/south pole
                                                         # because 90˚N, 0˚E == 90˚N, 10˚E
     return b

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -280,8 +280,6 @@ function timestep!( progn::PrognosticVariables{NF}, # all prognostic variables
     model.feedback.nars_detected && return nothing  # exit immediately if NaRs already present
     (; time) = progn.clock                           # current time
 
-    @info (progn.clock.timestep_counter, time)
-
     # set the tendencies back to zero for accumulation
     zero_tendencies!(diagn)
 

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -195,9 +195,7 @@ function first_timesteps!(
     progn::PrognosticVariables,         # all prognostic variables
     diagn::DiagnosticVariables,         # all pre-allocated diagnostic variables
     model::ModelSetup,                  # everything that is constant at runtime
-    output::AbstractOutputWriter,
 )
-    
     (; clock) = progn
     clock.n_timesteps == 0 && return nothing    # exit immediately for no time steps
     
@@ -227,7 +225,7 @@ function first_timesteps!(
     timestep!(clock, Δt_millisec) 
     
     # do output and callbacks after the first proper (from i=0 to i=1) time step
-    write_output!(output, clock.time, diagn)
+    write_output!(model.output, clock.time, diagn)
     callback!(model.callbacks, progn, diagn, model)
 
     # from now on precomputed implicit terms with 2Δt
@@ -242,10 +240,10 @@ Calculate a single time step for the `model <: Barotropic`."""
 function timestep!( 
     progn::PrognosticVariables,     # all prognostic variables
     diagn::DiagnosticVariables,     # all pre-allocated diagnostic variables
-    dt::Real,                       # time step (mostly =2Δt, but for init steps =Δt, Δt/2)
+    dt::Real,                       # time step (mostly =2Δt, but for first_timesteps! =Δt, Δt/2)
     model::Barotropic,              # everything that's constant at runtime
-    lf1::Int=2,                     # leapfrog index 1 (dis/enables Robert+Williams filter)
-    lf2::Int=2,                     # leapfrog index 2 (time step used for tendencies)
+    lf1::Integer=2,                 # leapfrog index 1 (dis/enables Robert+Williams filter)
+    lf2::Integer=2,                 # leapfrog index 2 (time step used for tendencies)
 )
     model.feedback.nars_detected && return nothing  # exit immediately if NaRs already present
     (; time) = progn.clock                           # current time
@@ -262,20 +260,22 @@ function timestep!(
         gridded!(diagn_layer, progn_lf, model)
     end
 
-    # PARTICLE ADVECTION
-    particle_advection!(progn, diagn, model.particle_advection)
+    # PARTICLE ADVECTION (always skip 1st step of first_timesteps!)
+    not_first_timestep = lf2 == 2
+    not_first_timestep && particle_advection!(progn, diagn, model.particle_advection)
 end
 
 """
 $(TYPEDSIGNATURES)
 Calculate a single time step for the `model <: ShallowWater`."""
-function timestep!( progn::PrognosticVariables{NF}, # all prognostic variables
-                    diagn::DiagnosticVariables{NF}, # all pre-allocated diagnostic variables
-                    dt::Real,                       # time step (mostly =2Δt, but for init steps =Δt, Δt/2)
-                    model::ShallowWater,            # everything that's constant at runtime
-                    lf1::Int=2,                     # leapfrog index 1 (dis/enables Robert+Williams filter)
-                    lf2::Int=2                      # leapfrog index 2 (time step used for tendencies)
-                    ) where {NF<:AbstractFloat}
+function timestep!( 
+    progn::PrognosticVariables,     # all prognostic variables
+    diagn::DiagnosticVariables,     # all pre-allocated diagnostic variables
+    dt::Real,                       # time step (mostly =2Δt, but for first_timesteps! =Δt, Δt/2)
+    model::ShallowWater,            # everything that's constant at runtime
+    lf1::Integer=2,                 # leapfrog index 1 (dis/enables Robert+Williams filter)
+    lf2::Integer=2,                 # leapfrog index 2 (time step used for tendencies)
+)
 
     model.feedback.nars_detected && return nothing  # exit immediately if NaRs already present
     (; time) = progn.clock                           # current time
@@ -304,20 +304,22 @@ function timestep!( progn::PrognosticVariables{NF}, # all prognostic variables
     leapfrog!(progn.surface, diagn.surface, dt, lf1, model)
     gridded!(pres_grid, pres, spectral_transform)
     
-    # PARTICLE ADVECTION
-    particle_advection!(progn, diagn, model.particle_advection)
+    # PARTICLE ADVECTION (always skip 1st step of first_timesteps!)
+    not_first_timestep = lf2 == 2
+    not_first_timestep && particle_advection!(progn, diagn, model.particle_advection)
 end
 
 """
 $(TYPEDSIGNATURES)
 Calculate a single time step for the `model<:PrimitiveEquation`"""
-function timestep!( progn::PrognosticVariables{NF}, # all prognostic variables
-                    diagn::DiagnosticVariables{NF}, # all pre-allocated diagnostic variables
-                    dt::Real,                       # time step (mostly =2Δt, but for init steps =Δt, Δt/2)
-                    model::PrimitiveEquation,       # everything that's constant at runtime
-                    lf1::Int=2,                     # leapfrog index 1 (dis/enables Robert+Williams filter)
-                    lf2::Int=2                      # leapfrog index 2 (time step used for tendencies)
-                    ) where {NF<:AbstractFloat}
+function timestep!( 
+    progn::PrognosticVariables,     # all prognostic variables
+    diagn::DiagnosticVariables,     # all pre-allocated diagnostic variables
+    dt::Real,                       # time step (mostly =2Δt, but for first_timesteps! =Δt, Δt/2)
+    model::PrimitiveEquation,       # everything that's constant at runtime
+    lf1::Integer=2,                 # leapfrog index 1 (dis/enables Robert+Williams filter)
+    lf2::Integer=2,                 # leapfrog index 2 (time step used for tendencies)
+)
 
     model.feedback.nars_detected && return nothing  # exit immediately if NaRs already present
     (; time) = progn.clock                           # current time
@@ -364,8 +366,9 @@ function timestep!( progn::PrognosticVariables{NF}, # all prognostic variables
         end
     end
 
-    # PARTICLE ADVECTION
-    particle_advection!(progn, diagn, model.particle_advection)
+    # PARTICLE ADVECTION (always skip 1st step of first_timesteps!)
+    not_first_timestep = lf2 == 2
+    not_first_timestep && particle_advection!(progn, diagn, model.particle_advection)
 end
 
 """
@@ -396,7 +399,7 @@ function time_stepping!(
     
     # FIRST TIMESTEPS: EULER FORWARD THEN 1x LEAPFROG
     # considered part of the model initialisation
-    first_timesteps!(progn, diagn, model, output)
+    first_timesteps!(progn, diagn, model)
     
     # only now initialise feedback for benchmark accuracy
     initialize!(feedback, clock, model)

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -263,7 +263,7 @@ function timestep!(
     end
 
     # PARTICLE ADVECTION
-    particle_advection!(progn, diagn, lf2, model.particle_advection)
+    particle_advection!(progn, diagn, model.particle_advection)
 end
 
 """
@@ -279,6 +279,8 @@ function timestep!( progn::PrognosticVariables{NF}, # all prognostic variables
 
     model.feedback.nars_detected && return nothing  # exit immediately if NaRs already present
     (; time) = progn.clock                           # current time
+
+    @info (progn.clock.timestep_counter, time)
 
     # set the tendencies back to zero for accumulation
     zero_tendencies!(diagn)
@@ -305,7 +307,7 @@ function timestep!( progn::PrognosticVariables{NF}, # all prognostic variables
     gridded!(pres_grid, pres, spectral_transform)
     
     # PARTICLE ADVECTION
-    particle_advection!(progn, diagn, lf2, model.particle_advection)
+    particle_advection!(progn, diagn, model.particle_advection)
 end
 
 """
@@ -365,7 +367,7 @@ function timestep!( progn::PrognosticVariables{NF}, # all prognostic variables
     end
 
     # PARTICLE ADVECTION
-    particle_advection!(progn, diagn, lf2, model.particle_advection)
+    particle_advection!(progn, diagn, model.particle_advection)
 end
 
 """
@@ -390,6 +392,7 @@ function time_stepping!(
     (; output, feedback) = model
     lf = 1                                  # use first leapfrog index
     gridded!(diagn, progn, lf, model)
+    initialize!(progn.particles, progn, diagn, model.particle_advection)
     initialize!(output, feedback, time_stepping, clock, diagn, model)
     initialize!(model.callbacks, progn, diagn, model)
     

--- a/test/spectral_gradients.jl
+++ b/test/spectral_gradients.jl
@@ -234,9 +234,9 @@ end
         SpeedyWeather.divergence!(div1, u_coslat⁻¹, v_coslat⁻¹, S)
 
         for lm in SpeedyWeather.eachharmonic(vor0, vor1, div0, div1)
-            # increased to 20 as 10 caused single fails every now and then
-            @test vor0[lm] ≈ vor1[lm] rtol=20*sqrt(eps(NF))
-            @test div0[lm] ≈ div1[lm] rtol=20*sqrt(eps(NF))
+            # increased to 30 as 10, 20 caused single fails every now and then
+            @test vor0[lm] ≈ vor1[lm] rtol=30*sqrt(eps(NF))
+            @test div0[lm] ≈ div1[lm] rtol=30*sqrt(eps(NF))
         end
     end
 end


### PR DESCRIPTION
Time stepping for particles is now

- initialized (i.e. $u(t=0), v(t=0)$ interpolated to initial particle locations for the predictor step
- then executed at the end of a time step just before the n-th time step, where u,v are already `gridded!` at $t=n\Delta t$ (even though the clock time didn't step forward yet)
- ignores the initial euler and unfiltered leapfrog step (as before)

So that (PA Particle advection, otherwise dynamics)

```julia
julia> run!(simulation, period=Day(1));
PA: Initial velocities interpolated on initial locations[ Info: (0, DateTime("2000-01-01T00:00:00"))
[ Info: (0, DateTime("2000-01-01T00:00:00"))
[ Info: (0, DateTime("2000-01-01T00:15:00"))
[ Info: (1, DateTime("2000-01-01T00:30:00"))
[ Info: (2, DateTime("2000-01-01T01:00:00"))
[ Info: (3, DateTime("2000-01-01T01:30:00"))
[ Info: (4, DateTime("2000-01-01T02:00:00"))
[ Info: (5, DateTime("2000-01-01T02:30:00"))
[ Info: (6, DateTime("2000-01-01T03:00:00"))
[ Info: (7, DateTime("2000-01-01T03:30:00"))
PA: [ Info: (7, DateTime("2000-01-01T04:00:00"))
[ Info: (8, DateTime("2000-01-01T04:00:00"))
[ Info: (9, DateTime("2000-01-01T04:30:00"))
[ Info: (10, DateTime("2000-01-01T05:00:00"))
[ Info: (11, DateTime("2000-01-01T05:30:00"))
[ Info: (12, DateTime("2000-01-01T06:00:00"))
[ Info: (13, DateTime("2000-01-01T06:30:00"))
[ Info: (14, DateTime("2000-01-01T07:00:00"))
[ Info: (15, DateTime("2000-01-01T07:30:00"))
PA: [ Info: (15, DateTime("2000-01-01T08:00:00"))
[ Info: (16, DateTime("2000-01-01T08:00:00"))
[ Info: (17, DateTime("2000-01-01T08:30:00"))
[ Info: (18, DateTime("2000-01-01T09:00:00"))
[ Info: (19, DateTime("2000-01-01T09:30:00"))
[ Info: (20, DateTime("2000-01-01T10:00:00"))
[ Info: (21, DateTime("2000-01-01T10:30:00"))
[ Info: (22, DateTime("2000-01-01T11:00:00"))
[ Info: (23, DateTime("2000-01-01T11:30:00"))
PA: [ Info: (23, DateTime("2000-01-01T12:00:00"))
[ Info: (24, DateTime("2000-01-01T12:00:00"))
[ Info: (25, DateTime("2000-01-01T12:30:00"))
[ Info: (26, DateTime("2000-01-01T13:00:00"))
[ Info: (27, DateTime("2000-01-01T13:30:00"))
[ Info: (28, DateTime("2000-01-01T14:00:00"))
[ Info: (29, DateTime("2000-01-01T14:30:00"))
[ Info: (30, DateTime("2000-01-01T15:00:00"))
[ Info: (31, DateTime("2000-01-01T15:30:00"))
PA: [ Info: (31, DateTime("2000-01-01T16:00:00"))
[ Info: (32, DateTime("2000-01-01T16:00:00"))
[ Info: (33, DateTime("2000-01-01T16:30:00"))
[ Info: (34, DateTime("2000-01-01T17:00:00"))
[ Info: (35, DateTime("2000-01-01T17:30:00"))
[ Info: (36, DateTime("2000-01-01T18:00:00"))
[ Info: (37, DateTime("2000-01-01T18:30:00"))
[ Info: (38, DateTime("2000-01-01T19:00:00"))
[ Info: (39, DateTime("2000-01-01T19:30:00"))
PA: [ Info: (39, DateTime("2000-01-01T20:00:00"))
[ Info: (40, DateTime("2000-01-01T20:00:00"))
[ Info: (41, DateTime("2000-01-01T20:30:00"))
[ Info: (42, DateTime("2000-01-01T21:00:00"))
[ Info: (43, DateTime("2000-01-01T21:30:00"))
[ Info: (44, DateTime("2000-01-01T22:00:00"))
[ Info: (45, DateTime("2000-01-01T22:30:00"))
[ Info: (46, DateTime("2000-01-01T23:00:00"))
[ Info: (47, DateTime("2000-01-01T23:30:00"))
PA: [ Info: (47, DateTime("2000-01-02T00:00:00"))
```
Note that the notion of time somewhat different

- dynamics: the denoted time is time $t$ where the tendencies are evaluated to leapfrog from $t-\Delta t$ over $t$ to $t+\Delta t$ (hence the integration ends at t = 24h)
- particle advection: the denoted time $t$ is the time where the Heun step *ends*, so particle advection steps from $t-\Delta$ to $t$ with velocity at $t-\Delta t$ (the predictor step) averaged with the velocity at $t$ (the corrector step)

We may illustrate this as follows. Note two half steps in `first_timsteps!` to get from 0 to 0 (Euler forward, not counted) and from 0 to 1 (unfiltered leapfrog)

Dynamics (step i):
`| -- | -- | ------ | ------ | ------ | ------ | ------ | ------ | ------ |`
`0    0    1        2        3        4        5        6        7        8`
Particle advection (step j, every 4th dynamics step)
`| -- | -- | ------ | ------ | ------ | ------ | ------ | ------ | ------ |`
`0->P1                            C1->1->P2                           C2->2`

So that to get from particle step j=0 to j=1 it's the average betwee predictor step P1 which uses velocities at i=0 (stored during initialisation) and corrector step C1 which uses velocities at i=4; which is also directly used to interpolate and store velocities for predictor step P2 which is then averaged with corrector step C2 using velocities at i=8 to get from particle step j=1 to j=2 when the dynamics have reached i=8.
