### PR TITLE
large-scale condensation at <100% 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - SpectralFilter for horizontal diffusion [#601](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/601)
 - GeoMakie weak dependency, globe function for 3D data visualisation [#600](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/600)
 - Zonal mean for AbstractGridArray [#603](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/603)
+- bugfix: large-scale condensation also at <100% [#609](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/609)
 
 ## v0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+- bugfix: large-scale condensation also at <100% [#609](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/609)
+
+## v0.12.1
+
 - ConstantLandTemperature implemented [#612](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/612)
 - set! for more boundary conditions [#611](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/611)
 - SpectralFilter for horizontal diffusion [#601](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/601)
 - GeoMakie weak dependency, globe function for 3D data visualisation [#600](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/600)
 - Zonal mean for AbstractGridArray [#603](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/603)
-- bugfix: large-scale condensation also at <100% [#609](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/609)
 
 ## v0.12.0
 

--- a/docs/src/large_scale_condensation.md
+++ b/docs/src/large_scale_condensation.md
@@ -105,6 +105,22 @@ This also means that at higher resolution condensation is more immediate than
 at low resolution, but the dispersive time integration of this term is in all
 cases similar (and not much higher at lower resolution).
 
+The above implied that condensation takes place at 100% relative humidity as
+we are directly comparing the specific humidity to the saturation specific humidity
+in ``q^\star - q_i``. However, in coarse-resolution models there is a good argument
+that condensation may already take place below a grid-cell average of 100% relative humidity.
+Given some subgrid-scale variability parts of the grid cells may condense even though
+the average humidity is below 100%. To change this threshold one can introduce
+a parameter ``r``, e.g. ``r=0.95`` for condensation to take place at 95% relative humidity,
+as follows
+
+```math
+\delta q = \frac{q_{i+1} - q_i}{\Delta t} &= \frac{rq^\star(T_i) - q_i}{ \Delta t_c
+\left( 1 + \frac{L_vr}{c_p} \frac{\partial q^\star}{\partial T}(T_i) \right)}
+```
+``r`` is linear scale and therefore taken out of the gradient ``\frac{\partial q^\star}{\partial T}``
+in the denominator.
+
 ## Large-scale precipitation
 
 The tendencies ``\delta q`` in units of  kg/kg/s are vertically

--- a/src/physics/large_scale_condensation.jl
+++ b/src/physics/large_scale_condensation.jl
@@ -85,10 +85,10 @@ function large_scale_condensation!(
         if humid[k] > sat_humid[k]*relative_humidity_threshold
 
             # tendency for Implicit humid = sat_humid, divide by leapfrog time step below
-            δq = sat_humid[k] - humid[k]
+            δq = sat_humid[k] * relative_humidity_threshold - humid[k]
 
             # implicit correction, Frierson et al. 2006 eq. (21)
-            dqsat_dT = sat_humid[k] * Lᵥ_Rᵥ/temp[k]^2       # derivative of qsat wrt to temp
+            dqsat_dT = sat_humid[k] * relative_humidity_threshold * Lᵥ_Rᵥ/temp[k]^2       # derivative of qsat wrt to temp
             δq /= ((1 + Lᵥ_cₚ*dqsat_dT) * time_scale*Δt_sec) 
 
             # latent heat release for enthalpy conservation

--- a/test/large_scale_cond.jl
+++ b/test/large_scale_cond.jl
@@ -1,0 +1,15 @@
+@testset "Large-scale condensation" begin
+    spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+    @testset for r in (0.8, 0.9, 1.0)
+        large_scale_condensation = ImplicitCondensation(spectral_grid, relative_humidity_threshold=r)
+        model = PrimitiveWetModel(spectral_grid; large_scale_condensation)
+        simulation = initialize!(model)
+        run!(simulation, period=Day(5))
+        
+        precip = simulation.diagnostic_variables.physics.precip_large_scale
+
+        for ij in eachindex(precip)
+            @test precip[ij] >= 0   # precipitation should always be non-negative
+        end
+    end
+end


### PR DESCRIPTION
The problem is that large-scale condensation at <100% currently gives negative precipitation as the `ImplicitCondensation` isn't correctly generalised for other thresholds than 1=100%

from #614 

```julia
using SpeedyWeather
spectral_grid = SpectralGrid(trunc=31, nlayers=8)
large_scale_condensation = ImplicitCondensation(spectral_grid, relative_humidity_threshold = 0.8)
convection = SimplifiedBettsMiller(spectral_grid)
model = PrimitiveWetModel(; spectral_grid, large_scale_condensation, convection)
simulation = initialize!(model, time=DateTime(2007, 1, 1))
run!(simulation, period=Day(20), output=true)
```

![image](https://github.com/user-attachments/assets/31605911-2a4c-492b-9d77-aabc64b78185)

