### PR TITLE
Define `zonal_mean` for any AbstractGridArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Zonal mean for AbstractGridArray [#603](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/603)
+
 ## v0.12.0
 
 - OctaminimalGaussianArray/Grid to start with 4 points around the poles [#595](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/595)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -88,6 +88,6 @@ The bibtex entry for the paper is:
 ## Funding
 
 MK received funding by the European Research Council under Horizon 2020 within the ITHACA project,
-grant agreement number 741112 from 2021-2022. From 2022-2024 this project is also funded by the
-National Science Foundation NSF. Since 2024, the main funding is from Schmidt Sciences through
-a Eric & Wendy Schmidt AI in Science Fellowship.
+grant agreement number 741112 from 2021-2022. From 2022-2024 this project was also funded by the
+National Science Foundation NSF. Since 2024, the main funding is from Schmidt Sciences LLC through
+MK's Eric & Wendy Schmidt AI in Science Fellowship.

--- a/src/RingGrids/RingGrids.jl
+++ b/src/RingGrids/RingGrids.jl
@@ -5,7 +5,7 @@ using  DocStringExtensions
 import UnicodePlots
 
 # NUMERICS
-import Statistics: mean
+import Statistics: Statistics, mean
 import FastGaussQuadrature
 import LinearAlgebra
 
@@ -95,6 +95,9 @@ export  interpolate,
         update_locator,
         update_locator!
 
+# STATISTICS
+export zonal_mean
+
 include("utility_functions.jl")
 
 # GENERAL
@@ -120,6 +123,7 @@ include("grids/octaminimal_gaussian.jl")
 # INTEGRATION AND INTERPOLATION
 include("quadrature_weights.jl")
 include("interpolation.jl")
+include("statistics.jl")
 
 # OUTPUT
 include("show.jl")

--- a/src/RingGrids/general.jl
+++ b/src/RingGrids/general.jl
@@ -294,6 +294,12 @@ function get_nlons(Grid::Type{<:AbstractGridArray}, nlat_half::Integer; both_hem
     return [get_nlon_per_ring(Grid, nlat_half, j) for j in 1:n]
 end
 
+"""$(TYPEDSIGNATURES)
+Number of longitude points per latitude ring `j`."""
+function get_nlon_per_ring(grid::AbstractGridArray, j::Integer)
+    return get_nlon_per_ring(typeof(grid), grid.nlat_half, j)
+end
+
 ## ITERATORS
 """
 $(TYPEDSIGNATURES)

--- a/src/RingGrids/statistics.jl
+++ b/src/RingGrids/statistics.jl
@@ -1,0 +1,16 @@
+"""$(TYPEDSIGNATURES)
+Zonal mean of `grid`, i.e. along its latitude rings."""
+function zonal_mean(grid::AbstractGridArray)
+    # extend to any non-horizontal dimensions of grid (e.g. vertical or time)
+    ks = size(grid)[2:end]
+    m = zeros(eltype(grid), RingGrids.get_nlat(grid), ks...)
+
+    rings = RingGrids.eachring(grid)
+    for k in eachgrid(grid)
+        for (j, ring) in enumerate(rings)
+            m[j, k] = mean(grid[ring, k])
+        end
+    end
+
+    return m
+end

--- a/src/RingGrids/statistics.jl
+++ b/src/RingGrids/statistics.jl
@@ -3,7 +3,10 @@ Zonal mean of `grid`, i.e. along its latitude rings."""
 function zonal_mean(grid::AbstractGridArray)
     # extend to any non-horizontal dimensions of grid (e.g. vertical or time)
     ks = size(grid)[2:end]
-    m = zeros(eltype(grid), RingGrids.get_nlat(grid), ks...)
+
+    # determine type T after division with integer (happening in mean)
+    T = Base.promote_op(/, eltype(grid), Int64)
+    m = zeros(T, RingGrids.get_nlat(grid), ks...)
 
     rings = RingGrids.eachring(grid)
     for k in eachgrid(grid)

--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -61,6 +61,7 @@ export  FullClenshawGrid, FullClenshawArray,
         eachring, eachgrid, plot
 export  AnvilInterpolator
 export  spherical_distance
+export  zonal_mean
 
 include("RingGrids/RingGrids.jl")
 using .RingGrids

--- a/test/grids.jl
+++ b/test/grids.jl
@@ -483,3 +483,29 @@ end
         @test all(G .== 2)
     end
 end
+
+@testset "Zonal mean" begin
+    @testset for NF in (Int32, Int64, Float16, Float32, Float64)
+        @testset for Grid in ( 
+            FullClenshawArray,
+            FullGaussianArray,
+            OctahedralGaussianArray,
+            OctahedralClenshawArray,
+            OctaminimalGaussianArray,
+            HEALPixArray,
+            OctaHEALPixArray,
+            FullHEALPixArray,
+            FullOctaHEALPixArray,
+        )
+            nlat_half = 4
+            npoints = RingGrids.get_npoints(Grid, nlat_half)
+            grid = Grid{NF}(1:npoints, nlat_half)
+        
+            zm = zonal_mean(grid)
+
+            for (j, m) in enumerate(zonal_mean(grid))
+                @test m == sum(RingGrids.eachring(grid)[j]) / RingGrids.get_nlon_per_ring(grid, j)
+            end
+        end
+    end
+end


### PR DESCRIPTION
Works like
```julia
julia> grid = rand(OctaminimalGaussianGrid, 24);

julia> zonal_mean(grid)
48-element Vector{Float64}:
 0.42047615276091105
 0.6183232426174334
 0.5419674788041474
 ...
 0.5335573970204017
 0.5450494457321489
 0.5580410685173629
```

but also for higher dimensional grids to compute for example the zonal mean on every vertical layer
```julia
julia> grid = rand(OctahedralGaussianGrid, 24, 8);

julia> zonal_mean(grid)
48×8 Matrix{Float64}:
 0.405402  0.47431   0.576086  0.537575  0.600084  0.449199  0.447076  0.339065
 0.449003  0.507051  0.517339  0.591228  0.529189  0.440736  0.477669  0.584857
 0.427745  0.567123  0.631275  0.420446  0.480813  0.471277  0.465219  0.453441
...
 0.474773  0.531362  0.627162  0.527202  0.543062  0.422074  0.540145  0.504732
 0.563937  0.522871  0.523507  0.535094  0.517435  0.611373  0.521471  0.519368
 0.596201  0.493693  0.518514  0.518096  0.563179  0.658203  0.46003   0.506762
```
which would return a latitude x layers "slice", which can for example be used to plot the zonal mean zonal velocity

![image](https://github.com/user-attachments/assets/ab3f44c2-fea5-4eb6-8bda-7ded1b7f41f1)

or zonally averaged total precipitation

![image](https://github.com/user-attachments/assets/f795006d-9cdf-4b45-a4c3-81d995954531)

@minqi6