### PR TITLE
Grid cell average bug fixes

### DIFF
--- a/src/RingGrids/interpolation.jl
+++ b/src/RingGrids/interpolation.jl
@@ -533,7 +533,7 @@ function grid_cell_average!(
         j1 = findlast( θ -> θ <  θ1, colat_in)
 
         for ij in ring
-            ϕ0 = mod(lons_out[ij] - Δϕ/2, 2π)        # western edge
+            ϕ0 = mod(lons_out[ij] - Δϕ/2, 2π)       # western edge
             ϕ1 = ϕ0 + Δϕ                            # eastern edge
             # the last line does not require a mod and in fact throws
             # an error if, as long as the offset from prime meridian
@@ -541,8 +541,12 @@ function grid_cell_average!(
             # Gaussian and Clenshaw grids)
 
             # matrix indices for input grid that lie in output grid cell
-            a = findfirst(ϕ -> ϕ >= ϕ0, lon_in)
-            b = findlast( ϕ -> ϕ <  ϕ1, lon_in)
+            a = findlast( ϕ -> ϕ <  ϕ0, lon_in)     # western edge
+            b = findfirst(ϕ -> ϕ >= ϕ1, lon_in)     # eastern edge
+
+            # map around prime meridian if coordinates outside of range
+            a = isnothing(a) ? nlon_in : a
+            b = isnothing(b) ? 1 : b
             
             # in most cases we will have 1 <= a < b <=n, then loop i in a:b (b:a isn't looping)
             # however at the edges we have a < 1 or n < b the mod turns this into
@@ -550,7 +554,7 @@ function grid_cell_average!(
             ab, ba = b < a ? (1:b, a:nlon_in) : (a:b, b:a)
 
             sum_of_weights = 0
-            @inbounds for j′ in j0:j1
+            for j′ in j0:j1
                     
                 for i in ab
                     w = coslat[j′]

--- a/src/physics/land_sea_mask.jl
+++ b/src/physics/land_sea_mask.jl
@@ -95,6 +95,8 @@ function initialize!(land_sea_mask::LandSeaMask, model::PrimitiveEquation)
     RingGrids.grid_cell_average!(land_sea_mask.mask, lsm_highres)
 
     # TODO this shoudln't be necessary, but at the moment grid_cell_average! can return values > 1
+    # lo, hi = extrema(land_sea_mask.mask)
+    # (lo < 0 || hi > 1) && @warn "Land-sea mask has values in [$lo, $hi], clamping to [0, 1]."
     clamp!(land_sea_mask.mask, 0, 1)
 end
 

--- a/test/grids/interpolation.jl
+++ b/test/grids/interpolation.jl
@@ -211,3 +211,22 @@ end
 
     @test B == C
 end
+
+@testset "Grid cell average" begin
+    for Grid in (   FullGaussianGrid,
+                    FullClenshawGrid,
+                    OctahedralGaussianGrid,
+                    OctahedralClenshawGrid,
+                    OctaminimalGaussianGrid,
+                    HEALPixGrid,
+                    OctaHEALPixGrid)
+                
+        for trunc in (31, 42, 63)
+
+            spectral_grid = SpectralGrid(; trunc, Grid)
+
+            land_sea_mask = LandSeaMask(spectral_grid)
+            initialize!(land_sea_mask, PrimitiveDryModel(spectral_grid))
+        end
+    end
+end


### PR DESCRIPTION
fixes #644 and therefore provides a temporary bypass of #648 by fixing bugs in `RingGrids.grid_cell_average!`. Eventually we want to do solve #648 via https://github.com/JuliaGeo/GeometryOps.jl/issues/246 i.e. by calculating area intersections but for now let's just do it the hacky way.

This seems to work

![image](https://github.com/user-attachments/assets/cf617a55-27aa-422d-986d-7dc2f741b789)

and added some tests too