### PR TITLE
Clamp in ZonalWind to [0, 1] for sqrt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bug: ZonalWind had sqrt of negative for uncommon resolutions [#649](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/649)
 - Spectral Gradients are now differentiable, with correctness check in extended CI [#638](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/638)
 - Tracer advection [#579](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/579)
 - Buildkite CI with dummy pipeline [#646](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/646)

--- a/src/dynamics/initial_conditions.jl
+++ b/src/dynamics/initial_conditions.jl
@@ -289,7 +289,7 @@ function initialize!(   progn::PrognosticVariables{NF},
             R = radius*perturb_radius # spatial extent of perturbation
 
             # great circle distance to perturbation
-            X = sinφc*sinφ + cosφc*cosφ*cosd(λij-λc)
+            X = clamp(sinφc*sinφ + cosφc*cosφ*cosd(λij-λc), 0, 1)
             X_norm = 1/sqrt(1-X^2)
             r = radius*acos(X)
             exp_decay = exp(-(r/R)^2)

--- a/test/resolutions.jl
+++ b/test/resolutions.jl
@@ -1,0 +1,9 @@
+@testset "Single time step at uncommon resolutions" begin
+    @testset for trunc in rand(15:200, 10)
+        spectral_grid = SpectralGrid(; trunc, Grid=FullClenshawGrid)
+        model = PrimitiveWetModel(spectral_grid)
+        simulation = initialize!(model)
+        run!(simulation, period=Day(0))
+        @test simulation.model.feedback.nars_detected == false
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,7 @@ include("random_process.jl")
 include("stochastic_physics.jl")
 
 # INITIALIZATION AND INTEGRATION
+include("resolutions.jl")
 include("run_speedy.jl")
 
 # EXTENSION


### PR DESCRIPTION
@simone-silvestri found a bug

```julia
julia> spectral_grid = SpectralGrid(trunc=119, Grid=FullClenshawGrid, dealiasing=2)
SpectralGrid:
├ Spectral:   T119 LowerTriangularMatrix{Complex{Float32}}, radius = 6.371e6 m
├ Grid:       179-ring FullClenshawGrid{Float32}, 64440 grid points
├ Resolution: 89km (average)
├ Vertical:   8-layer SigmaCoordinates
└ Device:     CPU using Array

julia> model = PrimitiveWetModel(spectral_grid)

julia> simulation = initialize!(model)
[ Info: Time step changed from 640000 to 600000 milliseconds (-6%) to match output frequency.
ERROR: DomainError with -2.4943467069604708e-8:
sqrt was called with a negative real argument but will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
 [1] throw_complex_domainerror(f::Symbol, x::Float64)
   @ Base.Math ./math.jl:33
 [2] sqrt
   @ ./math.jl:608 [inlined]
 [3] initialize!(progn::PrognosticVariables{…}, initial_conditions::ZonalWind, model::PrimitiveWetModel{…})
   @ SpeedyWeather ~/.julia/packages/SpeedyWeather/qwHr6/src/dynamics/initial_conditions.jl:293
```