### PR TITLE
Reverse for AbstractGridArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reverse for AbstractGridArrays [#691](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/691)
 - LandGeometry, LandThermodynamics as component of LandModel, DryLandModel [#677](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/677)
 - Diagnostic albedo separate for ocean/land [#677](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/677)
 - Increasing precision for accumulated precipitation output [#685](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/685)

--- a/src/RingGrids/RingGrids.jl
+++ b/src/RingGrids/RingGrids.jl
@@ -109,6 +109,7 @@ include("full_grids.jl")
 include("reduced_grids.jl")
 include("scaling.jl")
 include("geodesics.jl")
+include("reverse.jl")
 
 # FULL GRIDS
 include("grids/full_gaussian.jl")

--- a/src/RingGrids/reverse.jl
+++ b/src/RingGrids/reverse.jl
@@ -1,3 +1,4 @@
+Base._reverse!(grid::AbstractGridArray, sym::Symbol) = Base._reverse!(grid, Val(sym))
 Base._reverse!(grid::AbstractGridArray, ::Val{Colon()}) = reverse!(grid)
 
 function Base._reverse!(grid::AbstractGridArray, ::Val{:lat})

--- a/src/RingGrids/reverse.jl
+++ b/src/RingGrids/reverse.jl
@@ -1,0 +1,41 @@
+Base._reverse!(grid::AbstractGridArray, ::Val{Colon()}) = reverse!(grid)
+
+function Base._reverse!(grid::AbstractGridArray, ::Val{:lat})
+
+    rings = eachring(grid)
+    nrings = length(rings)
+    rings_north = view(rings, 1:nrings ÷ 2)
+
+    for k in eachgrid(grid)
+        for (j_north, ring) in enumerate(rings_north)
+            j_south = nrings - j_north + 1
+            for (i, ij_north) in enumerate(ring)
+                ij_south = rings[j_south][i]
+
+                # read out northern and southern values
+                north = grid[ij_north, k]
+                south = grid[ij_south, k]
+
+                # and swap them
+                grid[ij_north, k] = south
+                grid[ij_south, k] = north
+            end
+        end
+    end
+
+    return grid
+end
+
+function Base._reverse!(grid::AbstractGridArray, ::Val{:lon})
+    for k in eachgrid(grid)
+        for ring in eachring(grid)
+            grid_ring = view(grid, ring, k)
+            reverse!(grid_ring)
+        end
+    end
+    return grid
+end
+
+# also allow long names longitude, latitude
+Base._reverse!(grid::AbstractGridArray, ::Val{:latitude}) = Base._reverse!(grid, Val{:lat}())
+Base._reverse!(grid::AbstractGridArray, ::Val{:longitude}) = Base._reverse!(grid, Val{:lon}())

--- a/src/RingGrids/reverse.jl
+++ b/src/RingGrids/reverse.jl
@@ -1,5 +1,4 @@
 Base._reverse!(grid::AbstractGridArray, sym::Symbol) = Base._reverse!(grid, Val(sym))
-Base._reverse!(grid::AbstractGridArray, ::Val{Colon()}) = reverse!(grid)
 
 function Base._reverse!(grid::AbstractGridArray, ::Val{:lat})
 

--- a/src/RingGrids/reverse.jl
+++ b/src/RingGrids/reverse.jl
@@ -6,7 +6,7 @@ function Base._reverse!(grid::AbstractGridArray, ::Val{:lat})
     nrings = length(rings)
     rings_north = view(rings, 1:nrings ÷ 2)
 
-    for k in eachgrid(grid)
+    @inbounds for k in eachgrid(grid)
         for (j_north, ring) in enumerate(rings_north)
             j_south = nrings - j_north + 1
             for (i, ij_north) in enumerate(ring)

--- a/test/grids/reverse.jl
+++ b/test/grids/reverse.jl
@@ -1,0 +1,42 @@
+@testset "Reverse grids" begin
+    @testset for Grid in (
+        FullGaussianGrid,
+        FullClenshawGrid,
+        FullHEALPixGrid,
+        FullOctaHEALPixGrid,
+        OctahedralGaussianGrid,
+        OctahedralClenshawGrid,
+        HEALPixGrid,
+        OctaHEALPixGrid,
+        OctaminimalGaussianGrid
+        )
+
+        @testset for nlat_half in (4, 6, 8)
+            @testset for k in 0:3
+                if k == 0
+                    grid = rand(Grid, nlat_half)
+                else
+                    grid = rand(Grid, nlat_half, k)
+                end
+
+                grid2 = deepcopy(grid)
+                reverse!(grid2)
+                @test reverse!(grid2) == grid
+                @test reverse(reverse(grid)) == grid
+
+                reverse!(grid2, dims=:lat)
+                @test reverse!(grid2, dims=:latitude) == grid
+                @test reverse(reverse(grid, dims=:lat), dims=:lat) == grid
+
+                reverse!(grid2, dims=:lon)
+                @test reverse!(grid2, dims=:longitude) == grid
+                @test reverse(reverse(grid, dims=:lon), dims=:lon) == grid
+
+                if k < 2
+                    @test reverse(reverse(grid, dims=:lat), dims=:lon) == reverse(grid)
+                    @test reverse(reverse(grid, dims=:lon), dims=:lat) == reverse(grid)
+                end
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ include("utility_functions.jl")
 include("grids/grids.jl")
 include("grids/geodesics.jl")
 include("grids/interpolation.jl")
+include("grids/reverse.jl")
 
 # GPU/KERNELABSTRACTIONS
 include("gpu/kernelabstractions.jl")


### PR DESCRIPTION
Extend `Base.reverse`, `Base.reverse!` for `AbstractGridArray` with `dims=:lat` (or `:latitude`) and `dims=:lon` (or `:longitude`) keyword arguments.

<img width="535" alt="image" src="https://github.com/user-attachments/assets/ec6db0da-d69a-4a3b-9813-8cefbf0f951a" />

<img width="535" alt="image" src="https://github.com/user-attachments/assets/b1a49df1-e28f-48a2-aa7e-a12f2398115c" />
