### PR TITLE
SpectralAR1Process and AbstractRandomProcess

### DIFF
--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -115,6 +115,7 @@ include("dynamics/scaling.jl")
 include("dynamics/tendencies.jl")
 include("dynamics/hole_filling.jl")
 include("dynamics/particle_advection.jl")
+include("dynamics/random_process.jl")
 
 # PARAMETERIZATIONS
 include("physics/albedo.jl")

--- a/src/dynamics/diagnostic_variables.jl
+++ b/src/dynamics/diagnostic_variables.jl
@@ -119,7 +119,9 @@ $TYPEDFIELDS."""
     v_grid          ::GridVariable3D = zeros(GridVariable3D, nlat_half, nlayers)
     "Logarithm of surface pressure [Pa]"
     pres_grid       ::GridVariable2D = zeros(GridVariable2D, nlat_half)
-    
+    "Random pattern controlled by random process [1]"
+    random_pattern  ::GridVariable2D = zeros(GridVariable3D, nlat_half)
+
     # PREVIOUS TIME STEP
     "Absolute temperature [K] at previous time step"
     temp_grid_prev  ::GridVariable3D = zeros(GridVariable3D, nlat_half, nlayers)

--- a/src/dynamics/prognostic_variables.jl
+++ b/src/dynamics/prognostic_variables.jl
@@ -96,6 +96,9 @@ export PrognosticVariables
     pres::NTuple{NSTEPS, SpectralVariable2D} =
         ntuple(i -> zeros(SpectralVariable2D, trunc+2, trunc+1), NSTEPS)
 
+    "Random pattern following a random process [1]"
+    random_pattern::SpectralVariable2D = zeros(SpectralVariable2D, trunc+2, trunc+1)
+
     "Ocean variables, sea surface temperature and sea ice concentration"
     ocean::PrognosticVariablesOcean{NF, ArrayType, GridVariable2D} =
         PrognosticVariablesOcean{NF, ArrayType, GridVariable2D}(; nlat_half)
@@ -148,6 +151,7 @@ function Base.show(
     println(io, "├ temp:  T$trunc, $nlayers-layer, $NSTEPS-steps LowerTriangularArray{$NF}")
     println(io, "├ humid: T$trunc, $nlayers-layer, $NSTEPS-steps LowerTriangularArray{$NF}")
     println(io, "├ pres:  T$trunc, 1-layer, $NSTEPS-steps LowerTriangularArray{$NF}")
+    println(io, "├ random_pattern: T$trunc, 1-layer LowerTriangularArray{$NF}")
     println(io, "├┐ocean: PrognosticVariablesOcean{$NF}")
     println(io, "│├ sea_surface_temperature:  $nlat-ring $Grid")
     println(io, "│└ sea_ice_concentration:    $nlat-ring $Grid")

--- a/src/dynamics/random_process.jl
+++ b/src/dynamics/random_process.jl
@@ -1,0 +1,95 @@
+abstract type AbstractRandomProcess <: AbstractModelComponent end
+
+"""$(TYPEDSIGNATURES)
+General transform for `random processes <: AbstractRandomProcess`.
+Takes the spectral `random_pattern` in the prognostic variables
+and transforms it to spectral space in `diagn.grid.random_pattern`."""
+function SpeedyTransforms.transform!(
+    diagn::DiagnosticVariables,
+    progn::PrognosticVariables,
+    lf::Integer,
+    random_process::AbstractRandomProcess,
+    spectral_transform::SpectralTransform,
+)
+    grid = diagn.grid.random_pattern
+    spec = progn.random_pattern
+    transform!(grid, spec, spectral_transform)
+
+    if :clamp in fieldnames(typeof(random_process))
+        clamp!(grid, random_process.clamp...)
+    end
+end
+
+export NoRandomProcess
+"""Dummy type for no random process."""
+struct NoRandomProcess <: AbstractRandomProcess end
+NoRandomProcess(::SpectralGrid) = NoRandomProcess()
+
+"""$(TYPEDSIGNATURES)
+`NoRandomProcess` does not need to transform any random pattern from
+spectral to grid space."""
+function SpeedyTransforms.transform!(
+    diagn::DiagnosticVariables,
+    progn::PrognosticVariables,
+    lf::Integer,
+    random_process::NoRandomProcess,
+    spectral_transform::SpectralTransform,
+)
+    return nothing
+end
+
+initialize!(process::NoRandomProcess, model::AbstractModel) = nothing
+random_process!(progn::PrognosticVariables, process::NoRandomProcess) = nothing
+
+export SpectralAR1Process
+
+@kwdef struct SpectralAR1Process{NF} <: AbstractRandomProcess
+    time_scales::Vector{Second} = [Hour(6), Day(3), Day(30)]
+    wavenumbers::Vector{Int} = [26, 16, 8]
+    standard_deviations::Vector{NF} = [0.52, 0.18, 0.06]
+    clamp::NTuple{2, NF} = (-1, 1)
+    rand_function::Function = randn
+
+    seed::Int = 123
+    random_number_generator::Random.Xoshiro = Random.Xoshiro(seed)
+
+    autoregressive_factors::Vector{NF} = zeros(NF, length(time_scales))
+    noise_factors::Vector{NF} = zeros(NF, length(time_scales))
+end
+
+SpectralAR1Process(SG::SpectralGrid, kwargs...) = SpectralAR1Process{SG.NF}(; kwargs...)
+
+function initialize!(
+    process::SpectralAR1Process,
+    model::AbstractModel,
+)
+    @assert maximum(process.wavenumbers) <= model.spectral_grid.trunc
+
+    dt = model.time_stepping.Δt_sec         # in seconds
+
+    for (i, (τ, σ)) in enumerate(zip(process.time_scales, process.standard_deviations))
+        process.autoregressive_factors[i] = exp(-dt/Second(τ).value)
+        process.noise_factors[i] = σ*sqrt(1 - exp(-dt/Second(τ).value))
+    end
+
+    # reseed the random number generator
+    Random.seed!(process.random_number_generator, process.seed)
+    return nothing
+end
+
+function random_process!(
+    progn::PrognosticVariables,
+    process::SpectralAR1Process{NF},
+) where NF
+
+    (; random_pattern) = progn
+    (; wavenumbers, autoregressive_factors, noise_factors) = process
+    (; rand_function) = process
+
+    for (l, a, ξ) in zip(wavenumbers, autoregressive_factors,  noise_factors)
+        for m in 0:l-1
+            r = rand_function(process.random_number_generator, Complex{NF})
+            random_pattern[l+1, m+1] = a*random_pattern[l+1, m+1] + ξ*r
+        end
+    end
+end

--- a/src/dynamics/tendencies.jl
+++ b/src/dynamics/tendencies.jl
@@ -746,6 +746,9 @@ function SpeedyTransforms.transform!(
     transform!(u_grid, U, S, unscale_coslat=true)
     transform!(v_grid, V, S, unscale_coslat=true)
  
+    # transform random pattern for random process unless NoRandomProcess
+    transform!(diagn, progn, lf, model.random_process, S)
+
     return nothing
 end
 
@@ -783,6 +786,9 @@ function SpeedyTransforms.transform!(
     # transform from U, V in spectral to u, v on grid (U, V = u, v*coslat)
     transform!(u_grid, U, S, unscale_coslat=true)
     transform!(v_grid, V, S, unscale_coslat=true)
+
+    # transform random pattern for random process unless NoRandomProcess
+    transform!(diagn, progn, lf, model.random_process, S)
 
     return nothing
 end
@@ -860,6 +866,11 @@ function SpeedyTransforms.transform!(
         @. u_grid_prev = u_grid
         @. v_grid_prev = v_grid
     end
+
+    # transform random pattern for random process unless NoRandomProcess
+    transform!(diagn, progn, lf, model.random_process, S)
+
+    return nothing
 end
 
 """ 

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -175,6 +175,10 @@ function leapfrog!(
         spectral_truncation!(var_tend)
         leapfrog!(var_old, var_new, var_tend, dt, lf, model.time_stepping)
     end
+
+    # evolve the random pattern in time
+    random_process!(progn, model.random_process)
+    return nothing
 end
 
 """

--- a/src/models/barotropic.jl
+++ b/src/models/barotropic.jl
@@ -20,6 +20,7 @@ $(TYPEDFIELDS)"""
     DR,     # <:AbstractDrag,
     PA,     # <:AbstractParticleAdvection,
     IC,     # <:AbstractInitialConditions,
+    RP,     # <:AbstractRandomProcess,
     TS,     # <:AbstractTimeStepper,
     ST,     # <:SpectralTransform{NF},
     IM,     # <:AbstractImplicit,
@@ -40,6 +41,7 @@ $(TYPEDFIELDS)"""
     drag::DR = NoDrag()
     particle_advection::PA = NoParticleAdvection()
     initial_conditions::IC = InitialConditions(Barotropic)
+    random_process::RP = NoRandomProcess()
 
     # NUMERICS
     time_stepping::TS = Leapfrog(spectral_grid)
@@ -73,6 +75,7 @@ function initialize!(model::Barotropic; time::DateTime = DEFAULT_DATE)
     initialize!(model.forcing, model)
     initialize!(model.drag, model)
     initialize!(model.horizontal_diffusion, model)
+    initialize!(model.random_process, model)
 
     # initial conditions
     prognostic_variables = PrognosticVariables(spectral_grid, model)

--- a/src/models/primitive_dry.jl
+++ b/src/models/primitive_dry.jl
@@ -21,6 +21,7 @@ $(TYPEDFIELDS)"""
     AC,     # <:AbstractAdiabaticConversion,
     PA,     # <:AbstractParticleAdvection,
     IC,     # <:AbstractInitialConditions,
+    RP,     # <:AbstractRandomProcess,
     LS,     # <:AbstractLandSeaMask,
     OC,     # <:AbstractOcean,
     LA,     # <:AbstractLand,
@@ -57,6 +58,7 @@ $(TYPEDFIELDS)"""
     adiabatic_conversion::AC = AdiabaticConversion(spectral_grid)
     particle_advection::PA = NoParticleAdvection()
     initial_conditions::IC = InitialConditions(PrimitiveDry)
+    random_process::RP = NoRandomProcess()
     
     # BOUNDARY CONDITIONS
     orography::OR = EarthOrography(spectral_grid)
@@ -110,6 +112,7 @@ function initialize!(model::PrimitiveDry; time::DateTime = DEFAULT_DATE)
     initialize!(model.coriolis, model)
     initialize!(model.geopotential, model)
     initialize!(model.adiabatic_conversion, model)
+    initialize!(model.random_process, model)
 
     # boundary conditionss
     initialize!(model.orography, model)

--- a/src/models/primitive_wet.jl
+++ b/src/models/primitive_wet.jl
@@ -21,6 +21,7 @@ $(TYPEDFIELDS)"""
     AC,     # <:AbstractAdiabaticConversion,
     PA,     # <:AbstractParticleAdvection,
     IC,     # <:AbstractInitialConditions,
+    RP,     # <:AbstractRandomProcess,
     LS,     # <:AbstractLandSeaMask,
     OC,     # <:AbstractOcean,
     LA,     # <:AbstractLand,
@@ -63,6 +64,7 @@ $(TYPEDFIELDS)"""
     adiabatic_conversion::AC = AdiabaticConversion(spectral_grid)
     particle_advection::PA = NoParticleAdvection()
     initial_conditions::IC = InitialConditions(PrimitiveWet)
+    random_process::RP = NoRandomProcess()
     
     # BOUNDARY CONDITIONS
     orography::OR = EarthOrography(spectral_grid)
@@ -122,6 +124,7 @@ function initialize!(model::PrimitiveWet; time::DateTime = DEFAULT_DATE)
     initialize!(model.coriolis, model)
     initialize!(model.geopotential, model)
     initialize!(model.adiabatic_conversion, model)
+    initialize!(model.random_process, model)
 
     # boundary conditions
     initialize!(model.orography, model)

--- a/src/models/shallow_water.jl
+++ b/src/models/shallow_water.jl
@@ -21,6 +21,7 @@ $(TYPEDFIELDS)"""
     DR,     # <:AbstractDrag,
     PA,     # <:AbstractParticleAdvection,
     IC,     # <:AbstractInitialConditions,
+    RP,     # <:AbstractRandomProcess,
     TS,     # <:AbstractTimeStepper,
     ST,     # <:SpectralTransform{NF},
     IM,     # <:AbstractImplicit,
@@ -42,6 +43,7 @@ $(TYPEDFIELDS)"""
     drag::DR = NoDrag()
     particle_advection::PA = NoParticleAdvection()
     initial_conditions::IC = InitialConditions(ShallowWater)
+    random_process::RP = NoRandomProcess()
 
     # NUMERICS
     time_stepping::TS = Leapfrog(spectral_grid)
@@ -77,6 +79,7 @@ function initialize!(model::ShallowWater; time::DateTime = DEFAULT_DATE)
     initialize!(model.drag, model)
     initialize!(model.horizontal_diffusion, model)
     # model.implicit is initialized in first_timesteps!
+    initialize!(model.random_process, model)
 
     # initial conditions
     prognostic_variables = PrognosticVariables(spectral_grid, model)

--- a/src/physics/column_variables.jl
+++ b/src/physics/column_variables.jl
@@ -65,6 +65,9 @@ function get_column!(
         C.humid[k] = humid_grid_prev[ij, k] 
     end
 
+    # extract value from random pattern for this column
+    C.random_value = D.grid.random_pattern[ij]
+
     # TODO skin = surface approximation for now
     C.skin_temperature_sea = P.ocean.sea_surface_temperature[ij]
     C.skin_temperature_land = P.land.land_surface_temperature[ij]

--- a/src/physics/define_column.jl
+++ b/src/physics/define_column.jl
@@ -49,6 +49,9 @@ $(TYPEDFIELDS)"""
     const flux_humid_upward::Vector{NF} = zeros(NF, nlayers+1)
     const flux_humid_downward::Vector{NF} = zeros(NF, nlayers+1)
 
+    # random value (scalar) from random pattern controlled by model.random_process
+    random_value::NF = 0
+
     # boundary layer
     boundary_layer_depth::Int = 0
     boundary_layer_drag::NF = 0


### PR DESCRIPTION
Implements two random processes `<:AbstractRandomProcess` to generate random patterns (2D only for now) with temporal and spatial autocorrelation following idea from the Stochastically Perturbed Parameterization Schemes (SPPT) developed at ECMWF, see [here](https://www.ecmwf.int/sites/default/files/elibrary/2016/16733-model-uncertainty-representations-ifs.pdf) for example:

<img width="736" alt="image" src="https://github.com/user-attachments/assets/c694cd2e-370f-4263-b641-7b65b57c54b3">

@samhatfield the mentioned length scales are 500, 1000, and 2000km. Do you know which wavenumbers these are? I picked ``l = 24, 16, 8`` for now.  It seems you do this [here](https://github.com/samhatfield/speedy.f90/blob/0ebfdbfcd62efd46dd1802284908645be4b230be/source/sppt.f90#L74-L84) in speedy.f90

@minqi6