### PR TITLE
Isfinites in ocean and land to avoid NaNs 

### DIFF
--- a/src/physics/land/vegetation.jl
+++ b/src/physics/land/vegetation.jl
@@ -49,7 +49,9 @@ function soil_moisture_availability!(
     r = 1/(D_top*W_cap + D_root*(W_cap - W_wilt))
 
     @inbounds for ij in eachindex(soil_moisture_availability)
-        soil_moisture_availability[ij] = r*D_top*soil_moisture[ij, 1]
+        if isfinite(soil_moisture_availability[ij])
+            soil_moisture_availability[ij] = r*D_top*soil_moisture[ij, 1]
+        end 
     end
 
     return nothing
@@ -169,11 +171,13 @@ function soil_moisture_availability!(
 
     for ij in eachgridpoint(soil_moisture_availability, high_cover, low_cover)
         
-        # Fortran SPEEDY source/land_model.f90 line 111 origin unclear
-        veg = max(0, high_cover[ij] + low_veg_factor*low_cover[ij])
+        if isfinite(soil_moisture_availability[ij])
+            # Fortran SPEEDY source/land_model.f90 line 111 origin unclear
+            veg = max(0, high_cover[ij] + low_veg_factor*low_cover[ij])
 
-        # Fortran SPEEDY documentation eq. 51
-        soil_moisture_availability[ij] = r*(D_top*soil_moisture[ij, 1] +
-            veg*D_root*max(soil_moisture[ij, 2] - W_wilt, 0))
+            # Fortran SPEEDY documentation eq. 51
+            soil_moisture_availability[ij] = r*(D_top*soil_moisture[ij, 1] +
+                veg*D_root*max(soil_moisture[ij, 2] - W_wilt, 0))
+        end 
     end
 end

--- a/src/physics/ocean.jl
+++ b/src/physics/ocean.jl
@@ -161,8 +161,10 @@ function ocean_timestep!(
     weight = convert(NF, Dates.days(time-Dates.firstdayofmonth(time))/Dates.daysinmonth(time))
 
     @inbounds for ij in eachgridpoint(sea_surface_temperature)
-        sea_surface_temperature[ij] = (1-weight) * monthly_temperature[ij, this_month] +
-                                          weight  * monthly_temperature[ij, next_month]
+        if isfinite(sea_surface_temperature[ij])
+            sea_surface_temperature[ij] = (1-weight) * monthly_temperature[ij, this_month] +
+                                            weight  * monthly_temperature[ij, next_month]
+        end 
     end
 end
 


### PR DESCRIPTION
This is partially addressing #689 

I also tried doing it with the land sea mask, but this still yields `NaN` in the derivatives in the end. I suspect that's because the `mask[ij] > 0` isn't the same as the `NaN` in `soil_moisture_availability`, but I might be wrong, I was running out of time now to check that (I'll look into it later). 