### PR TITLE
Fix RingGrid broadcast issue with mismatching dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ## Unreleased
 
+* Fixed a bug in `RingGrids`, so that now broadcasts are defined even when the dimensions mismatch in some cases 
+  
 ## v0.11.0

--- a/src/RingGrids/general.jl
+++ b/src/RingGrids/general.jl
@@ -410,12 +410,12 @@ end
 AbstractGPUGridArrayStyle{N, ArrayType, Grid}(::Val{N}) where {N, ArrayType, Grid} =
     AbstractGPUGridArrayStyle{N, ArrayType, Grid}()
 
-AbstractGPUGridArrayStyle{1, ArrayType, Grid}(::Val{2}) where {Grid} = AbstractGPUGridArrayStyle{2, ArrayType, Grid}()
-AbstractGPUGridArrayStyle{1, ArrayType, Grid}(::Val{0}) where {Grid} = AbstractGPUGridArrayStyle{1, ArrayType, Grid}()
-AbstractGPUGridArrayStyle{2, ArrayType, Grid}(::Val{3}) where {Grid} = AbstractGPUGridArrayStyle{3, ArrayType, Grid}()
-AbstractGPUGridArrayStyle{2, ArrayType, Grid}(::Val{1}) where {Grid} = AbstractGPUGridArrayStyle{2, ArrayType, Grid}()
-AbstractGPUGridArrayStyle{3, ArrayType, Grid}(::Val{4}) where {Grid} = AbstractGPUGridArrayStyle{4, ArrayType, Grid}()
-AbstractGPUGridArrayStyle{3, ArrayType, Grid}(::Val{2}) where {Grid} = AbstractGPUGridArrayStyle{3, ArrayType, Grid}()
+AbstractGPUGridArrayStyle{1, ArrayType, Grid}(::Val{2}) where {ArrayType, Grid} = AbstractGPUGridArrayStyle{2, ArrayType, Grid}()
+AbstractGPUGridArrayStyle{1, ArrayType, Grid}(::Val{0}) where {ArrayType, Grid} = AbstractGPUGridArrayStyle{1, ArrayType, Grid}()
+AbstractGPUGridArrayStyle{2, ArrayType, Grid}(::Val{3}) where {ArrayType, Grid} = AbstractGPUGridArrayStyle{3, ArrayType, Grid}()
+AbstractGPUGridArrayStyle{2, ArrayType, Grid}(::Val{1}) where {ArrayType, Grid} = AbstractGPUGridArrayStyle{2, ArrayType, Grid}()
+AbstractGPUGridArrayStyle{3, ArrayType, Grid}(::Val{4}) where {ArrayType, Grid} = AbstractGPUGridArrayStyle{4, ArrayType, Grid}()
+AbstractGPUGridArrayStyle{3, ArrayType, Grid}(::Val{2}) where {ArrayType, Grid} = AbstractGPUGridArrayStyle{3, ArrayType, Grid}()
     
 function GPUArrays.backend(
     ::Type{Grid}

--- a/src/RingGrids/general.jl
+++ b/src/RingGrids/general.jl
@@ -387,7 +387,14 @@ function Base.similar(bc::Broadcasted{AbstractGridArrayStyle{N, Grid}}, ::Type{T
 end
 
 # ::Val{0} for broadcasting with 0-dimensional, ::Val{1} for broadcasting with vectors, etc
-AbstractGridArrayStyle{N, Grid}(::Val{M}) where {N, Grid, M} = AbstractGridArrayStyle{N, Grid}()
+# when there's a dimension mismatch always choose the larger dimension
+AbstractGridArrayStyle{N, Grid}(::Val{N}) where {N, Grid} = AbstractGridArrayStyle{N, Grid}()
+AbstractGridArrayStyle{1, Grid}(::Val{2}) where {Grid} = AbstractGridArrayStyle{2, Grid}()
+AbstractGridArrayStyle{1, Grid}(::Val{0}) where {Grid} = AbstractGridArrayStyle{1, Grid}()
+AbstractGridArrayStyle{2, Grid}(::Val{3}) where {Grid} = AbstractGridArrayStyle{3, Grid}()
+AbstractGridArrayStyle{2, Grid}(::Val{1}) where {Grid} = AbstractGridArrayStyle{2, Grid}()
+AbstractGridArrayStyle{3, Grid}(::Val{4}) where {Grid} = AbstractGridArrayStyle{4, Grid}()
+AbstractGridArrayStyle{3, Grid}(::Val{2}) where {Grid} = AbstractGridArrayStyle{3, Grid}()
 
 ## GPU
 struct AbstractGPUGridArrayStyle{N, ArrayType, Grid} <: GPUArrays.AbstractGPUArrayStyle{N} end
@@ -399,9 +406,17 @@ function Base.BroadcastStyle(
 end
 
 # ::Val{0} for broadcasting with 0-dimensional, ::Val{1} for broadcasting with vectors, etc
-AbstractGPUGridArrayStyle{N, ArrayType, Grid}(::Val{M}) where {N, ArrayType, Grid, M} =
+# when there's a dimension mismatch always choose the larger dimension
+AbstractGPUGridArrayStyle{N, ArrayType, Grid}(::Val{N}) where {N, ArrayType, Grid} =
     AbstractGPUGridArrayStyle{N, ArrayType, Grid}()
 
+AbstractGPUGridArrayStyle{1, ArrayType, Grid}(::Val{2}) where {Grid} = AbstractGPUGridArrayStyle{2, ArrayType, Grid}()
+AbstractGPUGridArrayStyle{1, ArrayType, Grid}(::Val{0}) where {Grid} = AbstractGPUGridArrayStyle{1, ArrayType, Grid}()
+AbstractGPUGridArrayStyle{2, ArrayType, Grid}(::Val{3}) where {Grid} = AbstractGPUGridArrayStyle{3, ArrayType, Grid}()
+AbstractGPUGridArrayStyle{2, ArrayType, Grid}(::Val{1}) where {Grid} = AbstractGPUGridArrayStyle{2, ArrayType, Grid}()
+AbstractGPUGridArrayStyle{3, ArrayType, Grid}(::Val{4}) where {Grid} = AbstractGPUGridArrayStyle{4, ArrayType, Grid}()
+AbstractGPUGridArrayStyle{3, ArrayType, Grid}(::Val{2}) where {Grid} = AbstractGPUGridArrayStyle{3, ArrayType, Grid}()
+    
 function GPUArrays.backend(
     ::Type{Grid}
 ) where {Grid <: AbstractGridArray{T, N, ArrayType}} where {T, N, ArrayType <: GPUArrays.AbstractGPUArray}

--- a/test/grids.jl
+++ b/test/grids.jl
@@ -311,6 +311,18 @@ end
         @test all(ones(G{Float16}, n) ./ ones(G{Float32}, n) .=== 1f0)
         @test all(ones(G{Float16}, n) ./ ones(G{Float64}, n) .=== 1.0)
         @test all(ones(G{Float32}, n) ./ ones(G{Float64}, n) .=== 1.0)
+
+        # dimension mismatches, but still broadcasting
+        g1 = rand(G, n)
+        g2 = rand(G, n, 1)
+        g2_2 = rand(G, n, 2)
+        g3 = rand(G, n, 1, 1)
+
+        @test (g1 .* g2)[:,1] == (g1 .* g2[:,1])
+        @test (g2 .* g1)[:,1] == (g1 .* g2[:,1])
+        @test (g2 .* g3)[:,1,1] == (g2[:,1] .* g3[:,1,1])
+        @test (g1 .* g2_2)[:,1] == (g1 .* g2_2[:,1])
+        @test (g1 .* g2_2)[:,2] == (g1 .* g2_2[:,2])
     end 
 end
 


### PR DESCRIPTION
Fixes #565 

Just needed a look into the Julia docs to figure it out. 

Unfortunately the solution is a bit "ugly" and not completely general as Julia doesn't allow any arithmetics with type parameters (e.g. `Grid{N+1}`) doesn't work 