### PR TITLE
Longwave radiative transfer

### DIFF
--- a/src/dynamics/atmosphere.jl
+++ b/src/dynamics/atmosphere.jl
@@ -6,7 +6,7 @@ $(TYPEDSIGNATURES)
 Create a struct `EarthAtmosphere <: AbstractAtmosphere`, with the following physical/chemical
 characteristics. Keyword arguments are
 $(TYPEDFIELDS)"""
-Base.@kwdef mutable struct EarthAtmosphere{NF<:AbstractFloat} <: AbstractAtmosphere
+@kwdef mutable struct EarthAtmosphere{NF<:AbstractFloat} <: AbstractAtmosphere
     "molar mass of dry air [g/mol]"
     mol_mass_dry_air::NF = 28.9649
 

--- a/src/dynamics/geometry.jl
+++ b/src/dynamics/geometry.jl
@@ -83,7 +83,7 @@ $(TYPEDFIELDS)
     "σ at full levels, σₖ"
     σ_levels_full::VectorType = 0.5*(σ_levels_half[2:end] + σ_levels_half[1:end-1])  
     
-    "σ level thicknesses, σₖ₊₁ - σₖ"
+    "σ level thicknesses, σ_k+1/2 - σ_k-1/2"
     σ_levels_thick::VectorType = σ_levels_half[2:end] - σ_levels_half[1:end-1]      
 
     "log of σ at full levels, include surface (σ=1) as last element"

--- a/src/physics/define_column.jl
+++ b/src/physics/define_column.jl
@@ -35,6 +35,7 @@ $(TYPEDFIELDS)"""
     # (log) pressure per layer, surface is prognostic, last element here, but precompute other layers too
     const ln_pres::VectorType = zeros(NF, nlayers+1)    # logarithm of pressure [log(Pa)]
     const pres::VectorType = zeros(NF, nlayers+1)       # pressure [Pa]
+    const layer_depth::VectorType = zeros(NF, nlayers)  # normalised layer depth in terms of pressure [1]
 
     # TENDENCIES to accumulate the parametrizations into
     const u_tend::VectorType = zeros(NF, nlayers)       # zonal velocity [m/s²]


### PR DESCRIPTION
Via transmittance, 1-band only for now, see [Fortran SPEEDY documentation](https://users.ictp.it/~kucharsk/speedy_description/km_ver41_appendixA.pdf)

<img width="520" alt="image" src="https://github.com/user-attachments/assets/8e648964-d922-4440-909e-d18f7d120fa2" />

I want to follow the notation from Petty, *A First Course in Atmospheric Radiation* 

<img width="765" alt="image" src="https://github.com/user-attachments/assets/efda1f73-66e9-40c6-b3bc-ebdb4abb4ff9" />

with transmittance $t$ and optical depth $\tau$