### PR TITLE
run! with steps argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Allow steps to be specified for for run!(simulation, steps=n) [#684](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/684)
 - Restrict extended CI tests to Julia v1.10 (due to Enzyme) [#681](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/681)
 - SigmaCoordinates constructors [#679](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/679)
 - Full timestepping differentiable by Enzyme with Julia 1.10 [#656](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/656)

--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -26,7 +26,7 @@ import UnicodePlots
 import ProgressMeter
 
 # to avoid a `using Dates` to pass on DateTime arguments
-export DateTime, Second, Minute, Hour, Day, Week
+export DateTime, Millisecond, Second, Minute, Hour, Day, Week
 
 # export functions that have many cross-component methods
 export initialize!, finalize!

--- a/src/dynamics/clock.jl
+++ b/src/dynamics/clock.jl
@@ -52,46 +52,35 @@ function Base.copy!(clock::Clock, clock_old::Clock)
     return nothing 
 end 
 
-"""
-$(TYPEDSIGNATURES)
-Initialize the clock with the time step `Δt` in the `time_stepping`."""
-function initialize!(
-    clock::Clock,
-    time_stepping::AbstractTimeStepper;
-    n_timesteps::Int = -1,
-)
-    # if >=0 use to set n_timesteps, otherwise calculate from period
-    if n_timesteps >= 0
-        clock.n_timesteps = n_timesteps
-        clock.period = Second(time_stepping.Δt_sec * n_timesteps)
-    else
-        clock.n_timesteps = ceil(Int, clock.period.value/time_stepping.Δt_sec)
-    end
-    
+"""$(TYPEDSIGNATURES)
+Initialize the clock with the time step `Δt` from `time_stepping`."""
+initialize!(clock::Clock, time_stepping::Leapfrog, args...) =
+    initialize!(clock, time_stepping.Δt_millisec, args...)
+
+"""$(TYPEDSIGNATURES)
+Initialize the clock with the time step `Δt` and `period` to integrate for."""
+function initialize!(clock::Clock, Δt::Period, period::Period)
+    clock.Δt = Δt
+    clock.period = period
+    clock.n_timesteps = ceil(Int, Millisecond(period).value/Millisecond(Δt).value)
+    initialize!(clock)      # set start time, reset counter
+end
+
+"""$(TYPEDSIGNATURES)
+Initialize the clock with the time step `Δt` and the number of time steps `n_timesteps`."""
+function initialize!(clock::Clock, Δt::Period, n_timesteps::Integer)
+    clock.Δt = Δt
+    clock.n_timesteps = n_timesteps
+    clock.period = Δt * n_timesteps
+    initialize!(clock)
+end
+
+"""$(TYPEDSIGNATURES)
+Initialize the clock with setting the start time and resetting the timestep counter."""
+function initialize!(clock::Clock)
     clock.start = clock.time    # store the start time
     clock.timestep_counter = 0  # reset counter
-    clock.Δt = time_stepping.Δt_millisec
     return clock
-end
-
-function set_period!(clock::Clock, steps::Integer)
-    clock.period = Second(period)
-end
-
-
-"""
-$(TYPEDSIGNATURES)
-Set the `period` of the clock to a new value. Converts any `Dates.Period` input to `Second`."""
-function set_period!(clock::Clock, period::Period)
-    clock.period = Second(period)
-end
-
-"""
-$(TYPEDSIGNATURES)
-Set the `period` of the clock to a new value. Converts any `::Real` input to `Day`."""
-function set_period!(clock::Clock, period::Real)
-    @info "Input $period assumed to have units of days. Use Week($period), Hour($period), Minute($period) otherwise."
-    clock.period = Day(period)
 end
 
 """
@@ -99,5 +88,5 @@ $(TYPEDSIGNATURES)
 Create and initialize a clock from `time_stepping`"""
 function Clock(time_stepping::AbstractTimeStepper; kwargs...)
     clock = Clock(; kwargs...)
-    initialize!(clock, time_stepping)
+    initialize!(clock, time_stepping, clock.period)
 end

--- a/src/dynamics/clock.jl
+++ b/src/dynamics/clock.jl
@@ -14,7 +14,7 @@ Base.@kwdef mutable struct Clock <: AbstractClock
     "start time of simulation"
     start::DateTime = DEFAULT_DATE
     
-    "period to integrate for, set in set_period!(::Clock, ::Dates.Period)"
+    "period to integrate for"
     period::Second = Second(0)
 
     "Counting all time steps during simulation"

--- a/src/dynamics/clock.jl
+++ b/src/dynamics/clock.jl
@@ -54,7 +54,7 @@ end
 
 """$(TYPEDSIGNATURES)
 Initialize the clock with the time step `Δt` from `time_stepping`."""
-initialize!(clock::Clock, time_stepping::Leapfrog, args...) =
+initialize!(clock::Clock, time_stepping::AbstractTimeStepper, args...) =
     initialize!(clock, time_stepping.Δt_millisec, args...)
 
 """$(TYPEDSIGNATURES)

--- a/src/models/simulation.jl
+++ b/src/models/simulation.jl
@@ -65,14 +65,12 @@ function initialize!(
     (; clock) = progn
     (; time_stepping) = model
     if steps != DEFAULT_TIMESTEPS
-        @assert steps > 0 "steps must be positive, got $steps"
-        @assert period == DEFAULT_PERIOD "Period and steps cannot be set simultaneously"
-        
         # sets the steps, calculate period from it, store the start date, reset counter
-        initialize!(clock, time_stepping, n_timesteps=steps)    
+        @assert period == DEFAULT_PERIOD "Period and steps cannot be set simultaneously"
+        initialize!(clock, time_stepping, steps)    
     else
-        set_period!(clock, period)              # set how long to integrate for
-        initialize!(clock, time_stepping)       # store the start date, reset counter
+        # set period = how long to integrate for, tore the start date, reset counter
+        initialize!(clock, time_stepping, period)
     end
 
     # OUTPUT

--- a/test/dynamics/time_stepping.jl
+++ b/test/dynamics/time_stepping.jl
@@ -129,7 +129,7 @@ end
 end
 
 @testset "Set clock" begin
-    spectral_grid = SpectralGrid()
+    spectral_grid = SpectralGrid(nlayers=1)
     time_stepping = Leapfrog(spectral_grid)
     Δt = time_stepping.Δt_at_T31
 
@@ -146,5 +146,11 @@ end
     initialize!(clock, time_stepping, period)
     @test clock.period == period
     @test clock.n_timesteps == ceil(Int, Millisecond(period).value/time_stepping.Δt_millisec.value)
+
+    model = BarotropicModel(spectral_grid)
+    simulation = initialize!(model)
+    run!(simulation, steps=1)
+    run!(simulation, period=Hour(1))
+    @test_throws AssertionError run!(simulation, steps=1, period=Day(1))
 end
     

--- a/test/dynamics/time_stepping.jl
+++ b/test/dynamics/time_stepping.jl
@@ -144,7 +144,7 @@ end
     clock = Clock()
     period = Day(10)
     initialize!(clock, time_stepping, period)
-    @test clock.period == Period
+    @test clock.period == period
     @test clock.n_timesteps == ceil(Int, Millisecond(period).value/time_stepping.Δt_millisec.value)
 end
     

--- a/test/dynamics/time_stepping.jl
+++ b/test/dynamics/time_stepping.jl
@@ -127,30 +127,3 @@ end
         @test time_stepping.Δt_sec == 20*60
     end
 end
-
-@testset "Set clock" begin
-    spectral_grid = SpectralGrid(nlayers=1)
-    time_stepping = Leapfrog(spectral_grid)
-    Δt = time_stepping.Δt_at_T31
-
-    # set n_timesteps
-    clock = Clock()
-    n_timesteps = 100
-    initialize!(clock, time_stepping, n_timesteps)
-    @test clock.n_timesteps == 100
-    @test clock.period == Second(100*Δt)
-
-    # set period
-    clock = Clock()
-    period = Day(10)
-    initialize!(clock, time_stepping, period)
-    @test clock.period == period
-    @test clock.n_timesteps == ceil(Int, Millisecond(period).value/time_stepping.Δt_millisec.value)
-
-    model = BarotropicModel(spectral_grid)
-    simulation = initialize!(model)
-    run!(simulation, steps=1)
-    run!(simulation, period=Hour(1))
-    @test_throws AssertionError run!(simulation, steps=1, period=Day(1))
-end
-    

--- a/test/dynamics/time_stepping.jl
+++ b/test/dynamics/time_stepping.jl
@@ -128,14 +128,23 @@ end
     end
 end
 
-@testset "Set n_timesteps" begin
+@testset "Set clock" begin
     spectral_grid = SpectralGrid()
     time_stepping = Leapfrog(spectral_grid)
     Δt = time_stepping.Δt_at_T31
 
+    # set n_timesteps
     clock = Clock()
-    initialize!(clock, time_stepping, n_timesteps=100)
+    n_timesteps = 100
+    initialize!(clock, time_stepping, n_timesteps)
     @test clock.n_timesteps == 100
     @test clock.period == Second(100*Δt)
+
+    # set period
+    clock = Clock()
+    period = Day(10)
+    initialize!(clock, time_stepping, period)
+    @test clock.period == Period
+    @test clock.n_timesteps == ceil(Int, Millisecond(period).value/time_stepping.Δt_millisec.value)
 end
     

--- a/test/dynamics/time_stepping.jl
+++ b/test/dynamics/time_stepping.jl
@@ -127,3 +127,15 @@ end
         @test time_stepping.Δt_sec == 20*60
     end
 end
+
+@testset "Set n_timesteps" begin
+    spectral_grid = SpectralGrid()
+    time_stepping = Leapfrog(spectral_grid)
+    Δt = time_stepping.Δt_at_T31
+
+    clock = Clock()
+    initialize!(clock, time_stepping, n_timesteps=100)
+    @test clock.n_timesteps == 100
+    @test clock.period == Second(100*Δt)
+end
+    

--- a/test/output/schedule.jl
+++ b/test/output/schedule.jl
@@ -7,8 +7,7 @@
 
         clock = Clock()
         period = Day(1)
-        SpeedyWeather.set_period!(clock, period)
-        initialize!(clock, time_stepping)
+        initialize!(clock, time_stepping, period)
 
         hour = Hour(2)
         schedule = Schedule(every=hour)

--- a/test/physics/convection.jl
+++ b/test/physics/convection.jl
@@ -15,7 +15,8 @@
                 model = Model(spectral_grid; convection)
                 model.feedback.verbose = false
                 simulation = initialize!(model)
-                run!(simulation, period=Day(1))
+
+                run!(simulation, steps=36)
             end
         end
     end


### PR DESCRIPTION
I thought it would be neat if
```julia
run!(simulation, steps=5)
```

was also possible, so that also some specified numer of time steps can be run. I find myself in tests often in the position where I just want to make sure that the model runs for some time steps without throwing an error, so something like the above would be neat.