### PR TITLE
Benchmarks for individual dynamics functions

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+SpeedyWeather = "9e226e20-d153-4fed-8a5b-493def4f21a9"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-created for SpeedyWeather.jl v0.9.0 on Tue, 02 Apr 2024 14:05:51. 
+created for SpeedyWeather.jl v0.10.0 on Wed, 25 Sep 2024 18:36:59. 
 
 All simulations have been benchmarked over several seconds (wallclock time) without output. Benchmarking excludes initialization and is started just before the main time loop and finishes right after. The benchmarking results here are not very robust, timings that change with +-50% are not uncommon. Proper benchmarking for performance optimization uses the minimum or median of many executions, while we run a simulation for several time steps which effectively represents the mean, susceptible to outliers that slow down the simulation. However, this is what a user will experience in most situations anyway and the following therefore presents a rough idea of how fast a SpeedyWeather simulation will run, and how much memory it requires.
 
@@ -9,19 +9,17 @@ All simulations have been benchmarked over several seconds (wallclock time) with
 All benchmark simulation were single-threaded on a CPU:
 ```julia
 julia> versioninfo()
-Julia Version 1.10.2
-Commit bd47eca2c8a (2024-03-01 10:14 UTC)
+Julia Version 1.10.4
+Commit 48d4fd48430 (2024-06-04 10:41 UTC)
 Build Info:
   Official https://julialang.org/ release
 Platform Info:
-  OS: macOS (x86_64-apple-darwin22.4.0)
-  CPU: 8 × Intel(R) Core(TM) i5-1030NG7 CPU @ 1.10GHz
+  OS: macOS (arm64-apple-darwin22.4.0)
+  CPU: 8 × Apple M3
   WORD_SIZE: 64
   LIBM: libopenlibm
-  LLVM: libLLVM-15.0.7 (ORCJIT, icelake-client)
-Threads: 1 default, 0 interactive, 1 GC (on 8 virtual cores)
-Environment:
-  LD_LIBRARY_PATH = /Users/milan/.julia/conda/3/lib:
+  LLVM: libLLVM-15.0.7 (ORCJIT, apple-m1)
+Threads: 1 default, 0 interactive, 1 GC (on 4 virtual cores)
 ```
 
 ### Explanation
@@ -49,73 +47,94 @@ inside `the SpeedyWeather.jl/benchmark` folder. It will create this `README.md` 
 
 | Model | T | L | Physics | Δt | SYPD | Memory|
 | - | - | - | - | - | - | - |
-| BarotropicModel | 31 | 1 | false | 1800 | 19349 | 1.22 MB |
-| ShallowWaterModel | 31 | 1 | false | 1800 | 10195 | 1.24 MB |
-| PrimitiveDryModel | 31 | 8 | true | 1800 | 530 | 3.95 MB |
-| PrimitiveWetModel | 31 | 8 | true | 1800 | 399 | 4.28 MB |
+| BarotropicModel | 31 | 1 | false | 1800 | 59137 | 1.17 MB |
+| ShallowWaterModel | 31 | 1 | false | 1800 | 35866 | 1.19 MB |
+| PrimitiveDryModel | 31 | 8 | true | 1800 | 1656 | 4.11 MB |
+| PrimitiveWetModel | 31 | 8 | true | 1800 | 1249 | 4.47 MB |
 
 ## Grids
 
 | Model | T | L | Grid | Rings | Δt | SYPD | Memory|
 | - | - | - | - | - | - | - | - |
-| PrimitiveWetModel | 63 | 8 | FullGaussianGrid | 96 | 900 | 35 | 22.50 MB |
-| PrimitiveWetModel | 63 | 8 | FullClenshawGrid | 95 | 900 | 34 | 22.29 MB |
-| PrimitiveWetModel | 63 | 8 | OctahedralGaussianGrid | 96 | 900 | 45 | 15.34 MB |
-| PrimitiveWetModel | 63 | 8 | OctahedralClenshawGrid | 95 | 900 | 54 | 15.12 MB |
-| PrimitiveWetModel | 63 | 8 | HEALPixGrid | 95 | 900 | 77 | 11.46 MB |
-| PrimitiveWetModel | 63 | 8 | OctaHEALPixGrid | 95 | 900 | 56 | 13.67 MB |
+| PrimitiveWetModel | 63 | 8 | FullGaussianGrid | 96 | 900 | 107 | 23.40 MB |
+| PrimitiveWetModel | 63 | 8 | FullClenshawGrid | 95 | 900 | 134 | 23.19 MB |
+| PrimitiveWetModel | 63 | 8 | OctahedralGaussianGrid | 96 | 900 | 145 | 15.91 MB |
+| PrimitiveWetModel | 63 | 8 | OctahedralClenshawGrid | 95 | 900 | 193 | 15.68 MB |
+| PrimitiveWetModel | 63 | 8 | HEALPixGrid | 95 | 900 | 192 | 11.86 MB |
+| PrimitiveWetModel | 63 | 8 | OctaHEALPixGrid | 95 | 900 | 186 | 14.16 MB |
 
 ## Primitive wet model, resolution
 
 | Model | T | L | Rings | Δt | SYPD | Memory|
 | - | - | - | - | - | - | - |
-| PrimitiveWetModel | 31 | 8 | 48 | 1800 | 378 | 4.28 MB |
-| PrimitiveWetModel | 42 | 8 | 64 | 1350 | 161 | 7.22 MB |
-| PrimitiveWetModel | 63 | 8 | 96 | 900 | 47 | 15.34 MB |
-| PrimitiveWetModel | 85 | 8 | 128 | 675 | 20 | 26.73 MB |
-| PrimitiveWetModel | 127 | 8 | 192 | 450 | 6 | 59.10 MB |
-| PrimitiveWetModel | 170 | 8 | 256 | 338 | 2 | 105.37 MB |
+| PrimitiveWetModel | 31 | 8 | 48 | 1800 | 1259 | 4.47 MB |
+| PrimitiveWetModel | 42 | 8 | 64 | 1350 | 598 | 7.51 MB |
+| PrimitiveWetModel | 63 | 8 | 96 | 900 | 199 | 15.91 MB |
+| PrimitiveWetModel | 85 | 8 | 128 | 675 | 81 | 27.66 MB |
+| PrimitiveWetModel | 127 | 8 | 192 | 450 | 19 | 60.99 MB |
+| PrimitiveWetModel | 170 | 8 | 256 | 338 | 6 | 108.55 MB |
 
 ## PrimitiveWetModel: Physics or dynamics only
 
 | Model | T | L | Dynamics | Physics | Δt | SYPD | Memory|
 | - | - | - | - | - | - | - | - |
-| PrimitiveWetModel | 31 | 8 | true | true | 1800 | 322 | 4.28 MB |
-| PrimitiveWetModel | 31 | 8 | true | false | 1800 | 587 | 4.28 MB |
-| PrimitiveWetModel | 31 | 8 | false | true | 1800 | 527 | 4.28 MB |
+| PrimitiveWetModel | 31 | 8 | true | true | 1800 | 1092 | 4.47 MB |
+| PrimitiveWetModel | 31 | 8 | true | false | 1800 | 2535 | 4.47 MB |
+| PrimitiveWetModel | 31 | 8 | false | true | 1800 | 1680 | 4.47 MB |
+
+## Individual dynamics functions
+
+
+### PrimitiveWetModel | Float32 | T31 L8 | OctahedralGaussianGrid | 48 Rings
+
+| Function | Time | Memory | Allocations |
+| - | - | - | - |
+| pressure_gradient_flux! | 30.292 μs| 12.88 KiB| 260 |
+| linear_virtual_temperature! | 958.304 ns| 0 bytes| 0 |
+| temperature_anomaly! | 3.297 μs| 0 bytes| 0 |
+| geopotential! | 3.047 μs| 0 bytes| 0 |
+| vertical_integration! | 13.500 μs| 0 bytes| 0 |
+| surface_pressure_tendency! | 11.667 μs| 6.44 KiB| 130 |
+| vertical_velocity! | 4.571 μs| 0 bytes| 0 |
+| linear_pressure_gradient! | 936.793 ns| 0 bytes| 0 |
+| vertical_advection! | 87.584 μs| 2.81 KiB| 24 |
+| vordiv_tendencies! | 192.000 μs| 98.38 KiB| 1940 |
+| temperature_tendency! | 276.375 μs| 147.56 KiB| 2910 |
+| humidity_tendency! | 269.375 μs| 147.56 KiB| 2910 |
+| bernoulli_potential! | 91.542 μs| 49.19 KiB| 970 |
 
 ## Shallow water model, resolution
 
 | Model | T | L | Rings | Δt | SYPD | Memory|
 | - | - | - | - | - | - | - |
-| ShallowWaterModel | 31 | 1 | 48 | 1800 | 9402 | 1.24 MB |
-| ShallowWaterModel | 42 | 1 | 64 | 1350 | 4034 | 2.13 MB |
-| ShallowWaterModel | 63 | 1 | 96 | 900 | 1132 | 4.71 MB |
-| ShallowWaterModel | 85 | 1 | 128 | 675 | 415 | 8.45 MB |
-| ShallowWaterModel | 127 | 1 | 192 | 450 | 105 | 19.60 MB |
-| ShallowWaterModel | 170 | 1 | 256 | 338 | 39 | 36.41 MB |
-| ShallowWaterModel | 255 | 1 | 384 | 225 | 9 | 89.44 MB |
+| ShallowWaterModel | 31 | 1 | 48 | 1800 | 30230 | 1.19 MB |
+| ShallowWaterModel | 42 | 1 | 64 | 1350 | 15080 | 2.02 MB |
+| ShallowWaterModel | 63 | 1 | 96 | 900 | 4303 | 4.40 MB |
+| ShallowWaterModel | 85 | 1 | 128 | 675 | 1485 | 7.86 MB |
+| ShallowWaterModel | 127 | 1 | 192 | 450 | 393 | 18.16 MB |
+| ShallowWaterModel | 170 | 1 | 256 | 338 | 115 | 33.76 MB |
+| ShallowWaterModel | 255 | 1 | 384 | 225 | 31 | 83.28 MB |
 
 ## Primitive Equation, Float32 vs Float64
 
 | Model | NF | T | L | Δt | SYPD | Memory|
 | - | - | - | - | - | - | - |
-| PrimitiveWetModel | Float32 | 31 | 8 | 1800 | 317 | 4.28 MB |
-| PrimitiveWetModel | Float64 | 31 | 8 | 1800 | 343 | 8.03 MB |
+| PrimitiveWetModel | Float32 | 31 | 8 | 1800 | 1256 | 4.47 MB |
+| PrimitiveWetModel | Float64 | 31 | 8 | 1800 | 1242 | 8.36 MB |
 
 ## PrimitiveDryModel: Physics or dynamics only
 
 | Model | T | L | Dynamics | Physics | Δt | SYPD | Memory|
 | - | - | - | - | - | - | - | - |
-| PrimitiveDryModel | 31 | 8 | true | true | 1800 | 462 | 3.95 MB |
-| PrimitiveDryModel | 31 | 8 | true | false | 1800 | 657 | 3.95 MB |
-| PrimitiveDryModel | 31 | 8 | false | true | 1800 | 683 | 3.95 MB |
+| PrimitiveDryModel | 31 | 8 | true | true | 1800 | 2027 | 4.11 MB |
+| PrimitiveDryModel | 31 | 8 | true | false | 1800 | 3375 | 4.11 MB |
+| PrimitiveDryModel | 31 | 8 | false | true | 1800 | 2514 | 4.11 MB |
 
 ## Number of vertical layers
 
 | Model | T | L | Δt | SYPD | Memory|
 | - | - | - | - | - | - |
-| PrimitiveWetModel | 31 | 4 | 1800 | 583 | 2.92 MB |
-| PrimitiveWetModel | 31 | 8 | 1800 | 345 | 4.28 MB |
-| PrimitiveWetModel | 31 | 12 | 1800 | 217 | 5.65 MB |
-| PrimitiveWetModel | 31 | 16 | 1800 | 186 | 7.03 MB |
+| PrimitiveWetModel | 31 | 4 | 1800 | 1824 | 3.00 MB |
+| PrimitiveWetModel | 31 | 8 | 1800 | 1260 | 4.47 MB |
+| PrimitiveWetModel | 31 | 12 | 1800 | 1114 | 5.94 MB |
+| PrimitiveWetModel | 31 | 16 | 1800 | 823 | 7.42 MB |

--- a/benchmark/benchmark_suite.jl
+++ b/benchmark/benchmark_suite.jl
@@ -1,4 +1,7 @@
-Base.@kwdef mutable struct BenchmarkSuite
+using BenchmarkTools 
+
+abstract type AbstractBenchmarkSuite end 
+@kwdef mutable struct BenchmarkSuite <: AbstractBenchmarkSuite
     title::String
     nruns::Int = 1
     model::Vector = fill(PrimitiveWetModel, nruns)
@@ -61,3 +64,195 @@ function run_benchmark_suite!(suite::BenchmarkSuite)
         suite.SYPD[i] = sypd
     end
 end
+
+function write_results(md, suite::BenchmarkSuite)
+
+    write(md, "\n## $(suite.title)\n\n")
+
+    print_NF = any(suite.NF .!= suite.NF[1])
+    print_Grid = any(suite.Grid .!= suite.Grid[1])
+    print_nlat = any(suite.nlat .!= suite.nlat[1]) 
+    print_dynamics = any(suite.dynamics .!= suite.dynamics[1])
+    print_physics = any(suite.physics .!= suite.physics[1])
+
+    column_header = "| Model "
+    column_header *= print_NF ? "| NF " : ""
+    column_header *= "| T "
+    column_header *= "| L "
+    column_header *= print_Grid ? "| Grid " : ""
+    column_header *= print_nlat ? "| Rings " : ""
+    column_header *= print_dynamics ? "| Dynamics " : ""
+    column_header *= print_physics ? "| Physics " : ""
+    column_header *= "| Δt | SYPD | Memory|"
+
+    ncolumns = length(findall('|',column_header)) - 1
+    second_row = repeat("| - ", ncolumns) * "|"
+
+    write(md,"$column_header\n")
+    write(md,"$second_row\n")
+
+    for i in 1:suite.nruns
+
+        row = "| $(suite.model[i]) "
+        row *= print_NF ? "| $(suite.NF[i]) " : ""
+        row *= "| $(suite.trunc[i]) "
+        row *= "| $(suite.nlev[i]) "
+        row *= print_Grid ? "| $(suite.Grid[i]) " : ""
+        row *= print_nlat ? "| $(suite.nlat[i]) " : ""
+        row *= print_dynamics ? "| $(suite.dynamics[i]) " : ""
+        row *= print_physics  ? "| $(suite.physics[i]) " : ""
+
+        Δt = round(Int,suite.Δt[i])
+        sypd = suite.SYPD[i]
+        SYPD = isfinite(sypd) ? round(Int, sypd) : 0
+        memory = prettymemory(suite.memory[i])
+        row *= "| $Δt | $SYPD | $memory |"
+
+        write(md,"$row\n")
+    end
+end 
+
+@kwdef mutable struct BenchmarkSuiteDynamics <: AbstractBenchmarkSuite
+    title::String
+    nruns::Int = 1
+    model::Vector = fill(PrimitiveWetModel, nruns)
+    NF::Vector = fill(SpeedyWeather.DEFAULT_NF, nruns)
+    trunc::Vector{Int} = fill(SpeedyWeather.DEFAULT_TRUNC, nruns)
+    nlev::Vector{Int} = default_nlev(model)
+    Grid::Vector = fill(SpeedyWeather.DEFAULT_GRID, nruns)
+    nlat::Vector{Int} = fill(0, nruns)
+    dynamics::Vector{Bool} = fill(true, nruns)
+    physics::Vector{Bool} = fill(true, nruns)
+    function_names::Vector{String} = default_function_names()
+    time_median::Vector{Vector{Float64}} = [fill(0.0, length(function_names)) for i=1:nruns]
+    memory::Vector{Vector{Int}} = [fill(0, length(function_names)) for i=1:nruns]
+    allocs::Vector{Vector{Int}} = [fill(0, length(function_names)) for i=1:nruns]
+end 
+
+default_function_names() = ["pressure_gradient_flux!", "linear_virtual_temperature!", "temperature_anomaly!", "geopotential!", "vertical_integration!", "surface_pressure_tendency!", "vertical_velocity!", "linear_pressure_gradient!", "vertical_advection!","vordiv_tendencies!", "temperature_tendency!", "humidity_tendency!", "bernoulli_potential!"]
+
+function add_results!(suite::BenchmarkSuiteDynamics, trial::BenchmarkTools.Trial, i_run::Integer, i_func::Integer)
+
+    t = median(trial)
+
+    suite.time_median[i_run][i_func] = t.time 
+    suite.memory[i_run][i_func] = t.memory 
+    suite.allocs[i_run][i_func] = t.allocs
+
+    return suite
+end 
+
+function run_benchmark_suite!(suite::BenchmarkSuiteDynamics)
+    for i in 1:suite.nruns
+
+        Model = suite.model[i]
+        NF = suite.NF[i]
+        trunc = suite.trunc[i]
+        nlayers = suite.nlev[i]
+        Grid = suite.Grid[i]
+        dynamics = suite.dynamics[i]
+        physics = suite.physics[i]
+
+        spectral_grid = SpectralGrid(;NF, trunc, Grid, nlayers)
+        suite.nlat[i] = spectral_grid.nlat
+
+        model = Model(;spectral_grid)
+        if Model <: PrimitiveEquation
+            model.physics = physics
+            model.dynamics = dynamics
+        else
+            suite.dynamics[i] = true
+            suite.physics[i] = false
+        end
+
+        simulation = initialize!(model)
+
+        diagn = simulation.diagnostic_variables
+        progn = simulation.prognostic_variables 
+        lf = 2 
+        (; orography, geometry, spectral_transform, geopotential, atmosphere, implicit) = model
+        lf_implicit = implicit.α == 0 ? lf : 1
+
+        b = @benchmark SpeedyWeather.pressure_gradient_flux!($diagn, $progn, $lf, $spectral_transform)
+        add_results!(suite, b, i, 1)
+
+        b = @benchmark SpeedyWeather.linear_virtual_temperature!($diagn, $progn, $lf_implicit, $model)
+        add_results!(suite, b, i, 2)
+
+        b = @benchmark SpeedyWeather.temperature_anomaly!($diagn, $implicit)
+        add_results!(suite, b, i, 3)
+
+        b = @benchmark SpeedyWeather.geopotential!($diagn, $geopotential, $orography)
+        add_results!(suite, b, i, 4)
+
+        b = @benchmark SpeedyWeather.vertical_integration!($diagn, $progn, $lf_implicit, $geometry)
+        add_results!(suite, b, i, 5)
+
+        b = @benchmark SpeedyWeather.surface_pressure_tendency!($diagn, $spectral_transform)
+        add_results!(suite, b, i, 6)
+
+        b = @benchmark SpeedyWeather.vertical_velocity!($diagn, $geometry)
+        add_results!(suite, b, i, 7)
+
+        b = @benchmark SpeedyWeather.linear_pressure_gradient!($diagn, $progn, $lf_implicit, $atmosphere, $implicit)
+        add_results!(suite, b, i, 8)
+
+        b = @benchmark SpeedyWeather.vertical_advection!($diagn, $model)
+        add_results!(suite, b, i, 9)
+
+        b = @benchmark SpeedyWeather.vordiv_tendencies!($diagn, $model)
+        add_results!(suite, b, i, 10)
+
+        b = @benchmark SpeedyWeather.temperature_tendency!($diagn, $model)
+        add_results!(suite, b, i, 11)
+
+        b = @benchmark SpeedyWeather.humidity_tendency!($diagn, $model)
+        add_results!(suite, b, i, 12)
+
+        b = @benchmark SpeedyWeather.bernoulli_potential!($diagn, $spectral_transform)
+        add_results!(suite, b, i, 13)
+    end
+
+    return suite
+end 
+
+function write_results(md, suite::BenchmarkSuiteDynamics)
+
+    write(md, "\n## $(suite.title)\n\n")
+
+    for i_run in 1:suite.nruns
+
+        title_row = "$(suite.model[i_run]) "
+        title_row *= "| $(suite.NF[i_run]) " 
+        title_row *= "| T$(suite.trunc[i_run]) "
+        title_row *= "L$(suite.nlev[i_run]) "
+        title_row *= "| $(suite.Grid[i_run]) " 
+        title_row *= "| $(suite.nlat[i_run]) Rings" 
+
+        write(md, "\n### $title_row\n\n")
+
+        column_header = "| Function "
+        column_header *= "| Time "
+        column_header *= "| Memory "
+        column_header *= "| Allocations |" 
+
+        ncolumns = length(findall('|',column_header)) - 1
+        second_row = repeat("| - ", ncolumns) * "|"
+
+        write(md,"$column_header\n")
+        write(md,"$second_row\n")
+
+        for i_func in 1:length(suite.function_names)
+
+            time = BenchmarkTools.prettytime(suite.time_median[i_run][i_func])
+            memory = BenchmarkTools.prettymemory(suite.memory[i_run][i_func])
+
+            row = "| $(suite.function_names[i_func]) "
+            row *= "| $time"
+            row *= "| $memory"
+            row *= "| $(suite.allocs[i_run][i_func]) |"
+
+            write(md,"$row\n")
+        end
+    end
+end 

--- a/benchmark/define_benchmarks.jl
+++ b/benchmark/define_benchmarks.jl
@@ -1,5 +1,5 @@
 # dictionary of all benchmark suites, define with whatever key ::Symbol
-benchmarks = Dict{Symbol,BenchmarkSuite}()
+benchmarks = Dict{Symbol,AbstractBenchmarkSuite}()
 
 # Models
 benchmarks[:benchmark100] = BenchmarkSuite(
@@ -63,3 +63,11 @@ benchmarks[:benchmark601] = BenchmarkSuite(
     physics = [true, false, true],
     dynamics = [true, true, false],
     )
+
+## DYNAMICS, benchmark individual functions 
+benchmarks[:benchmark700] = BenchmarkSuiteDynamics(
+    title = "Individual dynamics functions",
+    nruns = 1, 
+    physics = [true],
+    dynamics = [true],
+)

--- a/benchmark/manual_benchmarking.jl
+++ b/benchmark/manual_benchmarking.jl
@@ -53,52 +53,7 @@ write(md, "to the repository for updates or comparison.")
 
 # Write benchmark suites into markdown
 for key in keys(benchmarks)
-
-    suite = benchmarks[key]
-
-    write(md, "\n## $(suite.title)\n\n")
-
-    print_NF = any(suite.NF .!= suite.NF[1])
-    print_Grid = any(suite.Grid .!= suite.Grid[1])
-    print_nlat = any(suite.nlat .!= suite.nlat[1]) 
-    print_dynamics = any(suite.dynamics .!= suite.dynamics[1])
-    print_physics = any(suite.physics .!= suite.physics[1])
-
-    column_header = "| Model "
-    column_header *= print_NF ? "| NF " : ""
-    column_header *= "| T "
-    column_header *= "| L "
-    column_header *= print_Grid ? "| Grid " : ""
-    column_header *= print_nlat ? "| Rings " : ""
-    column_header *= print_dynamics ? "| Dynamics " : ""
-    column_header *= print_physics ? "| Physics " : ""
-    column_header *= "| Δt | SYPD | Memory|"
-
-    ncolumns = length(findall('|',column_header)) - 1
-    second_row = repeat("| - ", ncolumns) * "|"
-
-    write(md,"$column_header\n")
-    write(md,"$second_row\n")
-
-    for i in 1:suite.nruns
-
-        row = "| $(suite.model[i]) "
-        row *= print_NF ? "| $(suite.NF[i]) " : ""
-        row *= "| $(suite.trunc[i]) "
-        row *= "| $(suite.nlev[i]) "
-        row *= print_Grid ? "| $(suite.Grid[i]) " : ""
-        row *= print_nlat ? "| $(suite.nlat[i]) " : ""
-        row *= print_dynamics ? "| $(suite.dynamics[i]) " : ""
-        row *= print_physics  ? "| $(suite.physics[i]) " : ""
-
-        Δt = round(Int,suite.Δt[i])
-        sypd = suite.SYPD[i]
-        SYPD = isfinite(sypd) ? round(Int, sypd) : 0
-        memory = prettymemory(suite.memory[i])
-        row *= "| $Δt | $SYPD | $memory |"
-
-        write(md,"$row\n")
-    end
+    write_results(md, benchmarks[key])
 end
 
 close(md)


### PR DESCRIPTION
I added the individual dynamics functions as another benchmark suite. I had to change a few things around because they didn’t fit in the existing `BenchmarkSuite` scheme. 

I use `BenchmarkTools` which isn’t in the main environment, so I added a new local environment. This isn’t working ideally because the `Project.toml` doesn’t know that Speedy was added with `dev ..`. Maybe we should add the Manifest.toml as well here, or you know, just be aware of it when executing the benchmarks. 
