### PR TITLE
Introduce separate extended tests in CI 

### DIFF
--- a/.github/workflows/extended_tests.yml
+++ b/.github/workflows/extended_tests.yml
@@ -1,0 +1,29 @@
+name: Extended Test
+# Weekly extended tests
+on:
+  schedule:
+    - cron: '0 2 * * 0'  # Daily at 2 AM UTC every Sunday
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - '1.11'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          test_args: 'extended_tests'
+        env:
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/julianightly.yml
+++ b/.github/workflows/julianightly.yml
@@ -1,5 +1,5 @@
 name: JuliaNightly
-# Nightly Scheduled Julia Nightly Run
+# Nightly Scheduled Julia Nightly Run with extended tests
 on:
   schedule:
     - cron: '0 2 * * 0'  # Daily at 2 AM UTC every Sunday
@@ -28,3 +28,4 @@ jobs:
         uses: julia-actions/julia-runtest@v1
         with:
           coverage: false
+          test_args: 'extended_tests'

--- a/.github/workflows/julianightly.yml
+++ b/.github/workflows/julianightly.yml
@@ -1,5 +1,5 @@
 name: JuliaNightly
-# Nightly Scheduled Julia Nightly Run with extended tests
+# Nightly Scheduled Julia Nightly Run
 on:
   schedule:
     - cron: '0 2 * * 0'  # Daily at 2 AM UTC every Sunday
@@ -28,4 +28,3 @@ jobs:
         uses: julia-actions/julia-runtest@v1
         with:
           coverage: false
-          test_args: 'extended_tests'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Introduced seperate extended tests that are not run on every commit [#628](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/628)
 - One-band longwave radiation [#624](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/624)
 - compat entry for FiniteDifferences.jl [#620](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/620)
 - Slab ocean and net surface fluxes [#613](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/613)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,10 @@ using Test
 
 FLAG_EXTENDED_TESTS = "extended_tests" in ARGS ? true : false
 
+if FLAG_EXTENDED_TESTS 
+    @info "Running extended test suite"
+end 
+
 # GENERAL
 include("utility_functions.jl")
 include("dates.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using SpeedyWeather
 using Test
 
+FLAG_EXTENDED_TESTS = "extended_tests" in ARGS ? true : false
+
 # GENERAL
 include("utility_functions.jl")
 include("dates.jl")


### PR DESCRIPTION
This introduces a flag `FLAG_EXTENDED_TESTS` in the tests that mark tests that are not run in the regular CI, but only in the weekly CI. 

The first tests that went into this category are the more high-level differentiability tests. The low-level `test_reverse` from `EnzymeTestUtils` are staying in the main tests. 