### PR TITLE
CI ExtendedTtests on 1.10 as well

### DIFF
--- a/.github/workflows/extended_tests.yml
+++ b/.github/workflows/extended_tests.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         version:
+          - '1.10'
           - '1.11'
         os:
           - ubuntu-latest


### PR DESCRIPTION
There still seem to be some differences between Enzyme on Julia 1.10 and 1.11. So, I want to run the extended test set on both. 