### PR TITLE
NetCDF output: Precipitation accumulated and rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Output both accumulated and precipitation rate as netCDF [#596](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/596)
 - Random processes for random pattern generation [#592](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/592)
 - Also allow SpectralGrid as positional argument to model constructors [#593](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/593)
 - De-interweave SpectralTransform [#587](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/587)

--- a/docs/src/analysis.md
+++ b/docs/src/analysis.md
@@ -453,7 +453,7 @@ end
 
 Then we define a new callback `GlobalDiagnostics` subtype of SpeedyWeather's
 `AbstractCallback` and define new methods of `initialize!`,
-`callback!` and `finish!` for it (see [Callbacks](@ref) for more
+`callback!` and `finalize!` for it (see [Callbacks](@ref) for more
 details)
 
 ```@example analysis
@@ -526,8 +526,8 @@ end
 
 using NCDatasets
 
-# define how to finish a GlobalDiagnostics callback after simulation finished
-function SpeedyWeather.finish!(
+# define how to finalize a GlobalDiagnostics callback after simulation finished
+function SpeedyWeather.finalize!(
     callback::GlobalDiagnostics,
     progn::PrognosticVariables,
     diagn::DiagnosticVariables,
@@ -556,7 +556,7 @@ end
 
 Note that `callback!` will execute _every_ time step. If
 execution is only desired periodically, you can use [Schedules](@ref).
-At `finish!` we decide to write the timeseries of our global
+At `finalize!` we decide to write the timeseries of our global
 diagnostics as netCDF file via NCDatasets.jl to the current
 path `pwd()`. We need to add `using NCDatasets` here, as SpeedyWeather
 does not re-export the functionality therein.

--- a/docs/src/callbacks.md
+++ b/docs/src/callbacks.md
@@ -3,7 +3,7 @@
 SpeedyWeather.jl implements a callback system to let users include a flexible piece of code
 into the time stepping. You can think about the main time loop *calling back* to check whether
 anything else should be done before continuing with the next time step. The callback system
-here is called *after* the time step only (plus one call at `initialize!` and one at `finish!`),
+here is called *after* the time step only (plus one call at `initialize!` and one at `finalize!`),
 we currently do not implement other callsites.
 
 Callbacks are mainly introduced for diagnostic purposes, meaning that they do not influence
@@ -59,7 +59,7 @@ Now every callback needs to extend three methods
 
 1. `initialize!`, called once before the main time loop starts
 2. `callback!`, called after every time step
-3. `finish!`, called once after the last time step
+3. `finalize!`, called once after the last time step
 
 And we'll go through them one by one.
 
@@ -138,18 +138,18 @@ callback this should be read-only. While you could change other model components
 land sea mask in `model.land_sea_mask` or orography etc. then you interfere with the
 simulation which is more advanced and will be discussed in Intrusive callbacks below.
 
-Lastly, we extend the `finish!` function which is called once after the last time step.
+Lastly, we extend the `finalize!` function which is called once after the last time step.
 This could be used, for example, to save the `maximum_surface_wind_speed` vector to
 file or in case you want to find the highest wind speed across all time steps.
 But in many cases you may not need to do anything, in which case you just just let
 it return `nothing`.
 
 ```@example callbacks
-SpeedyWeather.finish!(::StormChaser, args...) = nothing
+SpeedyWeather.finalize!(::StormChaser, args...) = nothing
 ```
 
-!!! note "Always extend `initialize!`, `callback!` and `finish!`"
-    For a custom callback you need to extend all three, `initialize!`, `callback!` and `finish!`,
+!!! note "Always extend `initialize!`, `callback!` and `finalize!`"
+    For a custom callback you need to extend all three, `initialize!`, `callback!` and `finalize!`,
     even if your callback doesn't need it. Just return `nothing` in that case. Otherwise a
     `MethodError` will occur. While we could have defined all callbacks by default to do nothing
     on each of these, this may give you the false impression that your callback is already defined
@@ -162,7 +162,7 @@ keyword can be used to create a model with a dictionary of callbacks. Callbacks 
 with a `Symbol` key inside such a dictionary. We have a convenient `CallbackDict` generator function
 which can be used like `Dict` but the key-value pairs have to be of type `Symbol`-`AbstractCallback`.
 Let us illustrate this with the dummy callback `NoCallback` (which is a callback that returns `nothing`
-on `initialize!`, `callback!` and `finish!`)
+on `initialize!`, `callback!` and `finalize!`)
 
 ```@example callbacks
 callbacks = CallbackDict()                                  # empty dictionary
@@ -332,8 +332,8 @@ function SpeedyWeather.callback!(
     @info "North pole has a temperature of $temp_at_north_pole on $time."
 end
 
-# nothing needs to be done when finishing
-SpeedyWeather.finish!(::MyScheduledCallback, args...) = nothing
+# nothing needs to be done after simulation is finished
+SpeedyWeather.finalize!(::MyScheduledCallback, args...) = nothing
 ```
 
 So in summary

--- a/docs/src/examples_3D.md
+++ b/docs/src/examples_3D.md
@@ -244,12 +244,11 @@ nothing # hide
 ![Large-scale precipitation](large-scale_precipitation_acc.png)
 
 Precipitation (both large-scale and convective) are written into the
-`simulation.diagnostic_variables.surface` which, however, accumulate all precipitation
-until netCDF output is written. As we didn't specify `output=true` here, they accumulated
-precipitation over the last 10 days of the simulation which includes the initial
-adjustment of humidity in the tropics (the large band of precipitation here).
-So let us reset these accumulators and integrate for another 6 hours to get the
-precipitation only in the period.
+`simulation.diagnostic_variables.physics` which, however, accumulate all precipitation
+during simulation. In the NetCDF output, precipitation rate (in mm/hr) is calculated
+from accumulated precipitation as a post-processing step.
+More interactively, you can also reset these accumulators and integrate for another 6 hours
+to get the precipitation only in that period.
 
 ```@example precipitation
 # reset accumulators and simulate 6 hours
@@ -269,7 +268,7 @@ nothing # hide
 ![Convective precipitation](convective_precipitation.png)
 
 As the precipitation fields are accumulated meters over the integration period
-(in the case of no output) we divide by 6 hours to get a precipitation rate ``[m/s]``
+we divide by 6 hours to get a precipitation rate ``[m/s]``
 but then multiply with 1 hour and 1000 to get the typical precipitation unit of ``[mm/hr]``.
 
 ## References

--- a/docs/src/land_sea_mask.md
+++ b/docs/src/land_sea_mask.md
@@ -148,8 +148,8 @@ function SpeedyWeather.callback!(
     @info "Everything flooded on $(progn.clock.time)"
 end
 
-# nothing needs to be done when finishing
-SpeedyWeather.finish!(::MilleniumFlood, args...) = nothing
+# nothing needs to be done after simulation is finished
+SpeedyWeather.finalize!(::MilleniumFlood, args...) = nothing
 ```
 
 Note that the flooding will take place only at the start of the 21st century,

--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -29,7 +29,7 @@ import ProgressMeter
 export DateTime, Second, Minute, Hour, Day, Week
 
 # export functions that have many cross-component methods
-export initialize!, finish!
+export initialize!, finalize!
 
 include("utility_functions.jl")
 

--- a/src/dynamics/diagnostic_variables.jl
+++ b/src/dynamics/diagnostic_variables.jl
@@ -250,10 +250,10 @@ $(TYPEDFIELDS)"""
 
     nlat_half::Int
 
-    "Accumualted large-scale precipitation [m]"
+    "Accumulated large-scale precipitation [m]"
     precip_large_scale::GridVariable2D = zeros(GridVariable2D, nlat_half)
 
-    "Accumualted large-scale precipitation [m]"
+    "Accumulated large-scale precipitation [m]"
     precip_convection::GridVariable2D = zeros(GridVariable2D, nlat_half)
 
     "Cloud top [m]"

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -372,12 +372,12 @@ function time_stepping!(
     end
     
     # UNSCALE, CLOSE, FINISH
-    finish!(feedback)                       # finish the progress meter, do first for benchmark accuracy
+    finalize!(feedback)                     # finish the progress meter, do first for benchmark accuracy
     unscale!(progn)                         # undo radius-scaling for vor, div from the dynamical core
     unscale!(diagn)                         # undo radius-scaling for vor, div from the dynamical core
-    close(output)                           # close netCDF file
+    finalize!(output, progn, diagn, model)  # possibly post-process output, then close netCDF file
     write_restart_file(output, progn)       # as JLD2 
-    finish!(model.callbacks, progn, diagn, model)
+    finalize!(model.callbacks, progn, diagn, model)
 
     # return a UnicodePlot of surface vorticity
     surface_vorticity = diagn.grid.vor_grid[:, end]

--- a/src/output/callbacks.jl
+++ b/src/output/callbacks.jl
@@ -30,10 +30,10 @@ export NoCallback
 struct NoCallback <: AbstractCallback end
 initialize!(::NoCallback, args...) = nothing     # executed once before the main time loop
 callback!(::NoCallback, args...) = nothing       # executed after every time step
-finish!(::NoCallback, args...) = nothing         # executed after main time loop finishes
+finalize!(::NoCallback, args...) = nothing       # executed after main time loop finishes
 
 # simply loop over dict of callbacks
-for func in (:initialize!, :callback!, :finish!)
+for func in (:initialize!, :callback!, :finalize!)
     @eval begin
         function $func(callbacks::CALLBACK_DICT, args...)
             for key in keys(callbacks)
@@ -150,5 +150,5 @@ function callback!(
     callback.temp[i] = diagn.temp_average[diagn.nlayers]
 end
 
-# nothing to finish
-finish!(::GlobalSurfaceTemperatureCallback, args...) = nothing
+# nothing to finalize
+finalize!(::GlobalSurfaceTemperatureCallback, args...) = nothing

--- a/src/output/feedback.jl
+++ b/src/output/feedback.jl
@@ -119,7 +119,7 @@ end
 """
 $(TYPEDSIGNATURES)
 Finalises the progress meter and the progress txt file."""
-function finish!(F::Feedback)
+function finalize!(F::Feedback)
     ProgressMeter.finish!(F.progress_meter)
     
     if F.output     # write final progress to txt file

--- a/src/output/netcdf_output.jl
+++ b/src/output/netcdf_output.jl
@@ -368,8 +368,10 @@ function finalize!(
     diagn::DiagnosticVariables,
     model::AbstractModel,
 )
-    for (key, var) in output.variables
-        finalize!(output, var, progn, diagn, model)
+    if output.active    # only finalize if active otherwise output.netcdf_file is nothing
+        for (key, var) in output.variables
+            finalize!(output, var, progn, diagn, model)
+        end
     end
 
     close(output)

--- a/src/output/particle_tracker.jl
+++ b/src/output/particle_tracker.jl
@@ -148,4 +148,4 @@ function callback!(
     NCDatasets.sync(callback.netcdf_file)
 end
 
-finish!(callback::ParticleTracker,args...) = NCDatasets.close(callback.netcdf_file)
+finalize!(callback::ParticleTracker,args...) = NCDatasets.close(callback.netcdf_file)

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -77,7 +77,7 @@ end
         callback.maximum_surface_wind_speed[i] = max_2norm(u_grid, v_grid)
     end
 
-    SpeedyWeather.finish!(::StormChaser, args...) = nothing
+    SpeedyWeather.finalize!(::StormChaser, args...) = nothing
 
     spectral_grid = SpectralGrid()
     callbacks = CallbackDict(NoCallback())


### PR DESCRIPTION
NetCDF output has now by default accumulated precipitation (large-scale condensation and convection) so that the fields in `diagnostic_variables.physics.precip_large_scale` and `_convection` are not affected by the NetCDF output, previously the output writer was setting those accumulators back to zero which interferes with `RainGauge` in RainMaker.jl for example. Now the model records accumulated precipitation and everything else is done in output. Now `LargeScalePrecipitationRateOutput` and `ConvectivePrecipitationRateOutput` are implemented as a post-processing step, called during the `finalize!` of `model.output`. Also renames `finish!` generally to `finalize!` for consistency with `initialize!`.

