### PR TITLE
Shallow water implicit without precomputed arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- ImplicitShallowWater without precomputed arrays [#717](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/717)
 - Fix isapprox for particles with longitude modulo [#714](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/714)
 - Fix docustring rendering [#712](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/712)
 - Make KolmogorovFlow forcing default for BarotropicModel [#687](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/687)


### PR DESCRIPTION
Overhauled the `ImplicitShallowWater` solver in an attempt to fix #715 but this did not make any change but it's faster now at T127

```julia
julia> @btime SpeedyWeather.implicit_correction!($diagn, $progn, $implicit)
  26.250 μs (0 allocations: 0 bytes)
```

before

```julia
julia> @btime SpeedyWeather.implicit_correction!($diagn, $progn, $implicit)
  31.208 μs (0 allocations: 0 bytes)
```

and we don't need to precompute any arrays anymore, the inverse is computed on the fly