### PR TITLE
nonparametric_type also for SubArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix show of field views by defining nonparametric_type for SubArray [#776](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/776)
 - Add parameter handling system and implement for Barotropic model [#754](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/754)
 - Fix Enzyme CI to run as expected [#762](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/762)
 

--- a/src/LowerTriangularArrays/lower_triangular_array.jl
+++ b/src/LowerTriangularArrays/lower_triangular_array.jl
@@ -754,6 +754,7 @@ nonparametric_type(::Type{<:Array}) = Array
 
 # nonparametric_type for a SubArray is the arraytype it is viewing. Needed to construct new arrays from SubArrays!
 nonparametric_type(::Type{<:SubArray{T, N, A}}) where {T, N, A} = nonparametric_type(A)
+nonparametric_type(::Type{<:SubArray}) = SubArray   # if ArrayType A is not specified, return SubArray
 
 "`L = find_L(Ls)` returns the first LowerTriangularArray among the arguments. 
 Adapted from Julia documentation of Broadcast interface"

--- a/src/RingGrids/grid.jl
+++ b/src/RingGrids/grid.jl
@@ -29,6 +29,10 @@ nonparametric_type(grid::AbstractGrid) = nonparametric_type(typeof(grid))
 # also needed for other array types, defined in extensions
 nonparametric_type(::Type{<:Array}) = Array
 
+# nonparametric_type for a SubArray is the arraytype it is viewing. Needed to construct new arrays from SubArrays!
+nonparametric_type(::Type{<:SubArray{T, N, A}}) where {T, N, A} = nonparametric_type(A)
+nonparametric_type(::Type{<:SubArray}) = SubArray   # if ArrayType A is not specified, return SubArray
+
 """$(TYPEDSIGNATURES) Resolution paraemeters `nlat_half` of a `grid`.
 Number of latitude rings on one hemisphere, Equator included."""
 get_nlat_half(grid::AbstractGrid) = grid.nlat_half

--- a/test/grids/grids.jl
+++ b/test/grids/grids.jl
@@ -561,3 +561,16 @@ end
         end
     end
 end
+
+@testset "nonparametric types" begin
+    for M in (RingGrids, LowerTriangularArrays)
+        @test M.nonparametric_type(Array) == Array
+        @test M.nonparametric_type(Array{Float32}) == Array
+        @test M.nonparametric_type(Array{Float32, 1}) == Array
+        @test M.nonparametric_type(SubArray) == SubArray
+        @test M.nonparametric_type(SubArray{Float32}) == SubArray
+        @test M.nonparametric_type(SubArray{Float32, 1}) == SubArray
+        @test M.nonparametric_type(SubArray{Float32, 1, Array}) == Array
+        @test M.nonparametric_type(SubArray{Float32, 1, Array{Float32, 1}}) == Array
+    end
+end


### PR DESCRIPTION
fixes

```julia
julia> Tᵥ = RingGrids.field_view(simulation.diagnostic_variables.grid.temp_virt_grid, :, 8)
3168-element, 48-ring OctahedralGaussianField{Float32, 1}Error showing value of type Field{Float32, 1, SubArray{Float32, 1, Matrix{Float32}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true}, OctahedralGaussianGrid{SpeedyWeather.Architectures.CPU{KernelAbstractions.CPU}, Vector{UnitRange{Int64}}, Vector{Int64}}}:

SYSTEM (REPL): showing an error caused an error
ERROR: 1-element ExceptionStack:
MethodError: no method matching nonparametric_type(::Type{SubArray{Float32, 1, Matrix{Float32}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true}})
The function `nonparametric_type` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  nonparametric_type(::Type{<:Array})
   @ SpeedyWeather ~/.julia/packages/SpeedyWeather/DsDRF/src/RingGrids/grid.jl:30
  nonparametric_type(::Type{<:FullOctaHEALPixGrid})
   @ SpeedyWeather ~/.julia/packages/SpeedyWeather/DsDRF/src/RingGrids/grids/full_octahealpix.jl:14
  nonparametric_type(::Type{<:OctaminimalGaussianGrid})
   @ SpeedyWeather ~/.julia/packages/SpeedyWeather/DsDRF/src/RingGrids/grids/octaminimal_gaussian.jl:19
  ...
```

`nonparametric_type` of `SubArray` is `SubArray` unless the array type A it's viewing is defined then return `nonparametric_type(A)`