### PR TITLE
Power spectrum for n-dimensional LowerTriangularArray

### DIFF
--- a/src/LowerTriangularMatrices/lower_triangular_array.jl
+++ b/src/LowerTriangularMatrices/lower_triangular_array.jl
@@ -221,6 +221,14 @@ end
     return getindex(L.data, k, I[3:end]...)
 end
 
+@inline function Base.getindex(L::LowerTriangularArray{T, N}, i::Integer, j::Integer, c::CartesianIndex) where {T, N}
+    @boundscheck length(c)+1 == N || throw(BoundsError(L, I))
+    @boundscheck (0 < i <= L.m && 0 < j <= L.n) || throw(BoundsError(L, (i, j)))
+    @boundscheck j > i && return zero(T) 
+    k = ij2k(i, j, L.m)
+    return getindex(L.data, k, c)
+end
+
 @inline function Base.getindex(L::LowerTriangularMatrix{T}, col::Colon, i::Integer) where T
     if i==1
         return L.data[1:size(L, 1, as=Matrix)]

--- a/src/SpeedyTransforms/spectrum.jl
+++ b/src/SpeedyTransforms/spectrum.jl
@@ -1,6 +1,8 @@
 """$(TYPEDSIGNATURES)
 Compute the power spectrum of the spherical harmonic coefficients
-`spec` (lower triangular matrix/array) of type `Complex{NF}`."""
+`spec` (lower triangular matrix/array) of type `Complex{NF}`.
+For any additional dimensions in `spec`, the power spectrum is
+computed along the first/spherical harmonic dimension."""
 function power_spectrum(
     spec::LowerTriangularArray;
     normalize::Bool=true,
@@ -9,24 +11,28 @@ function power_spectrum(
     lmax, mmax = size(spec, OneBased, as=Matrix)    # 1-based max degree l, order m
     trunc = min(lmax, mmax)                         # consider only the triangle
                                                     # ignore higher degrees if lmax > mmax
-    spectrum = zeros(real(eltype(spec)), trunc)   
+    spectrum = zeros(real(eltype(spec)), trunc, size(spec)[2:end]...)   
 
-    # zonal modes m = 0, *1 as not mirrored at -m
-    @inbounds for l in 1:trunc
-        spectrum[l] = abs(spec[l, 1])^2
-    end
+    for k in eachmatrix(spec)
+        # zonal modes m = 0, *1 as not mirrored at -m
+        for l in 1:trunc    # use flat/vector indexing
+            spectrum[l, k] = abs(spec[l, k])^2
+        end
 
-    # other modes m > 0 *2 as complex conj at -m
-    @inbounds for m in 2:trunc
-        for l in m:trunc
-            spectrum[l] += 2*abs(spec[l, m])^2
+        # other modes m > 0 *2 as complex conj at -m
+        for m in 2:trunc
+            for l in m:trunc
+                spectrum[l, k] += 2*abs(spec[l, m, k])^2
+            end
         end
     end
 
     # divide by number of orders m at l for normalization, "average power at l"
     if normalize
-        @inbounds for l in 1:trunc  # 1-based degree, hence:
-            spectrum[l] /= 2l-1     # 1/(2l + 1) but l → l-1
+        for k in eachmatrix(spec)
+            for l in 1:trunc            # 1-based degree, hence:
+                spectrum[l, k] /= 2l-1  # 1/(2l + 1) but l → l-1
+            end
         end
     end
 


### PR DESCRIPTION
This allows to calculate the power spectrum on n-dimensional LowerTriangularArrays along the first/spherical harmonic dimension, e.g.
```julia
julia> L
15×2 LowerTriangularArray{ComplexF32, 2, Matrix{ComplexF32}}:
 -0.382899-0.119496im   -0.403847+0.663406im
 -0.364989+0.0916957im   0.258135+0.630038im
 -0.712897-0.499565im    -1.26181-0.6088im
 -0.700691+0.644983im   -0.360479+0.602015im
   1.12504+0.768878im   -0.579596+1.31353im
  -1.29236-0.566898im    0.688637+0.0492758im
 -0.732031-1.05859im      1.06551-1.45981im
 -0.601207+0.140327im     0.61631+0.334235im
  0.244479-0.205514im     0.38642+0.428516im
 0.0773385+1.09861im     -1.01195-1.18484im
  0.950894-0.682852im   -0.301167-0.599011im
 -0.628636+0.487482im    0.450988+0.312973im
 -0.331025+1.8114im     -0.648268+0.942647im
   1.26967+0.858582im   -0.424846-0.124433im
  0.107177-0.159691im   -0.127849-0.105034im

julia> L[:, 1]
15-element, 5x5 LowerTriangularMatrix{ComplexF32}
 -0.382899-0.119496im         0.0+0.0im       …        0.0+0.0im            0.0+0.0im
 -0.364989+0.0916957im   -1.29236-0.566898im           0.0+0.0im            0.0+0.0im
 -0.712897-0.499565im   -0.732031-1.05859im            0.0+0.0im            0.0+0.0im
 -0.700691+0.644983im   -0.601207+0.140327im     -0.331025+1.8114im         0.0+0.0im
   1.12504+0.768878im    0.244479-0.205514im       1.26967+0.858582im  0.107177-0.159691im

julia> SpeedyTransforms.power_spectrum(L)
5×2 Matrix{Float32}:
 0.160891  0.6032
 1.37493   0.472293
 1.29932   2.67026
 1.59882   0.713167
 0.899884  0.41962

julia> SpeedyTransforms.power_spectrum(L[:, 1])
5-element Vector{Float32}:
 0.16089073
 1.374925
 1.2993188
 1.5988191
 0.8998841

julia> SpeedyTransforms.power_spectrum(L[:, 2])
5-element Vector{Float32}:
 0.6032003
 0.4722927
 2.6702583
 0.7131671
 0.4196203
```