### PR TITLE
Array-agnostic horizontal diffusion, +modularised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.12.0
+
 - OctaminimalGaussianArray/Grid to start with 4 points around the poles [#595](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/595)
 - Output both accumulated and precipitation rate as netCDF [#596](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/596)
 - Random processes for random pattern generation [#592](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/592)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- SpectralFiltering for horizontal diffusion [#601](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/601)
+
 ## v0.12.0
 
 - OctaminimalGaussianArray/Grid to start with 4 points around the poles [#595](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/595)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpeedyWeather"
 uuid = "9e226e20-d153-4fed-8a5b-493def4f21a9"
 authors = ["Milan Klöwer and SpeedyWeather contributors"]
-version = "0.11.0"
+version = "0.12.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/README.md
+++ b/README.md
@@ -76,21 +76,20 @@ about dos and don'ts. Just express your interest to contribute and we'll be happ
 
 For a more comprehensive tutorial with several examples, see
 [Examples](https://speedyweather.github.io/SpeedyWeather.jl/dev/examples_2D/) in the documentation.
-The interface to SpeedyWeather.jl consist of 5 steps: define the grid, create model components,
+The basic interface to SpeedyWeather.jl consist of 4 steps: define the grid,
 construct the model, initialize, run
 
 ```julia
-spectral_grid = SpectralGrid(trunc=31, nlayers=8)       # define resolution
-orography = EarthOrography(spectral_grid)               # create non-default components
-model = PrimitiveWetModel(; spectral_grid, orography)   # construct model
-simulation = initialize!(model)                         # initialize all model components
-run!(simulation, period=Day(10), output=true)           # aaaand action!
+spectral_grid = SpectralGrid(trunc=31, nlayers=8)   # define resolution
+model = PrimitiveWetModel(spectral_grid)            # construct model
+simulation = initialize!(model)                     # initialize all model components
+run!(simulation, period=Day(10), output=true)       # aaaand action!
 ```
 and you will see
 
 <img src="https://github.com/SpeedyWeather/SpeedyWeather.jl/assets/25530332/a04fbb10-1cc1-4f77-93f2-7bdf047f277d" width="450"><br>
 
-Hurray🥳 In 5 seconds we just simulated 10 days of the Earth's atmosphere at a speed of 440 years per day.
+Hurray🥳 In a few seconds seconds we just simulated 10 days of the Earth's atmosphere at a speed of 440 years per day.
 This simulation used a T31 spectral resolution on an
 [octahedral Gaussian grid](https://speedyweather.github.io/SpeedyWeather.jl/dev/grids/#Implemented-grids)
 (~400km resolution) solving the primitive equations on 8 vertical levels.

--- a/README.md
+++ b/README.md
@@ -190,9 +190,19 @@ compatibilities with older versions are not guaranteed.
 
 ## Benchmarks
 
-The primitive equations at 400km resolution with 8 vertical layers are simulated by
-SpeedyWeather.jl at about 500 simulated years per day, i.e. one year takes about
-3min single-threaded on a CPU. Multi-threading will increase the speed typically by 2-4x.
+The primitive equations at 400km resolution with 8 vertical layers can be simulated by
+SpeedyWeather.jl at 1800 simulated years per day (SYPD) on a single core of newer CPUs with arm architecture
+(M-series MacBooks for example). At that speed, simulating one year takes about 50 seconds
+without output. The complex fused-multiply adds of the spectral transform compile efficiently to
+the large vector extensions of the newer arm chips in single precision.
+Another considerable speed-up comes from the reduced grids minimizing the number of columns for
+which expensive parameterizations like convection have to be computed. The parameterizations
+take up 40-60% of the total simulation time, depending on the grid. Particularly the
+`OctaminimalGaussianGrid`, `OctaHEALPixGrid` and the `HEALPixGrid` are increasingly faster,
+at a small accuracy sacrifice of the then inexact spectral transforms. 
+
+On older CPUs, like the Intel CPU MacBooks, the 1800 SYPD drop to about 500-600 SYPD,
+which is still 2x faster than Fortran SPEEDY which is reported to reach 240 SYPD.
 
 For an overview of typical simulation speeds a user can expect under different model setups see
 [Benchmarks](https://github.com/SpeedyWeather/SpeedyWeather.jl/blob/main/benchmark).

--- a/benchmark/benchmark_suite.jl
+++ b/benchmark/benchmark_suite.jl
@@ -41,7 +41,7 @@ function run_benchmark_suite!(suite::BenchmarkSuite)
         spectral_grid = SpectralGrid(;NF, trunc, Grid, nlayers)
         suite.nlat[i] = spectral_grid.nlat
 
-        model = Model(;spectral_grid)
+        model = Model(spectral_grid)
         if Model <: PrimitiveEquation
             model.physics = physics
             model.dynamics = dynamics
@@ -152,7 +152,7 @@ function run_benchmark_suite!(suite::BenchmarkSuiteDynamics)
         spectral_grid = SpectralGrid(;NF, trunc, Grid, nlayers)
         suite.nlat[i] = spectral_grid.nlat
 
-        model = Model(;spectral_grid)
+        model = Model(spectral_grid)
 
         simulation = initialize!(model)
 

--- a/docs/src/analysis.md
+++ b/docs/src/analysis.md
@@ -69,7 +69,7 @@ or wavenumber 0, see [Spherical Harmonic Transform](@ref)) encodes the global av
 ```@example analysis
 using SpeedyWeather
 spectral_grid = SpectralGrid(trunc=31, nlayers=1)
-model = ShallowWaterModel(;spectral_grid)
+model = ShallowWaterModel(spectral_grid)
 simulation = initialize!(model)
 ```
 

--- a/docs/src/callbacks.md
+++ b/docs/src/callbacks.md
@@ -189,7 +189,7 @@ Meaning that callbacks can be added before and after model construction
 ```@example callbacks
 spectral_grid = SpectralGrid()
 callbacks = CallbackDict(:callback_added_before => NoCallback())
-model = PrimitiveWetModel(; spectral_grid, callbacks)
+model = PrimitiveWetModel(spectral_grid; callbacks)
 add!(model.callbacks, :callback_added_afterwards => NoCallback())
 add!(model, :callback_added_afterwards2 => NoCallback())
 ```
@@ -353,7 +353,7 @@ for events that are scheduled. Now let's create a primitive equation model with 
 
 ```@example schedule
 spectral_grid = SpectralGrid(trunc=31, nlayers=5)
-model = PrimitiveWetModel(;spectral_grid)
+model = PrimitiveWetModel(spectral_grid)
 add!(model.callbacks, north_pole_temp_at_noon_jan9)
 
 # start simulation 7 days earlier

--- a/docs/src/custom_netcdf_output.md
+++ b/docs/src/custom_netcdf_output.md
@@ -130,7 +130,7 @@ Just some ideas how to customize this even further.
 Now let's try this in a primitive dry model
 
 ```@example netcdf_custom
-model = PrimitiveDryModel(;spectral_grid, output)
+model = PrimitiveDryModel(spectral_grid; output)
 model.output.variables[:w]
 ```
 

--- a/docs/src/examples_2D.md
+++ b/docs/src/examples_2D.md
@@ -266,13 +266,12 @@ using SpeedyWeather
 spectral_grid = SpectralGrid(trunc=127, nlayers=1)
 
 # model components
-time_stepping = SpeedyWeather.Leapfrog(spectral_grid, Δt_at_T31=Minute(30))
-implicit = SpeedyWeather.ImplicitShallowWater(spectral_grid, α=0.5)
+implicit = ImplicitShallowWater(spectral_grid, α=0.5)
 orography = EarthOrography(spectral_grid, smoothing=false)
-initial_conditions = SpeedyWeather.RandomWaves()
+initial_conditions = RandomWaves(lmin=10, lmax=30)      # between wavenumber 10 and 30
 
 # construct, initialize, run
-model = ShallowWaterModel(spectral_grid; orography, initial_conditions, implicit, time_stepping)
+model = ShallowWaterModel(spectral_grid; orography, initial_conditions, implicit)
 simulation = initialize!(model)
 run!(simulation, period=Day(2))
 nothing # hide
@@ -287,7 +286,7 @@ But we also want to keep orography, and particularly no smoothing on it, to have
 as rough as possible. The initial conditions are set to `RandomWaves` which set the spherical
 harmonic coefficients of ``\eta`` to between given wavenumbers to some random values
 ```@example gravity_wave_setup
-SpeedyWeather.RandomWaves()
+RandomWaves()
 ```
 so that the amplitude `A` is as desired, here 2000m. Our layer thickness in meters is by default
 ```@example gravity_wave_setup

--- a/docs/src/examples_2D.md
+++ b/docs/src/examples_2D.md
@@ -14,7 +14,7 @@ See also [Examples 3D](@ref) for examples with the primitive equation models.
     spectral_grid = SpectralGrid(trunc=63, nlayers=1)
     still_earth = Earth(spectral_grid, rotation=0)
     initial_conditions = StartWithRandomVorticity()
-    model = BarotropicModel(; spectral_grid, initial_conditions, planet=still_earth)
+    model = BarotropicModel(spectral_grid; initial_conditions, planet=still_earth)
     simulation = initialize!(model)
     run!(simulation, period=Day(20))
     ```
@@ -48,7 +48,7 @@ horizontal wavenumber, and the amplitude is ``10^{-5}\text{s}^{-1}``.
 Now we want to construct a `BarotropicModel`
 with these
 ```@example barotropic_setup
-model = BarotropicModel(; spectral_grid, initial_conditions, planet=still_earth)
+model = BarotropicModel(spectral_grid; initial_conditions, planet=still_earth)
 nothing # hide
 ```
 The `model` contains all the parameters, but isn't initialized yet, which we can do
@@ -74,7 +74,7 @@ with default settings. More options on output in [NetCDF output](@ref).
     spectral_grid = SpectralGrid(trunc=63, nlayers=1)
     orography = NoOrography(spectral_grid)
     initial_conditions = ZonalJet()
-    model = ShallowWaterModel(; spectral_grid, orography, initial_conditions)
+    model = ShallowWaterModel(spectral_grid; orography, initial_conditions)
     simulation = initialize!(model)
     run!(simulation, period=Day(6))
     ```
@@ -100,7 +100,7 @@ initial_conditions = ZonalJet()
 The jet sits at 45˚N with a maximum velocity of 80m/s and a perturbation as described in their paper.
 Now we construct a model, but this time a `ShallowWaterModel`
 ```@example galewsky_setup
-model = ShallowWaterModel(; spectral_grid, orography, initial_conditions)
+model = ShallowWaterModel(spectral_grid; orography, initial_conditions)
 simulation = initialize!(model)
 run!(simulation, period=Day(6))
 ```
@@ -191,7 +191,7 @@ options too, but let's not change them. Same as before, create a model, initiali
 This time directly for 12 days so that we can compare with the last plot
 
 ```@example galewsky_setup
-model = ShallowWaterModel(; spectral_grid, orography, initial_conditions)
+model = ShallowWaterModel(spectral_grid; orography, initial_conditions)
 simulation = initialize!(model)
 run!(simulation, period=Day(12), output=true)
 ```
@@ -233,7 +233,7 @@ spectral_grid = SpectralGrid(trunc=63, nlayers=1)
 forcing = JetStreamForcing(spectral_grid, latitude=60)
 drag = QuadraticDrag(spectral_grid)
 
-model = ShallowWaterModel(; spectral_grid, drag, forcing)
+model = ShallowWaterModel(spectral_grid; drag, forcing)
 simulation = initialize!(model)
 run!(simulation, period=Day(40))
 nothing # hide
@@ -272,7 +272,7 @@ orography = EarthOrography(spectral_grid, smoothing=false)
 initial_conditions = SpeedyWeather.RandomWaves()
 
 # construct, initialize, run
-model = ShallowWaterModel(; spectral_grid, orography, initial_conditions, implicit, time_stepping)
+model = ShallowWaterModel(spectral_grid; orography, initial_conditions, implicit, time_stepping)
 simulation = initialize!(model)
 run!(simulation, period=Day(2))
 nothing # hide

--- a/docs/src/examples_3D.md
+++ b/docs/src/examples_3D.md
@@ -20,7 +20,7 @@ initial_conditions = InitialConditions(
     temp = JablonowskiTemperature(),
     pres = ZeroInitially())
 
-model = PrimitiveDryModel(; spectral_grid, orography, initial_conditions, physics=false)
+model = PrimitiveDryModel(spectral_grid; orography, initial_conditions, physics=false)
 simulation = initialize!(model)
 run!(simulation, period=Day(9))
 nothing # hide
@@ -117,7 +117,7 @@ land_sea_mask = AquaPlanetMask(spectral_grid)
 orography = NoOrography(spectral_grid)
 
 # create model, initialize, run
-model = PrimitiveWetModel(; spectral_grid, ocean, land_sea_mask, orography)
+model = PrimitiveWetModel(spectral_grid; ocean, land_sea_mask, orography)
 simulation = initialize!(model)
 run!(simulation, period=Day(20))
 nothing # hide
@@ -171,7 +171,7 @@ and `orography` (because `spectral_grid` hasn't changed this is possible).
 convection = DryBettsMiller(spectral_grid, time_scale=Hour(4))
 
 # reuse other model components from before
-model = PrimitiveWetModel(; spectral_grid, ocean, land_sea_mask, orography, convection)
+model = PrimitiveWetModel(spectral_grid; ocean, land_sea_mask, orography, convection)
 
 simulation = initialize!(model)
 run!(simulation, period=Day(20))
@@ -191,7 +191,7 @@ don't require the `spectral_grid` to be passed on, but some do!)
 convection = NoConvection(spectral_grid)
 
 # reuse other model components from before
-model = PrimitiveWetModel(; spectral_grid, ocean, land_sea_mask, orography, convection)
+model = PrimitiveWetModel(spectral_grid; ocean, land_sea_mask, orography, convection)
 
 simulation = initialize!(model)
 run!(simulation, period=Day(20))
@@ -218,7 +218,7 @@ large_scale_condensation = ImplicitCondensation(spectral_grid)
 convection = SimplifiedBettsMiller(spectral_grid)
 
 # create model, initialize, run
-model = PrimitiveWetModel(; spectral_grid, large_scale_condensation, convection)
+model = PrimitiveWetModel(spectral_grid; large_scale_condensation, convection)
 simulation = initialize!(model)
 run!(simulation, period=Day(10))
 nothing # hide

--- a/docs/src/examples_3D.md
+++ b/docs/src/examples_3D.md
@@ -54,7 +54,7 @@ using SpeedyWeather
 spectral_grid = SpectralGrid(trunc=31, nlayers=8)
 
 # construct model with only Held-Suarez forcing, no other physics
-model = PrimitiveDryModel(;
+model = PrimitiveDryModel(
     spectral_grid,
 
     # Held-Suarez forcing and drag

--- a/docs/src/forcing_drag.md
+++ b/docs/src/forcing_drag.md
@@ -312,7 +312,7 @@ and just put them together as you like, and as long as you follow some rules.
 spectral_grid = SpectralGrid(trunc=85, nlayers=1)
 stochastic_stirring = StochasticStirring(spectral_grid, latitude=-45)
 initial_conditions = StartFromRest()
-model = BarotropicModel(; spectral_grid, initial_conditions, forcing=stochastic_stirring)
+model = BarotropicModel(spectral_grid; initial_conditions, forcing=stochastic_stirring)
 simulation = initialize!(model)
 run!(simulation)
 

--- a/docs/src/gradients.md
+++ b/docs/src/gradients.md
@@ -112,7 +112,7 @@ Let us start by generating some data
 spectral_grid = SpectralGrid(trunc=31, nlayers=1)
 forcing = SpeedyWeather.JetStreamForcing(spectral_grid)
 drag = QuadraticDrag(spectral_grid)
-model = ShallowWaterModel(; spectral_grid, forcing, drag)
+model = ShallowWaterModel(spectral_grid; forcing, drag)
 simulation = initialize!(model);
 run!(simulation, period=Day(30))
 nothing # hide

--- a/docs/src/how_to_run_speedy.md
+++ b/docs/src/how_to_run_speedy.md
@@ -124,7 +124,7 @@ on the components (they are keyword arguments so either use `; time_stepping`
 for which the naming must match, or `time_stepping=my_time_stepping` with
 any name)
 ```@example howto
-model = ShallowWaterModel(; spectral_grid, time_stepping)
+model = ShallowWaterModel(spectral_grid; time_stepping)
 ```
 This logic continues for all model components, see [Examples](@ref Examples).
 All model components are also subtype (i.e. `<:`) of some abstract supertype,
@@ -157,9 +157,9 @@ parameterizations. Conceptually you construct these different models with
 spectral_grid = SpectralGrid(trunc=..., ...)
 component1 = SomeComponent(spectral_grid, parameter1=..., ...)
 component2 = SomeOtherComponent(spectral_grid, parameter2=..., ...)
-model = BarotropicModel(; spectral_grid, all_other_components..., ...)
+model = BarotropicModel(spectral_grid; all_other_components..., ...)
 ```
-or `model = ShallowWaterModel(; spectral_grid, ...)`, etc.
+or `model = ShallowWaterModel(spectral_grid; ...)`, etc.
 
 ## [Model initialization](@id initialize)
 

--- a/docs/src/how_to_run_speedy.md
+++ b/docs/src/how_to_run_speedy.md
@@ -93,7 +93,7 @@ however, a new user might first want to know which components there are,
 so let's flip the logic around and assume you know you want to run a `ShallowWaterModel`.
 You can create a default `ShallowWaterModel` like so and inspect its components
 ```@example howto
-model = ShallowWaterModel(; spectral_grid)
+model = ShallowWaterModel(spectral_grid)
 ```
 
 So by default the `ShallowWaterModel` uses a [Leapfrog `time_stepping`](@ref leapfrog),

--- a/docs/src/initial_conditions.md
+++ b/docs/src/initial_conditions.md
@@ -27,7 +27,7 @@ as default
 ```@example haurwitz
 using SpeedyWeather
 spectral_grid = SpectralGrid(trunc=63, nlayers=1)
-model = BarotropicModel(; spectral_grid)
+model = BarotropicModel(spectral_grid)
 simulation = initialize!(model)
 ```
 

--- a/docs/src/initial_conditions.md
+++ b/docs/src/initial_conditions.md
@@ -148,7 +148,7 @@ initial_conditions = InitialConditions(
                         pres=PressureOnOrography())
 
 orography = NoOrography(spectral_grid)
-model = PrimitiveDryModel(; spectral_grid, initial_conditions, orography, physics=false)
+model = PrimitiveDryModel(spectral_grid; initial_conditions, orography, physics=false)
 simulation = initialize!(model)
 run!(simulation, period=Day(5))
 nothing # hide

--- a/docs/src/land_sea_mask.md
+++ b/docs/src/land_sea_mask.md
@@ -159,7 +159,7 @@ would then have this `MilleniumFlood` take place
 
 ```@example landseamask
 land_sea_mask = LandSeaMask(spectral_grid)      # start with Earth's land-sea mask
-model = PrimitiveWetModel(spectral_grid, land_sea_mask)
+model = PrimitiveWetModel(spectral_grid; land_sea_mask)
 add!(model, MilleniumFlood())   # or MilleniumFlood(::DateTime) for any non-default date
 
 simulation = initialize!(model, time=DateTime(1999,12,29))

--- a/docs/src/land_sea_mask.md
+++ b/docs/src/land_sea_mask.md
@@ -30,7 +30,7 @@ as defined in `spectral_grid` at initialization. The actual mask is in
 `land_sea_mask.mask` and you can visualise it with
 
 ```@example landseamask
-model = PrimitiveWetModel(;spectral_grid, land_sea_mask)
+model = PrimitiveWetModel(spectral_grid; land_sea_mask)
 simulation = initialize!(model)     # triggers also initialization of model.land_sea_mask
 
 using CairoMakie
@@ -159,7 +159,7 @@ would then have this `MilleniumFlood` take place
 
 ```@example landseamask
 land_sea_mask = LandSeaMask(spectral_grid)      # start with Earth's land-sea mask
-model = PrimitiveWetModel(;spectral_grid, land_sea_mask)
+model = PrimitiveWetModel(spectral_grid, land_sea_mask)
 add!(model, MilleniumFlood())   # or MilleniumFlood(::DateTime) for any non-default date
 
 simulation = initialize!(model, time=DateTime(1999,12,29))

--- a/docs/src/orography.md
+++ b/docs/src/orography.md
@@ -58,7 +58,7 @@ and interpolate the orography which happens at the `initialize!`
 step. Visualised with
 
 ```@example orography
-model = PrimitiveDryModel(;spectral_grid, orography)
+model = PrimitiveDryModel(spectral_grid; orography)
 initialize!(orography, model)   # happens also in simulation = initialize!(model)
 
 using CairoMakie

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -28,7 +28,7 @@ But any `NetCDFOutput` can be passed onto the model constructor with the `output
 
 ```@example netcdf
 output = NetCDFOutput(spectral_grid, Barotropic)
-model = ShallowWaterModel(spectral_grid; output=output)
+model = ShallowWaterModel(spectral_grid, output=output)
 nothing # hide
 ```
 
@@ -43,7 +43,7 @@ trigger it as `output=false` is the default here.
 If we want to increase the frequency of the output we can choose `output_dt` (default `=Hour(6)`) like so
 ```@example netcdf
 output = NetCDFOutput(spectral_grid, ShallowWater, output_dt=Hour(1))
-model = ShallowWaterModel(spectral_grid; output=output)
+model = ShallowWaterModel(spectral_grid, output=output)
 model.output
 ```
 which will now output every hour. It is important to pass on the new output writer `output` to the

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -17,7 +17,7 @@ which are explained in the following. By default, the `NetCDFOutput` is created 
 the model, i.e.
 
 ```@example netcdf
-model = ShallowWaterModel(;spectral_grid)
+model = ShallowWaterModel(spectral_grid)
 model.output
 ```
 
@@ -28,7 +28,7 @@ But any `NetCDFOutput` can be passed onto the model constructor with the `output
 
 ```@example netcdf
 output = NetCDFOutput(spectral_grid, Barotropic)
-model = ShallowWaterModel(; spectral_grid, output=output)
+model = ShallowWaterModel(spectral_grid; output=output)
 nothing # hide
 ```
 
@@ -43,7 +43,7 @@ trigger it as `output=false` is the default here.
 If we want to increase the frequency of the output we can choose `output_dt` (default `=Hour(6)`) like so
 ```@example netcdf
 output = NetCDFOutput(spectral_grid, ShallowWater, output_dt=Hour(1))
-model = ShallowWaterModel(; spectral_grid, output=output)
+model = ShallowWaterModel(spectral_grid; output=output)
 model.output
 ```
 which will now output every hour. It is important to pass on the new output writer `output` to the
@@ -60,7 +60,7 @@ seconds. Depending on the output frequency (we chose `output_dt = Hour(1)` above
 this will be slightly adjusted during model initialization:
 ```@example netcdf
 output = NetCDFOutput(spectral_grid, ShallowWater, output_dt=Hour(1))
-model = ShallowWaterModel(; spectral_grid, time_stepping, output)
+model = ShallowWaterModel(spectral_grid; time_stepping, output)
 simulation = initialize!(model)
 model.time_stepping.Δt_sec
 ```
@@ -75,7 +75,7 @@ time_stepping.Δt_sec
 and a little info will be printed to explain that even though you wanted
 `output_dt = Hour(1)` you will not actually get this upon initialization:
 ```@example netcdf
-model = ShallowWaterModel(; spectral_grid, time_stepping, output)
+model = ShallowWaterModel(spectral_grid; time_stepping, output)
 simulation = initialize!(model)
 ```
 
@@ -91,7 +91,7 @@ which is a bit ugly, that's why `adjust_with_output=true` is the default. In tha
 ```@example netcdf
 time_stepping = Leapfrog(spectral_grid, adjust_with_output=true)
 output = NetCDFOutput(spectral_grid, ShallowWater, output_dt=Hour(1))
-model = ShallowWaterModel(; spectral_grid, time_stepping, output)
+model = ShallowWaterModel(spectral_grid; time_stepping, output)
 simulation = initialize!(model)
 run!(simulation, period=Day(1), output=true)
 id = model.output.id

--- a/docs/src/parameterizations.md
+++ b/docs/src/parameterizations.md
@@ -109,14 +109,14 @@ the `convection` field inside `PrimitiveWetModel`, see
 [Keyword Arguments](https://docs.julialang.org/en/v1/manual/functions/#Keyword-Arguments).
 
 ```@example parameterization
-model = PrimitiveWetModel(;spectral_grid, convection)
+model = PrimitiveWetModel(spectral_grid; convection)
 nothing # hide
 ```
 otherwise we would need to write
 
 ```@example parameterization
 my_convection = SimplifiedBettsMiller(spectral_grid)
-model = PrimitiveWetModel(;spectral_grid, convection=my_convection)
+model = PrimitiveWetModel(spectral_grid, convection=my_convection)
 nothing # hide
 ```
 The following is an overview of what the parameterization fields inside the

--- a/docs/src/particles.md
+++ b/docs/src/particles.md
@@ -258,7 +258,7 @@ The callback is then added after the model is created
 
 ```@example particle_tracker
 particle_advection = ParticleAdvection2D(spectral_grid)
-model = ShallowWaterModel(spectral_grid, particle_advection)
+model = ShallowWaterModel(spectral_grid; particle_advection)
 add!(model.callbacks, particle_tracker)
 ```
 

--- a/docs/src/particles.md
+++ b/docs/src/particles.md
@@ -192,7 +192,7 @@ spectral_grid = SpectralGrid(nparticles = 3)
 ```
 Then the particles live as `Vector{Particle}` inside the prognostic variables
 ```@example particle
-model = BarotropicModel(;spectral_grid)
+model = BarotropicModel(spectral_grid)
 simulation = initialize!(model)
 simulation.prognostic_variables.particles
 ```
@@ -222,7 +222,7 @@ we choose the first (=top-most) layer although this is the default anyway. Now w
 advect our three particles we have defined above
 
 ```@example particle
-model = BarotropicModel(;spectral_grid, particle_advection)
+model = BarotropicModel(spectral_grid; particle_advection)
 simulation = initialize!(model)
 simulation.prognostic_variables.particles
 ```
@@ -258,7 +258,7 @@ The callback is then added after the model is created
 
 ```@example particle_tracker
 particle_advection = ParticleAdvection2D(spectral_grid)
-model = ShallowWaterModel(;spectral_grid, particle_advection)
+model = ShallowWaterModel(spectral_grid, particle_advection)
 add!(model.callbacks, particle_tracker)
 ```
 

--- a/docs/src/structure.md
+++ b/docs/src/structure.md
@@ -34,7 +34,7 @@ But let's start at the top.
 When creating a `Simulation`, its fields are
 ```@example structure
 spectral_grid = SpectralGrid(nlayers = 1)
-model = BarotropicModel(; spectral_grid)
+model = BarotropicModel(spectral_grid)
 simulation = initialize!(model)
 ```
 the `prognostic_variables`, the `diagnostic_variables` and the `model` (that we just
@@ -77,7 +77,7 @@ If you create a model with non-default conponents they will show up here.
 that tree may look different depending on what model you have constructed!
 
 ```@example structure
-model = BarotropicModel(; spectral_grid)
+model = BarotropicModel(spectral_grid)
 tree(model)
 ```
 
@@ -87,7 +87,7 @@ The `ShallowWaterModel` is similar to the `BarotropicModel`, but it contains for
 orography, that the `BarotropicModel` doesn't have.
 
 ```@example structure
-model = ShallowWaterModel(; spectral_grid)
+model = ShallowWaterModel(spectral_grid)
 tree(model)
 ```
 
@@ -99,7 +99,7 @@ aren't needed.
 
 ```@example structure
 spectral_grid = SpectralGrid()
-model = PrimitiveDryModel(; spectral_grid)
+model = PrimitiveDryModel(spectral_grid)
 tree(model)
 ```
 
@@ -109,7 +109,7 @@ The `PrimitiveWetModel` is the most complex model we currently have, hence its
 field tree is the longest, defining many components for the physics parameterizations.
 
 ```@example structure
-model = PrimitiveWetModel(; spectral_grid)
+model = PrimitiveWetModel(spectral_grid)
 tree(model)
 ```
 

--- a/docs/src/structure.md
+++ b/docs/src/structure.md
@@ -129,7 +129,7 @@ a higher resolution `PrimitiveWetModel` would use
 
 ```@example structure
 spectral_grid = SpectralGrid(trunc=127, nlayers=8)
-model = PrimitiveWetModel(;spectral_grid)
+model = PrimitiveWetModel(spectral_grid)
 simulation = initialize!(model)
 tree(simulation, max_level=1, with_size=true)
 ```

--- a/src/SpeedyTransforms/spectrum.jl
+++ b/src/SpeedyTransforms/spectrum.jl
@@ -9,7 +9,7 @@ function power_spectrum(
     lmax, mmax = size(spec, OneBased, as=Matrix)    # 1-based max degree l, order m
     trunc = min(lmax, mmax)                         # consider only the triangle
                                                     # ignore higher degrees if lmax > mmax
-    spectrum = zeros(NF, trunc)   
+    spectrum = zeros(real(eltype(spec)), trunc)   
 
     # zonal modes m = 0, *1 as not mirrored at -m
     @inbounds for l in 1:trunc

--- a/src/SpeedyTransforms/spectrum.jl
+++ b/src/SpeedyTransforms/spectrum.jl
@@ -1,23 +1,25 @@
 """$(TYPEDSIGNATURES)
 Compute the power spectrum of the spherical harmonic coefficients
-`alms` (lower triangular matrix) of type `Complex{NF}`."""
-function power_spectrum(alms::LowerTriangularMatrix{Complex{NF}};
-                        normalize::Bool=true) where NF
+`spec` (lower triangular matrix/array) of type `Complex{NF}`."""
+function power_spectrum(
+    spec::LowerTriangularArray;
+    normalize::Bool=true,
+)
     
-    lmax, mmax = size(alms, OneBased, as=Matrix)      # 1-based max degree l, order m
-    trunc = min(lmax, mmax)      # consider only the triangle
-                                 # ignore higher degrees if lmax > mmax
+    lmax, mmax = size(spec, OneBased, as=Matrix)    # 1-based max degree l, order m
+    trunc = min(lmax, mmax)                         # consider only the triangle
+                                                    # ignore higher degrees if lmax > mmax
     spectrum = zeros(NF, trunc)   
 
     # zonal modes m = 0, *1 as not mirrored at -m
     @inbounds for l in 1:trunc
-        spectrum[l] = abs(alms[l, 1])^2
+        spectrum[l] = abs(spec[l, 1])^2
     end
 
     # other modes m > 0 *2 as complex conj at -m
     @inbounds for m in 2:trunc
         for l in m:trunc
-            spectrum[l] += 2*abs(alms[l, m])^2
+            spectrum[l] += 2*abs(spec[l, m])^2
         end
     end
 

--- a/src/dynamics/horizontal_diffusion.jl
+++ b/src/dynamics/horizontal_diffusion.jl
@@ -137,17 +137,18 @@ function horizontal_diffusion!(
     ∇²ⁿ_impl::AbstractMatrix,           # implicit spectral damping (lmax x nlayers matrix)
 )
     lmax, mmax = size(tendency, OneBased, as=Matrix)
+    nlayers = size(var, 2)
 
     @boundscheck size(tendency) == size(var) || throw(BoundsError)
     @boundscheck lmax <= size(∇²ⁿ_expl, 1) == size(∇²ⁿ_impl, 1) || throw(BoundsError)
-    @boundscheck k <= size(∇²ⁿ_expl, 2) == size(∇²ⁿ_impl, 2) || throw(BoundsError)
+    @boundscheck nlayers <= size(∇²ⁿ_expl, 2) == size(∇²ⁿ_impl, 2) || throw(BoundsError)
 
-    @inbounds for k in eachmatrix(tendency, A)
+    @inbounds for k in eachmatrix(tendency, var)
         lm = 0                      # running index
         for m in 1:mmax             # loops over all columns/order m
             for l in m:lmax
                 lm += 1             # single index lm corresponding to harmonic l, m
-                tendency[lm, k] = (tendency[lm, k] + ∇²ⁿ_expl[l, k]*A[lm, k]) * ∇²ⁿ_impl[l, k]
+                tendency[lm, k] = (tendency[lm, k] + ∇²ⁿ_expl[l, k]*var[lm, k]) * ∇²ⁿ_impl[l, k]
             end
         end
     end

--- a/src/dynamics/horizontal_diffusion.jl
+++ b/src/dynamics/horizontal_diffusion.jl
@@ -13,7 +13,11 @@ above the `tapering_σ` sigma level to `power_stratosphere` (default 2).
 For the BarotropicModel and ShallowWaterModel no tapering or scaling is applied.
 Fields and options are
 $(TYPEDFIELDS)"""
-@kwdef mutable struct HyperDiffusion{NF} <: AbstractHorizontalDiffusion
+@kwdef mutable struct HyperDiffusion{
+    NF,
+    MatrixType,
+} <: AbstractHorizontalDiffusion
+
     # DIMENSIONS
     "spectral resolution"
     trunc::Int
@@ -23,7 +27,7 @@ $(TYPEDFIELDS)"""
     
     # PARAMETERS
     "[OPTION] power of Laplacian"
-    power::Float64 = 4.0
+    power::NF = 4
     
     "[OPTION] diffusion time scale"
     time_scale::Second = Minute(60)
@@ -32,59 +36,59 @@ $(TYPEDFIELDS)"""
     time_scale_temp_humid::Second = Minute(144)
     
     "[OPTION] stronger diffusion with resolution? 0: constant with trunc, 1: (inverse) linear with trunc, etc"
-    resolution_scaling::Float64 = 0.5
+    resolution_scaling::NF = 0.5
 
     # incrased diffusion in stratosphere
     "[OPTION] different power for tropopause/stratosphere"
-    power_stratosphere::Float64 = 2.0
+    power_stratosphere::NF = 2
     
     "[OPTION] linearly scale towards power_stratosphere above this σ"
-    tapering_σ::Float64 = 0.2
+    tapering_σ::NF = 0.2
 
     # ARRAYS, precalculated for each spherical harmonics degree and vertical layer
-    ∇²ⁿ::Vector{Vector{NF}} = [zeros(NF, trunc+2) for _ in 1:nlayers]           # explicit part
-    ∇²ⁿ_implicit::Vector{Vector{NF}} = [ones(NF, trunc+2) for _ in 1:nlayers]   # implicit part
+    ∇²ⁿ::MatrixType = zeros(NF, trunc+2, nlayers)           # explicit part
+    ∇²ⁿ_implicit::MatrixType = ones(NF, trunc+2, nlayers)   # implicit part
 
     # ARRAYS but no scaling or tapering and using time_scale_temp_humid
-    ∇²ⁿc::Vector{Vector{NF}} = [zeros(NF, trunc+2) for _ in 1:nlayers]           # explicit part
-    ∇²ⁿc_implicit::Vector{Vector{NF}} = [ones(NF, trunc+2) for _ in 1:nlayers]   # implicit part
+    ∇²ⁿc::MatrixType = zeros(NF, trunc+2, nlayers)          # explicit part
+    ∇²ⁿc_implicit::MatrixType = ones(NF, trunc+2, nlayers)  # implicit part
 end
 
 """$(TYPEDSIGNATURES)
 Generator function based on the resolutin in `spectral_grid`.
 Passes on keyword arguments."""
 function HyperDiffusion(spectral_grid::SpectralGrid; kwargs...)
-    (; NF, trunc, nlayers) = spectral_grid        # take resolution parameters from spectral_grid
-    return HyperDiffusion{NF}(; trunc, nlayers, kwargs...)
+    (; NF, trunc, nlayers, ArrayType) = spectral_grid        # take resolution parameters from spectral_grid
+    MatrixType = ArrayType{NF, 2}
+    return HyperDiffusion{NF, MatrixType}(; trunc, nlayers, kwargs...)
 end
 
 """$(TYPEDSIGNATURES)
-Precomputes the hyper diffusion terms in `scheme` based on the
+Precomputes the hyper diffusion terms in `diffusion` based on the
 model time step, and possibly with a changing strength/power in
-the vertical.
-"""
-function initialize!(   scheme::HyperDiffusion,
+the vertical."""
+function initialize!(   diffusion::HyperDiffusion,
                         model::AbstractModel)
-    initialize!(scheme, model.geometry, model.time_stepping)
+    initialize!(diffusion, model.geometry, model.time_stepping)
 end
 
 """$(TYPEDSIGNATURES)
 Precomputes the hyper diffusion terms for all layers based on the
 model time step in `L`, the vertical level sigma level in `G`."""
 function initialize!(   
-    scheme::HyperDiffusion,
+    diffusion::HyperDiffusion,
     G::AbstractGeometry,
     L::AbstractTimeStepper,
 )
-    (; trunc, nlayers, resolution_scaling) = scheme
-    (; ∇²ⁿ, ∇²ⁿ_implicit, ∇²ⁿc, ∇²ⁿc_implicit) = scheme
-    (; power, power_stratosphere, tapering_σ) = scheme
+    (; trunc, nlayers, resolution_scaling) = diffusion
+    (; ∇²ⁿ, ∇²ⁿ_implicit, ∇²ⁿc, ∇²ⁿc_implicit) = diffusion
+    (; power, power_stratosphere, tapering_σ) = diffusion
     (; Δt, radius) = L
 
     # Reduce diffusion time scale (=increase diffusion, always in seconds) with resolution
     # times 1/radius because time step Δt is scaled with 1/radius
-    time_scale = scheme.time_scale.value/radius * (32/(trunc+1))^resolution_scaling
-    time_scale_constant = scheme.time_scale_temp_humid.value/radius
+    time_scale = Second(diffusion.time_scale).value/radius * (32/(trunc+1))^resolution_scaling
+    time_scale_constant = Second(diffusion.time_scale_temp_humid).value/radius
 
     # NORMALISATION
     # Diffusion is applied by multiplication of the eigenvalues of the Laplacian -l*(l+1)
@@ -104,20 +108,20 @@ function initialize!(
             eigenvalue_norm = -l*(l+1)/largest_eigenvalue   # normalised diffusion ∇², power=1
 
             # Explicit part (=-ν∇²ⁿ), time scales to damping frequencies [1/s] times norm. eigenvalue
-            ∇²ⁿ[k][l+1] = -eigenvalue_norm^p/time_scale
-            ∇²ⁿc[k][l+1] = -eigenvalue_norm^power/time_scale_constant
+            ∇²ⁿ[l+1, k] = -eigenvalue_norm^p/time_scale
+            ∇²ⁿc[l+1, k] = -eigenvalue_norm^power/time_scale_constant
             
             # and implicit part of the diffusion (= 1/(1-2Δtν∇²ⁿ))
-            ∇²ⁿ_implicit[k][l+1] = 1/(1-2Δt*∇²ⁿ[k][l+1])           
-            ∇²ⁿc_implicit[k][l+1] = 1/(1-2Δt*∇²ⁿc[k][l+1])           
+            ∇²ⁿ_implicit[l+1, k] = 1/(1-2Δt*∇²ⁿ[l+1, k])           
+            ∇²ⁿc_implicit[l+1, k] = 1/(1-2Δt*∇²ⁿc[l+1, k])           
         end
         
         # last degree is only used by vector quantities; set to zero for implicit and explicit
         # to set any tendency at lmax+1,1:mmax to zero (what it should be anyway)
-        ∇²ⁿ[k][trunc+2] = 0
-        ∇²ⁿ_implicit[k][trunc+2] = 0
-        ∇²ⁿc[k][trunc+2] = 0
-        ∇²ⁿc_implicit[k][trunc+2] = 0
+        ∇²ⁿ[trunc+2, k] = 0
+        ∇²ⁿ_implicit[trunc+2, k] = 0
+        ∇²ⁿc[trunc+2, k] = 0
+        ∇²ⁿc_implicit[trunc+2, k] = 0
     end
 end
 
@@ -128,23 +132,23 @@ into an explicit part `∇²ⁿ_expl` and an implicit part `∇²ⁿ_impl`, such
 in a single forward step by using `A` as well as its tendency `tendency`."""
 function horizontal_diffusion!( 
     tendency::LowerTriangularArray,     # tendency of a 
-    A::LowerTriangularArray,            # spectral horizontal field
-    ∇²ⁿ_expl::AbstractVector,           # explicit spectral damping (vector of k vectors of lmax length)
-    ∇²ⁿ_impl::AbstractVector            # implicit spectral damping (vector of k vectors of lmax length)
+    var::LowerTriangularArray,          # spectral horizontal field to diffuse
+    ∇²ⁿ_expl::AbstractMatrix,           # explicit spectral damping (lmax x nlayers matrix)
+    ∇²ⁿ_impl::AbstractMatrix,           # implicit spectral damping (lmax x nlayers matrix)
 )
-    lmax, mmax = size(tendency; as=Matrix)      # 1-based
+    lmax, mmax = size(tendency, OneBased, as=Matrix)
 
-    @boundscheck size(tendency) == size(A) || throw(BoundsError)
-    @boundscheck lmax <= length(∇²ⁿ_expl[1]) == length(∇²ⁿ_impl[1]) || throw(BoundsError)
+    @boundscheck size(tendency) == size(var) || throw(BoundsError)
+    @boundscheck lmax <= size(∇²ⁿ_expl, 1) == size(∇²ⁿ_impl, 1) || throw(BoundsError)
+    @boundscheck k <= size(∇²ⁿ_expl, 2) == size(∇²ⁿ_impl, 2) || throw(BoundsError)
 
-    for k in eachmatrix(tendency, A)
-        lm = 0
+    @inbounds for k in eachmatrix(tendency, A)
+        lm = 0                      # running index
         for m in 1:mmax             # loops over all columns/order m
-            for l in m:lmax-1       # but skips the lmax+2 degree (1-based)
+            for l in m:lmax
                 lm += 1             # single index lm corresponding to harmonic l, m
-                tendency[lm, k] = (tendency[lm, k] + ∇²ⁿ_expl[k][l]*A[lm, k]) * ∇²ⁿ_impl[k][l]
+                tendency[lm, k] = (tendency[lm, k] + ∇²ⁿ_expl[l, k]*A[lm, k]) * ∇²ⁿ_impl[l, k]
             end
-            lm += 1                 # skip last row for scalar quantities
         end
     end
 end
@@ -154,6 +158,7 @@ Apply horizontal diffusion to vorticity in the BarotropicModel."""
 function horizontal_diffusion!( 
     diagn::DiagnosticVariables,
     progn::PrognosticVariables,
+    diffusion::AbstractHorizontalDiffusion,
     model::Barotropic,
     lf::Integer = 1,    # leapfrog index used (2 is unstable)
 )
@@ -170,6 +175,7 @@ Apply horizontal diffusion to vorticity and divergence in the ShallowWaterModel.
 function horizontal_diffusion!( 
     diagn::DiagnosticVariables,
     progn::PrognosticVariables,
+    diffusion::AbstractHorizontalDiffusion,
     model::ShallowWater,
     lf::Integer = 1,    # leapfrog index used (2 is unstable)
 )
@@ -189,6 +195,7 @@ humidity (PrimitiveWet only) in the PrimitiveEquation models."""
 function horizontal_diffusion!(
     diagn::DiagnosticVariables,
     progn::PrognosticVariables,
+    diffusion::HyperDiffusion,
     model::PrimitiveEquation,
     lf::Integer = 1,    # leapfrog index used (2 is unstable)
 )

--- a/src/dynamics/horizontal_diffusion.jl
+++ b/src/dynamics/horizontal_diffusion.jl
@@ -236,10 +236,10 @@ export SpectralFilter
     shift::NF = 0
 
     "[OPTION] Scale-selectiveness, steepness of the sigmoid, higher is more selective"
-    scale::NF = 0.06
+    scale::NF = 0.05
     
     "[OPTION] diffusion time scale"
-    time_scale::Second = Hour(1)
+    time_scale::Second = Hour(4)
 
     "[OPTION] resolution scaling to shorten time_scale with trunc"
     resolution_scaling::NF = 1

--- a/src/dynamics/horizontal_diffusion.jl
+++ b/src/dynamics/horizontal_diffusion.jl
@@ -30,10 +30,10 @@ $(TYPEDFIELDS)"""
     power::NF = 4
     
     "[OPTION] diffusion time scale"
-    time_scale::Second = Minute(144)
+    time_scale::Second = Hour(4)
 
     "[OPTION] diffusion time scale for temperature and humidity"
-    time_scale_div::Second = Minute(60)
+    time_scale_div::Second = Hour(1)
     
     "[OPTION] stronger diffusion with resolution? 0: constant with trunc, 1: (inverse) linear with trunc, etc"
     resolution_scaling::NF = 1
@@ -247,7 +247,7 @@ export SpectralFilter
     time_scale::Second = Hour(4)
 
     "[OPTION] stronger diffusion time scale for divergence"
-    time_scale_div::Second = Hour(1)
+    time_scale_div::Second = Minute(30)
 
     "[OPTION] resolution scaling to shorten time_scale with trunc"
     resolution_scaling::NF = 1
@@ -256,7 +256,7 @@ export SpectralFilter
     power::NF = 4
 
     "[OPTION] power of the tanh function for divergence"
-    power_div::NF = 2
+    power_div::NF = 4
 
     # ARRAYS, precalculated for each spherical harmonics degree and vertical layer
     expl::MatrixType = zeros(NF, trunc+2, nlayers)  # explicit part

--- a/src/dynamics/horizontal_diffusion.jl
+++ b/src/dynamics/horizontal_diffusion.jl
@@ -232,11 +232,11 @@ export SpectralFilter
     nlayers::Int
     
     # PARAMETERS
-    "[OPTION] relative wavenumber"
-    wavenumber::NF = 0
+    "[OPTION] shift diffusion to higher (positive shift) or lower (neg) wavenumbers, relative to trunc"
+    shift::NF = 0
 
-    "[OPTION] Scale-selectiveness"
-    scale::NF = 0.052
+    "[OPTION] Scale-selectiveness, steepness of the sigmoid, higher is more selective"
+    scale::NF = 0.06
     
     "[OPTION] diffusion time scale"
     time_scale::Second = Hour(1)
@@ -271,7 +271,7 @@ function initialize!(
 )
     (; trunc, nlayers) = diffusion
     (; ∇²ⁿ, ∇²ⁿ_implicit) = diffusion
-    (; scale, wavenumber, power, resolution_scaling) = diffusion
+    (; scale, shift, power, resolution_scaling) = diffusion
     (; Δt, radius) = L
 
     # times 1/radius because time step Δt is scaled with 1/radius
@@ -280,7 +280,7 @@ function initialize!(
     for k in 1:nlayers
         for l in 0:trunc    # diffusion for every degree l, but indendent of order m
             # Explicit part
-            ∇²ⁿ[l+1, k] =  -(1 + erf(scale*(l - trunc - wavenumber)))^power / time_scale
+            ∇²ⁿ[l+1, k] =  -(1 + tanh(scale*(l - trunc - shift)))^power / time_scale
             
             # and implicit part of the diffusion (= 1/(1-2Δtν∇²ⁿ))
             ∇²ⁿ_implicit[l+1, k] = 1/(1-2Δt*∇²ⁿ[l+1, k])                    

--- a/src/dynamics/initial_conditions.jl
+++ b/src/dynamics/initial_conditions.jl
@@ -581,7 +581,7 @@ $(TYPEDFIELDS)"""
     # random interface displacement field
     A::Float64 = 2000       # amplitude [m]
     lmin::Int64 = 10        # minimum wavenumber
-    lmax::Int64 = 20        # maximum wavenumber
+    lmax::Int64 = 30        # maximum wavenumber
 end
 
 RandomWaves(S::SpectralGrid; kwargs...) = RandomWaves(;kwargs...) 
@@ -598,11 +598,15 @@ function initialize!(   progn::PrognosticVariables{NF},
     (; A, lmin, lmax) = initial_conditions
     (; trunc) = progn
 
-    η = randn(LowerTriangularMatrix{Complex{NF}}, trunc+2, trunc+1)
+    # start with matrix to have matrix indexing
+    ηm = randn(Complex{NF}, trunc+2, trunc+1)
 
     # zero out other wavenumbers
-    η[1:min(lmin, trunc+2), :] .= 0
-    η[min(lmax+2, trunc+2):trunc+2, :] .= 0
+    ηm[1:min(lmin, trunc+2), :] .= 0
+    ηm[min(lmax+2, trunc+2):trunc+2, :] .= 0
+
+    # convert to LowerTriangularMatrix with vector indexing
+    η = LowerTriangularArray(ηm)
 
     # scale to amplitude
     η_grid = transform(η, model.spectral_transform)

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -245,7 +245,7 @@ function timestep!(
 
     # TENDENCIES, DIFFUSION, LEAPFROGGING AND TRANSFORM SPECTRAL STATE TO GRID
     dynamics_tendencies!(diagn, progn, lf2, model)
-    horizontal_diffusion!(diagn, progn, model)
+    horizontal_diffusion!(diagn, progn, model.horizontal_diffusion, model)
     leapfrog!(progn, diagn.tendencies, dt, lf1, model)
     transform!(diagn, progn, lf2, model)
 
@@ -275,7 +275,7 @@ function timestep!(
     implicit_correction!(diagn, progn, model.implicit)
     
     # APPLY DIFFUSION, STEP FORWARD IN TIME, AND TRANSFORM NEW TIME STEP TO GRID
-    horizontal_diffusion!(diagn, progn, model)
+    horizontal_diffusion!(diagn, progn, model.horizontal_diffusion, model)
     leapfrog!(progn, diagn.tendencies, dt, lf1, model)
     transform!(diagn, progn, lf2, model)
     
@@ -320,7 +320,7 @@ function timestep!(
     end
 
     # APPLY DIFFUSION, STEP FORWARD IN TIME, AND TRANSFORM NEW TIME STEP TO GRID
-    horizontal_diffusion!(diagn, progn, model)
+    horizontal_diffusion!(diagn, progn, model.horizontal_diffusion, model)
     leapfrog!(progn, diagn.tendencies, dt, lf1, model)
     transform!(diagn, progn, lf2, model)
 
@@ -371,7 +371,7 @@ function time_stepping!(
         callback!(model.callbacks, progn, diagn, model)
     end
     
-    # UNSCALE, CLOSE, FINISH
+    # UNSCALE, CLOSE, FINALIZE
     finalize!(feedback)                     # finish the progress meter, do first for benchmark accuracy
     unscale!(progn)                         # undo radius-scaling for vor, div from the dynamical core
     unscale!(diagn)                         # undo radius-scaling for vor, div from the dynamical core

--- a/src/models/barotropic.jl
+++ b/src/models/barotropic.jl
@@ -47,7 +47,7 @@ $(TYPEDFIELDS)"""
     time_stepping::TS = Leapfrog(spectral_grid)
     spectral_transform::ST = SpectralTransform(spectral_grid)
     implicit::IM = NoImplicit(spectral_grid)
-    horizontal_diffusion::HD = HyperDiffusion(spectral_grid)
+    horizontal_diffusion::HD = SpectralFilter(spectral_grid)
 
     # OUTPUT
     output::OU = NetCDFOutput(spectral_grid, Barotropic)

--- a/src/models/barotropic.jl
+++ b/src/models/barotropic.jl
@@ -47,7 +47,7 @@ $(TYPEDFIELDS)"""
     time_stepping::TS = Leapfrog(spectral_grid)
     spectral_transform::ST = SpectralTransform(spectral_grid)
     implicit::IM = NoImplicit(spectral_grid)
-    horizontal_diffusion::HD = SpectralFilter(spectral_grid)
+    horizontal_diffusion::HD = HyperDiffusion(spectral_grid)
 
     # OUTPUT
     output::OU = NetCDFOutput(spectral_grid, Barotropic)

--- a/src/models/barotropic.jl
+++ b/src/models/barotropic.jl
@@ -4,7 +4,7 @@ export BarotropicModel, initialize!
 The BarotropicModel contains all model components needed for the simulation of the
 barotropic vorticity equations. To be constructed like
 
-    model = BarotropicModel(; spectral_grid, kwargs...)
+    model = BarotropicModel(spectral_grid; kwargs...)
 
 with `spectral_grid::SpectralGrid` used to initalize all non-default components
 passed on as keyword arguments, e.g. `planet=Earth(spectral_grid)`. Fields, representing

--- a/src/models/primitive_dry.jl
+++ b/src/models/primitive_dry.jl
@@ -84,7 +84,7 @@ $(TYPEDFIELDS)"""
     time_stepping::TS = Leapfrog(spectral_grid)
     spectral_transform::ST = SpectralTransform(spectral_grid)
     implicit::IM = ImplicitPrimitiveEquation(spectral_grid)
-    horizontal_diffusion::HD = SpectralFilter(spectral_grid)
+    horizontal_diffusion::HD = HyperDiffusion(spectral_grid)
     vertical_advection::VA = CenteredVerticalAdvection(spectral_grid)
     
     # OUTPUT

--- a/src/models/primitive_dry.jl
+++ b/src/models/primitive_dry.jl
@@ -84,7 +84,7 @@ $(TYPEDFIELDS)"""
     time_stepping::TS = Leapfrog(spectral_grid)
     spectral_transform::ST = SpectralTransform(spectral_grid)
     implicit::IM = ImplicitPrimitiveEquation(spectral_grid)
-    horizontal_diffusion::HD = HyperDiffusion(spectral_grid)
+    horizontal_diffusion::HD = SpectralFilter(spectral_grid)
     vertical_advection::VA = CenteredVerticalAdvection(spectral_grid)
     
     # OUTPUT

--- a/src/models/primitive_dry.jl
+++ b/src/models/primitive_dry.jl
@@ -4,7 +4,7 @@ export PrimitiveDryModel
 The PrimitiveDryModel contains all model components (themselves structs) needed for the
 simulation of the primitive equations without humidity. To be constructed like
 
-    model = PrimitiveDryModel(; spectral_grid, kwargs...)
+    model = PrimitiveDryModel(spectral_grid; kwargs...)
 
 with `spectral_grid::SpectralGrid` used to initalize all non-default components
 passed on as keyword arguments, e.g. `planet=Earth(spectral_grid)`. Fields, representing

--- a/src/models/primitive_wet.jl
+++ b/src/models/primitive_wet.jl
@@ -95,7 +95,7 @@ $(TYPEDFIELDS)"""
     time_stepping::TS = Leapfrog(spectral_grid)
     spectral_transform::ST = SpectralTransform(spectral_grid)
     implicit::IM = ImplicitPrimitiveEquation(spectral_grid)
-    horizontal_diffusion::HD = HyperDiffusion(spectral_grid)
+    horizontal_diffusion::HD = SpectralFilter(spectral_grid)
     vertical_advection::VA = CenteredVerticalAdvection(spectral_grid)
     hole_filling::HF = ClipNegatives(spectral_grid)
     

--- a/src/models/primitive_wet.jl
+++ b/src/models/primitive_wet.jl
@@ -4,7 +4,7 @@ export PrimitiveWetModel
 The PrimitiveWetModel contains all model components (themselves structs) needed for the
 simulation of the primitive equations with humidity. To be constructed like
 
-    model = PrimitiveWetModel(; spectral_grid, kwargs...)
+    model = PrimitiveWetModel(spectral_grid; kwargs...)
 
 with `spectral_grid::SpectralGrid` used to initalize all non-default components
 passed on as keyword arguments, e.g. `planet=Earth(spectral_grid)`. Fields, representing

--- a/src/models/primitive_wet.jl
+++ b/src/models/primitive_wet.jl
@@ -95,7 +95,7 @@ $(TYPEDFIELDS)"""
     time_stepping::TS = Leapfrog(spectral_grid)
     spectral_transform::ST = SpectralTransform(spectral_grid)
     implicit::IM = ImplicitPrimitiveEquation(spectral_grid)
-    horizontal_diffusion::HD = SpectralFilter(spectral_grid)
+    horizontal_diffusion::HD = HyperDiffusion(spectral_grid)
     vertical_advection::VA = CenteredVerticalAdvection(spectral_grid)
     hole_filling::HF = ClipNegatives(spectral_grid)
     

--- a/src/models/shallow_water.jl
+++ b/src/models/shallow_water.jl
@@ -4,7 +4,7 @@ export ShallowWaterModel
 The ShallowWaterModel contains all model components needed for the simulation of the
 shallow water equations. To be constructed like
 
-    model = ShallowWaterModel(; spectral_grid, kwargs...)
+    model = ShallowWaterModel(spectral_grid; kwargs...)
 
 with `spectral_grid::SpectralGrid` used to initalize all non-default components
 passed on as keyword arguments, e.g. `planet=Earth(spectral_grid)`. Fields, representing

--- a/src/models/shallow_water.jl
+++ b/src/models/shallow_water.jl
@@ -49,7 +49,7 @@ $(TYPEDFIELDS)"""
     time_stepping::TS = Leapfrog(spectral_grid)
     spectral_transform::ST = SpectralTransform(spectral_grid)
     implicit::IM = ImplicitShallowWater(spectral_grid)
-    horizontal_diffusion::HD = HyperDiffusion(spectral_grid)
+    horizontal_diffusion::HD = SpectralFilter(spectral_grid)
 
     # OUTPUT
     output::OU = NetCDFOutput(spectral_grid, ShallowWater)

--- a/src/models/shallow_water.jl
+++ b/src/models/shallow_water.jl
@@ -49,7 +49,7 @@ $(TYPEDFIELDS)"""
     time_stepping::TS = Leapfrog(spectral_grid)
     spectral_transform::ST = SpectralTransform(spectral_grid)
     implicit::IM = ImplicitShallowWater(spectral_grid)
-    horizontal_diffusion::HD = SpectralFilter(spectral_grid)
+    horizontal_diffusion::HD = HyperDiffusion(spectral_grid)
 
     # OUTPUT
     output::OU = NetCDFOutput(spectral_grid, ShallowWater)

--- a/src/models/simulation.jl
+++ b/src/models/simulation.jl
@@ -28,16 +28,11 @@ export run!
 """
 $(TYPEDSIGNATURES)
 Run a SpeedyWeather.jl `simulation`. The `simulation.model` is assumed to be initialized."""
-function run!(  simulation::AbstractSimulation;
-                period::Dates.Period = Day(10),
-                output::Bool = false,
-                n_days::Union{Nothing, Real} = nothing)
-    
-    if !isnothing(n_days)
-        @warn "run!: n_days keyword is deprecated, use period = Day(n_days) instead."
-        period = Day(n_days) 
-    end 
-
+function run!(
+    simulation::AbstractSimulation;
+    period::Period = Day(10),
+    output::Bool = false,
+)
     (; prognostic_variables, diagnostic_variables, model) = simulation
     (; clock) = prognostic_variables
 

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -81,7 +81,7 @@ end
 
     spectral_grid = SpectralGrid()
     callbacks = CallbackDict(NoCallback())
-    model = PrimitiveWetModel(; spectral_grid, callbacks)
+    model = PrimitiveWetModel(spectral_grid; callbacks)
     
     storm_chaser = StormChaser(spectral_grid)
     key = :storm_chaser

--- a/test/column_variables.jl
+++ b/test/column_variables.jl
@@ -24,7 +24,7 @@ end
 
         nlayers = 8
         spectral_grid = SpectralGrid(; NF, nlayers)
-        model = PrimitiveDryModel(; spectral_grid)
+        model = PrimitiveDryModel(spectral_grid)
         simulation = initialize!(model)
         diagn = simulation.diagnostic_variables
         progn = simulation.prognostic_variables

--- a/test/convection.jl
+++ b/test/convection.jl
@@ -11,7 +11,7 @@
             # that combination is not defined
             if ~(Convection == SimplifiedBettsMiller && Model == PrimitiveDryModel)
                 convection = Convection(spectral_grid)
-                model = Model(;spectral_grid, convection)
+                model = Model(spectral_grid; convection)
                 model.feedback.verbose = false
                 simulation = initialize!(model)
                 run!(simulation, period=Day(1))

--- a/test/diffusion.jl
+++ b/test/diffusion.jl
@@ -1,6 +1,6 @@
 @testset "Horizontal diffusion of random" begin
-    for HD in (HyperDiffusion, SpectralFilter)
-        for NF in (Float32, Float64)
+    @testset for HD in (HyperDiffusion, SpectralFilter)
+        @testset for NF in (Float32, Float64)
 
             spectral_grid = SpectralGrid(; NF)
             horizontal_diffusion = HD(spectral_grid)

--- a/test/diffusion.jl
+++ b/test/diffusion.jl
@@ -1,43 +1,46 @@
 @testset "Horizontal diffusion of random" begin
-    for NF in (Float32, Float64)
+    for HD in (HyperDiffusion, SpectralFilter)
+        for NF in (Float32, Float64)
 
-        spectral_grid = SpectralGrid(; NF)
-        model = PrimitiveDryModel(spectral_grid)
-        simulation = initialize!(model)
-        progn = simulation.prognostic_variables
-        diagn = simulation.diagnostic_variables
+            spectral_grid = SpectralGrid(; NF)
+            horizontal_diffusion = HD(spectral_grid)
+            model = PrimitiveDryModel(spectral_grid; horizontal_diffusion)
+            simulation = initialize!(model)
+            progn = simulation.prognostic_variables
+            diagn = simulation.diagnostic_variables
 
-        (; ∇²ⁿ, ∇²ⁿ_implicit) = model.horizontal_diffusion
-        vor = progn.vor[1]
-        (; vor_tend) = diagn.tendencies
+            (; expl, impl) = model.horizontal_diffusion
+            vor = progn.vor[1]
+            (; vor_tend) = diagn.tendencies
 
-        vor .= randn(LowerTriangularArray{eltype(vor)}, size(vor, as=Matrix)...)
+            vor .= randn(LowerTriangularArray{eltype(vor)}, size(vor, as=Matrix)...)
 
-        # ∇²ⁿ, ∇²ⁿ_implicit are nlayers-vectors, one array per layer, pick surface
-        SpeedyWeather.horizontal_diffusion!(vor_tend, vor, ∇²ⁿ, ∇²ⁿ_implicit)
+            # apply diffusion
+            SpeedyWeather.horizontal_diffusion!(vor_tend, vor, expl, impl)
 
-        # diffusion tendency has opposite sign (real/imag respectively)
-        # than prognostic variable to act as a dissipation 
-        (; lmax, mmax) = model.spectral_transform
-        for k in eachmatrix(vor, vor_tend)
-            for m in 1:mmax+1
-                for l in max(2, m):lmax
-                    @test -sign(real(vor[l, m, k])) == sign(real(vor_tend[l, m, k]))
-                    @test -sign(imag(vor[l, m, k])) == sign(imag(vor_tend[l, m, k]))
+            # diffusion tendency has opposite sign (real/imag respectively)
+            # than prognostic variable to act as a dissipation 
+            (; lmax, mmax) = model.spectral_transform
+            for k in eachmatrix(vor, vor_tend)
+                for m in 1:mmax+1
+                    for l in max(2, m):lmax
+                        @test -sign(real(vor[l, m, k])) == sign(real(vor_tend[l, m, k]))
+                        @test -sign(imag(vor[l, m, k])) == sign(imag(vor_tend[l, m, k]))
+                    end
                 end
             end
-        end
 
-        vor2 = progn.vor[2]
-        SpeedyWeather.leapfrog!(vor, vor2, vor_tend, model.time_stepping.Δt, 1, model.time_stepping)
+            vor2 = progn.vor[2]
+            SpeedyWeather.leapfrog!(vor, vor2, vor_tend, model.time_stepping.Δt, 1, model.time_stepping)
 
-        @test any(vor .!= vor2)    # check that at least some coefficients are different
-        @test any(vor .== vor2)    # check that at least some coefficients are identical
+            @test any(vor .!= vor2)    # check that at least some coefficients are different
+            @test any(vor .== vor2)    # check that at least some coefficients are identical
 
-        # damping should not increase real or imaginary part of variable
-        for lmk in eachindex(vor, vor2)
-            @test abs(real(vor2[lmk])) <= abs(real(vor[lmk]))
-            @test abs(imag(vor2[lmk])) <= abs(imag(vor[lmk]))
+            # damping should not increase real or imaginary part of variable
+            for lmk in eachindex(vor, vor2)
+                @test abs(real(vor2[lmk])) <= abs(real(vor[lmk]))
+                @test abs(imag(vor2[lmk])) <= abs(imag(vor[lmk]))
+            end
         end
     end
 end

--- a/test/diffusion.jl
+++ b/test/diffusion.jl
@@ -4,16 +4,18 @@
 
             spectral_grid = SpectralGrid(; NF)
             horizontal_diffusion = HD(spectral_grid)
-            model = PrimitiveDryModel(spectral_grid; horizontal_diffusion)
+            model = PrimitiveWetModel(spectral_grid; horizontal_diffusion)
             simulation = initialize!(model)
+
+            # run for a day to have non-zero vor, vor_tend
+            run!(simulation, period=Day(1))
+
             progn = simulation.prognostic_variables
             diagn = simulation.diagnostic_variables
 
             (; expl, impl) = model.horizontal_diffusion
             vor = progn.vor[1]
             (; vor_tend) = diagn.tendencies
-
-            vor .= randn(LowerTriangularArray{eltype(vor)}, size(vor, as=Matrix)...)
 
             # apply diffusion
             SpeedyWeather.horizontal_diffusion!(vor_tend, vor, expl, impl)

--- a/test/diffusion.jl
+++ b/test/diffusion.jl
@@ -7,8 +7,8 @@
             model = PrimitiveWetModel(spectral_grid; horizontal_diffusion)
             simulation = initialize!(model)
 
-            # run for a day to have non-zero vor, vor_tend
-            run!(simulation, period=Day(1))
+            # # run for a day to have non-zero vor, vor_tend
+            # run!(simulation, period=Day(1))
 
             progn = simulation.prognostic_variables
             diagn = simulation.diagnostic_variables

--- a/test/diffusion.jl
+++ b/test/diffusion.jl
@@ -2,7 +2,7 @@
     for NF in (Float32, Float64)
 
         spectral_grid = SpectralGrid(; NF)
-        model = PrimitiveDryModel(; spectral_grid)
+        model = PrimitiveDryModel(spectral_grid)
         simulation = initialize!(model)
         progn = simulation.prognostic_variables
         diagn = simulation.diagnostic_variables

--- a/test/extending.jl
+++ b/test/extending.jl
@@ -201,14 +201,14 @@
     initial_conditions = StartFromRest()
 
     # with barotropic model
-    model = BarotropicModel(; spectral_grid, initial_conditions, forcing, drag)
+    model = BarotropicModel(spectral_grid; initial_conditions, forcing, drag)
     simulation = initialize!(model)
 
     run!(simulation, period=Day(5))
     @test simulation.model.feedback.nars_detected == false
 
     # with shallow water model
-    model = ShallowWaterModel(; spectral_grid, initial_conditions, forcing, drag)
+    model = ShallowWaterModel(spectral_grid; initial_conditions, forcing, drag)
     simulation = initialize!(model)
 
     run!(simulation, period=Day(5))

--- a/test/geopotential.jl
+++ b/test/geopotential.jl
@@ -2,7 +2,7 @@
     for NF in (Float32, Float64)
         nlayers = 8
         spectral_grid = SpectralGrid(; NF, nlayers, Grid=FullGaussianGrid)
-        model = PrimitiveWetModel(; spectral_grid)
+        model = PrimitiveWetModel(spectral_grid)
         simulation = initialize!(model)
         progn = simulation.prognostic_variables
         diagn = simulation.diagnostic_variables
@@ -33,7 +33,7 @@ end
 @testset "Add geopotential and kinetic energy, compute -∇²B term, no errors" begin
     for NF in (Float32, Float64)
         spectral_grid = SpectralGrid(; NF, nlayers=8, Grid=FullGaussianGrid)
-        model = PrimitiveWetModel(; spectral_grid)
+        model = PrimitiveWetModel(spectral_grid)
         simulation = initialize!(model)
         progn = simulation.prognostic_variables
         diagn = simulation.diagnostic_variables
@@ -56,7 +56,7 @@ end
 @testset "Virtual temperature calculation" begin
     for NF in (Float32, Float64)
         spectral_grid = SpectralGrid(; NF, nlayers=8, Grid=FullGaussianGrid)
-        model = PrimitiveWetModel(; spectral_grid)
+        model = PrimitiveWetModel(spectral_grid)
         simulation = initialize!(model)
         progn = simulation.prognostic_variables
         diagn = simulation.diagnostic_variables

--- a/test/land_sea_mask.jl
+++ b/test/land_sea_mask.jl
@@ -2,7 +2,7 @@
     @testset for Mask in (LandSeaMask, AquaPlanetMask)
         spectral_grid = SpectralGrid(trunc=31, nlayers=8)
         mask = Mask(spectral_grid)
-        model = PrimitiveWetModel(; spectral_grid, land_sea_mask=mask)
+        model = PrimitiveWetModel(spectral_grid; land_sea_mask=mask)
         simulation = initialize!(model)
         model.feedback.verbose = false
         run!(simulation, period=Day(5))

--- a/test/netcdf_output.jl
+++ b/test/netcdf_output.jl
@@ -7,7 +7,7 @@ using NCDatasets, Dates
     for Grid in (FullGaussianGrid, FullClenshawGrid, OctahedralGaussianGrid, OctahedralClenshawGrid, HEALPixGrid, OctaHEALPixGrid)
         spectral_grid = SpectralGrid(nlayers=1)
         output = NetCDFOutput(spectral_grid, path=tmp_output_path)
-        model = BarotropicModel(; spectral_grid, output)
+        model = BarotropicModel(spectral_grid; output)
         simulation = initialize!(model)
         run!(simulation, output=true; period)
         @test simulation.model.feedback.nars_detected == false
@@ -33,7 +33,7 @@ end
     for output_NF in (Float32, Float64)
         spectral_grid = SpectralGrid(nlayers=1)
         output = NetCDFOutput(spectral_grid, ShallowWater, path=tmp_output_path; output_NF)
-        model = ShallowWaterModel(; spectral_grid, output)
+        model = ShallowWaterModel(spectral_grid; output)
         simulation = initialize!(model)
         run!(simulation, output=true; period)
         @test simulation.model.feedback.nars_detected == false
@@ -80,7 +80,7 @@ end
     for nlat_half in (24, 32, 48, 64)
         spectral_grid = SpectralGrid(nlayers=8)
         output = NetCDFOutput(spectral_grid, ShallowWater, path=tmp_output_path; nlat_half)
-        model = PrimitiveDryModel(; spectral_grid, output)
+        model = PrimitiveDryModel(spectral_grid; output)
         simulation = initialize!(model)
         run!(simulation, output=true; period)
         @test simulation.model.feedback.nars_detected == false
@@ -105,7 +105,7 @@ end
     spectral_grid = SpectralGrid(nlayers=8)
     for output_dt in (Hour(1), Minute(120), Hour(3), Hour(6), Day(1))
         output = NetCDFOutput(spectral_grid, PrimitiveWet, path=tmp_output_path; output_dt)
-        model = PrimitiveWetModel(; spectral_grid, output)
+        model = PrimitiveWetModel(spectral_grid; output)
         simulation = initialize!(model)
         run!(simulation, output=true; period)
         @test simulation.model.feedback.nars_detected == false
@@ -123,7 +123,7 @@ end
 
     # test outputting other model defaults
     output = NetCDFOutput(spectral_grid, Barotropic, path=tmp_output_path)
-    model = PrimitiveWetModel(; spectral_grid, output)
+    model = PrimitiveWetModel(spectral_grid; output)
     simulation = initialize!(model)
     run!(simulation, output=true; period)
     @test simulation.model.feedback.nars_detected == false
@@ -138,12 +138,12 @@ end
 
     spectral_grid = SpectralGrid()
     output = NetCDFOutput(spectral_grid, PrimitiveDry, path=tmp_output_path, id="restart-test")
-    model = PrimitiveDryModel(; spectral_grid, output)
+    model = PrimitiveDryModel(spectral_grid; output)
     simulation = initialize!(model)
     run!(simulation, output=true; period=Day(1))
 
     initial_conditions = StartFromFile(path=tmp_output_path, id="restart-test")
-    model_new = PrimitiveDryModel(; spectral_grid, initial_conditions)
+    model_new = PrimitiveDryModel(spectral_grid; initial_conditions)
     simulation_new = initialize!(model_new)
 
     progn_old = simulation.prognostic_variables
@@ -170,7 +170,7 @@ end
     
     spectral_grid = SpectralGrid()
     output = NetCDFOutput(spectral_grid, PrimitiveDry, path=tmp_output_path, id="dense-output-test", output_dt=Hour(0))
-    model = PrimitiveDryModel(; spectral_grid, output)
+    model = PrimitiveDryModel(spectral_grid; output)
     simulation = initialize!(model)
     run!(simulation, output=true; period=Day(1))
     
@@ -182,7 +182,7 @@ end
     # do a simulation with the adjust_Δt_with_output turned on 
     output = NetCDFOutput(spectral_grid, PrimitiveDry, path=tmp_output_path, id="adjust_dt_with_output-test", output_dt=Minute(70))
     time_stepping = Leapfrog(spectral_grid, adjust_with_output=true)
-    model = PrimitiveDryModel(; spectral_grid, output, time_stepping)
+    model = PrimitiveDryModel(spectral_grid; output, time_stepping)
     simulation = initialize!(model)
     run!(simulation, output=true; period=Day(1))
     t = SpeedyWeather.load_trajectory("time", model)
@@ -196,7 +196,7 @@ end
     spectral_grid = SpectralGrid()
     time_stepping = Leapfrog(spectral_grid, Δt_at_T31=Day(3650))
     output = NetCDFOutput(spectral_grid, PrimitiveDry, path=tmp_output_path, id="long-output-test", output_dt=Day(3650))
-    model = PrimitiveDryModel(; spectral_grid, output, time_stepping)
+    model = PrimitiveDryModel(spectral_grid; output, time_stepping)
     simulation = initialize!(model)
     run!(simulation, output=true, period=Day(365000))
 

--- a/test/ocean.jl
+++ b/test/ocean.jl
@@ -7,7 +7,7 @@
                         AquaPlanet)
 
         ocean = OceanModel(spectral_grid)
-        model = PrimitiveWetModel(;spectral_grid, ocean)
+        model = PrimitiveWetModel(spectral_grid; ocean)
         model.feedback.verbose = false
         simulation = initialize!(model, time=DateTime(2000,5,1))
         run!(simulation, period=Day(5))     # run for 5 days as ocean time step is 3 days by default

--- a/test/orography.jl
+++ b/test/orography.jl
@@ -2,7 +2,7 @@
     @testset for Orography in (EarthOrography, ZonalRidge)
         spectral_grid = SpectralGrid(trunc=31, nlayers=8)
         orography = Orography(spectral_grid)
-        model = PrimitiveWetModel(; spectral_grid, orography)
+        model = PrimitiveWetModel(spectral_grid; orography)
         simulation = initialize!(model)
         run!(simulation, period=Day(5))
         @test simulation.model.feedback.nars_detected == false

--- a/test/particle_advection.jl
+++ b/test/particle_advection.jl
@@ -13,7 +13,7 @@
         spectral_grid = SpectralGrid(trunc=31, nlayers=nlayers, nparticles=100)
         particle_advection = ParticleAdvection2D(spectral_grid)
 
-        model = Model(;spectral_grid, particle_advection)
+        model = Model(spectral_grid; particle_advection)
         add!(model.callbacks, ParticleTracker(spectral_grid))
 
         simulation = initialize!(model)

--- a/test/radiation.jl
+++ b/test/radiation.jl
@@ -10,7 +10,7 @@
         
         for Model in (PrimitiveDryModel,
                         PrimitiveWetModel)
-            model = Model(;spectral_grid, longwave_radiation)
+            model = Model(spectral_grid; longwave_radiation)
             model.feedback.verbose = false
             simulation = initialize!(model)
             run!(simulation, period=Day(3))

--- a/test/run_speedy.jl
+++ b/test/run_speedy.jl
@@ -1,28 +1,28 @@
 @testset "run_speedy no errors, no blowup" begin
     # Barotropic
     spectral_grid = SpectralGrid(nlayers=1)
-    model = BarotropicModel(; spectral_grid)
+    model = BarotropicModel(spectral_grid)
     simulation = initialize!(model)
     run!(simulation, period=Day(10))
     @test simulation.model.feedback.nars_detected == false
     
     # ShallowWater
     spectral_grid = SpectralGrid(nlayers=1)
-    model = ShallowWaterModel(; spectral_grid)
+    model = ShallowWaterModel(spectral_grid)
     simulation = initialize!(model)
     run!(simulation, period=Day(10))
     @test simulation.model.feedback.nars_detected == false
 
     # PrimitiveDry
     spectral_grid = SpectralGrid()
-    model = PrimitiveDryModel(; spectral_grid)
+    model = PrimitiveDryModel(spectral_grid)
     simulation = initialize!(model)
     run!(simulation, period=Day(10))
     @test simulation.model.feedback.nars_detected == false
 
     # PrimitiveWet
     spectral_grid = SpectralGrid()
-    model = PrimitiveWetModel(; spectral_grid)
+    model = PrimitiveWetModel(spectral_grid)
     simulation = initialize!(model)
     run!(simulation, period=Day(10))
     @test simulation.model.feedback.nars_detected == false

--- a/test/set.jl
+++ b/test/set.jl
@@ -5,7 +5,7 @@
     NF = Float64
     complex_NF = Complex{NF}
     spectral_grid = SpectralGrid(; NF, trunc, nlayers)  # define resolution
-    model = PrimitiveWetModel(; spectral_grid)          # construct model
+    model = PrimitiveWetModel(spectral_grid)            # construct model
     simulation = initialize!(model)                     # initialize all model components
  
     lmax = model.spectral_transform.lmax

--- a/test/spectral_gradients.jl
+++ b/test/spectral_gradients.jl
@@ -2,7 +2,7 @@
     @testset for NF in (Float32, Float64)
 
         spectral_grid = SpectralGrid(; NF, nlayers=1)
-        model = ShallowWaterModel(; spectral_grid)
+        model = ShallowWaterModel(spectral_grid)
         simulation = initialize!(model)
         progn = simulation.prognostic_variables
         diagn = simulation.diagnostic_variables
@@ -48,7 +48,7 @@ end
     @testset for NF in (Float32, Float64)
 
         spectral_grid = SpectralGrid(; NF, nlayers=1)
-        model = ShallowWaterModel(; spectral_grid)
+        model = ShallowWaterModel(spectral_grid)
         simulation = initialize!(model)
         progn = simulation.prognostic_variables
         diagn = simulation.diagnostic_variables
@@ -170,7 +170,7 @@ end
     @testset for NF in (Float32, Float64)
 
         spectral_grid = SpectralGrid(; NF, nlayers=2)
-        model = PrimitiveDryModel(; spectral_grid)
+        model = PrimitiveDryModel(spectral_grid)
         simulation = initialize!(model)
         progn = simulation.prognostic_variables
         diagn = simulation.diagnostic_variables
@@ -281,7 +281,7 @@ end
 
             trunc = 31
             spectral_grid = SpectralGrid(; NF, trunc, Grid=FullGaussianGrid, nlayers)
-            model = PrimitiveDryModel(; spectral_grid)
+            model = PrimitiveDryModel(spectral_grid)
             simulation = initialize!(model)
             progn = simulation.prognostic_variables
             diagn = simulation.diagnostic_variables

--- a/test/vertical_advection.jl
+++ b/test/vertical_advection.jl
@@ -23,7 +23,7 @@ end
                         SpeedyWeather.UpwindVerticalAdvection)
 
     for Model in model_types, VerticalAdvection in advection_schems
-        model = Model(; spectral_grid,
+        model = Model(spectral_grid;
                         vertical_advection = VerticalAdvection(spectral_grid),
                         physics=false)
         simulation = initialize!(model)


### PR DESCRIPTION
fixes #547 

- implements `SpectralFilter` as an alternative to `HyperDiffusion` but leaves that one as default
- makes `HyperDiffusion somewhat weaker for all variables except divergence
- corrects the gravity wave example in the docs