### PR TITLE
Add view that returns a LowerTriangularArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- LowerTriangularArray-preserving view [#739](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/739)
 - Array-agnostic LowerTriangularMatrix [#738](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/738)
 - Major rework of LowerTriangularArrays: Introduce Spectrum type, changes in indexing and constructors [#734](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/734)
 - Reduce CI time [#731](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/731)

--- a/src/LowerTriangularArrays/LowerTriangularArrays.jl
+++ b/src/LowerTriangularArrays/LowerTriangularArrays.jl
@@ -16,6 +16,7 @@ export AbstractSpectrum, Spectrum, resolution, truncation
 export LowerTriangularMatrix, LowerTriangularArray
 export eachharmonic, eachmatrix, eachorder
 export OneBased, ZeroBased
+export lta_view
 
 include("spectrum.jl")
 include("lower_triangular_array.jl")

--- a/src/LowerTriangularArrays/lower_triangular_array.jl
+++ b/src/LowerTriangularArrays/lower_triangular_array.jl
@@ -669,6 +669,9 @@ Base.any(L::LowerTriangularArray) = any(L.data)
 
 Base.repeat(L::LowerTriangularArray, counts...) = LowerTriangularArray(repeat(L.data, counts...), L.spectrum)
 
+# Views that return a LowerTriangularArrays again
+lta_view(L::LowerTriangularArray, args...) = LowerTriangularArray(view(L.data, args...), L.spectrum)
+
 # Broadcast CPU/GPU
 import Base.Broadcast: BroadcastStyle, Broadcasted, DefaultArrayStyle
 import LinearAlgebra: isstructurepreserving, fzeropreserving

--- a/src/LowerTriangularArrays/lower_triangular_array.jl
+++ b/src/LowerTriangularArrays/lower_triangular_array.jl
@@ -669,8 +669,11 @@ Base.any(L::LowerTriangularArray) = any(L.data)
 
 Base.repeat(L::LowerTriangularArray, counts...) = LowerTriangularArray(repeat(L.data, counts...), L.spectrum)
 
-# Views that return a LowerTriangularArrays again
-lta_view(L::LowerTriangularArray, args...) = LowerTriangularArray(view(L.data, args...), L.spectrum)
+# Views that return a LowerTriangularArrays again (need to retain all horizontal grid points, hence `:, 1` for example)
+# TODO extend Base.view?
+lta_view(L::LowerTriangularArray,  c::Colon, i, args...) = LowerTriangularArray(view(L.data, c, i, args...), L.spectrum)
+lta_view(L::LowerTriangularMatrix, c::Colon) = LowerTriangularArray(view(L.data, c), L.spectrum)
+lta_view(L::LowerTriangularArray, args...) = view(L, args...)   # fallback to normal view
 
 # Broadcast CPU/GPU
 import Base.Broadcast: BroadcastStyle, Broadcasted, DefaultArrayStyle

--- a/src/LowerTriangularArrays/lower_triangular_array.jl
+++ b/src/LowerTriangularArrays/lower_triangular_array.jl
@@ -669,7 +669,9 @@ Base.any(L::LowerTriangularArray) = any(L.data)
 
 Base.repeat(L::LowerTriangularArray, counts...) = LowerTriangularArray(repeat(L.data, counts...), L.spectrum)
 
-# Views that return a LowerTriangularArrays again (need to retain all horizontal grid points, hence `:, 1` for example)
+# Views that return a LowerTriangularArray again (need to retain all horizontal grid points, hence `:, 1` for example)
+# view(array, :) unravels like array[:] does hence "::Colon, i, args..." used to enforce one argument after :
+# exception is view(vector, :) which preserves the vector structure, equivalent here is the LowerTriangularMatrix
 # TODO extend Base.view?
 lta_view(L::LowerTriangularArray,  c::Colon, i, args...) = LowerTriangularArray(view(L.data, c, i, args...), L.spectrum)
 lta_view(L::LowerTriangularMatrix, c::Colon) = LowerTriangularArray(view(L.data, c), L.spectrum)

--- a/test/transforms/lower_triangular_matrix.jl
+++ b/test/transforms/lower_triangular_matrix.jl
@@ -853,3 +853,9 @@ end
         end 
     end 
 end 
+
+@testset "LTA view" begin
+    L = randn(LowerTriangularArray{Float32}, 5, 5, 2)
+    @test view(L, :, 1) isa SubArray
+    @test lta_view(L, :, 1) isa LowerTriangularArray
+end

--- a/test/transforms/lower_triangular_matrix.jl
+++ b/test/transforms/lower_triangular_matrix.jl
@@ -857,5 +857,13 @@ end
 @testset "LTA view" begin
     L = randn(LowerTriangularArray{Float32}, 5, 5, 2)
     @test view(L, :, 1) isa SubArray
-    @test lta_view(L, :, 1) isa LowerTriangularArray
+    @test view(L, 1, :) isa SubArray
+    @test LowerTriangularArrays.lta_view(L, :) isa SubArray                 # unravels both layers
+    @test LowerTriangularArrays.lta_view(L, :, 1) isa LowerTriangularArray
+    @test LowerTriangularArrays.lta_view(L, 1, :) isa SubArray
+
+    L = randn(LowerTriangularArray{Float32}, 5, 5)
+    @test LowerTriangularArrays.lta_view(L, 1:3) isa SubArray
+    @test LowerTriangularArrays.lta_view(L, 1) isa SubArray
+    @test LowerTriangularArrays.lta_view(L, :) isa LowerTriangularArray     # this is LTA representable though!
 end


### PR DESCRIPTION
Introduces `lta_view` (happy for naming suggestions)

```julia
julia> L = zeros(LowerTriangularArray, 3, 3, 2)
6×2 LowerTriangularArray{Float64, 2, Matrix{Float64}, Spectrum{Main.LowerTriangularArrays.CPU, Vector{UnitRange{Int64}}, Vector{Int64}, Vector{Int64}}}:
 0.0  0.0
 0.0  0.0
 0.0  0.0
 0.0  0.0
 0.0  0.0
 0.0  0.0

julia> view(L, :, 1)
6-element view(::LowerTriangularArray{Float64, 2, Matrix{Float64}, Spectrum{Main.LowerTriangularArrays.CPU, Vector{UnitRange{Int64}}, Vector{Int64}, Vector{Int64}}}, :, 1) with eltype Float64:
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0

julia> lta_view(L, :, 1)
6-element, 3x3 LowerTriangularMatrix{Float64}
 0.0  0.0  0.0
 0.0  0.0  0.0
 0.0  0.0  0.0
```

so `view` works as before returning a `SubArray` of a `LowerTriangularArray` but `lta_view` returns a `LowerTriangularArray` of a view on the data of a `LowerTriangularArray`, in other words `lta_view` preserves the `LowerTriangularArray`.