### PR TITLE
Model constructors with positional SpectralGrid argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Also allow SpectralGrid as positional argument to model constructors [#593](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/593)
 - De-interweave SpectralTransform [#587](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/587)
 - Rossby-Haurwitz wave initial conditions [#591](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/591)
 - Haversine formula and AbstractSphericalDistance [#588](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/588)

--- a/src/dynamics/spectral_grid.jl
+++ b/src/dynamics/spectral_grid.jl
@@ -93,6 +93,9 @@ function Base.show(io::IO, SG::SpectralGrid)
       print(io, "└ Device:     $(typeof(device)) using $ArrayType")
 end
 
+# also allow spectral grid to be passed on as first an only positional argument to model constructors
+(M::Type{<:AbstractModel})(SG::SpectralGrid; kwargs...) = M(spectral_grid=SG; kwargs...)
+
 """
 $(TYPEDSIGNATURES)
 Generator function for a SpectralTransform struct pulling in parameters from a SpectralGrid struct."""


### PR DESCRIPTION
At the moment one *has to* write
```julia
model = PrimitiveWetModel(; spectral_grid, kwargs...)
```
to construct any model. To lower the confusion for beginners ("what's that `;` for?") also allow for the spectral grid to be passed on as first positional argument, i.e.

```julia
model = PrimitiveWetModel(spectral_grid, kwargs...)
```

which is also consistent with how we create all model components.