### PR TITLE
add a mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Milan Klöwer <milankloewer@gmx.de>
+Milan Klöwer <milankloewer@gmx.de> <milan.kloewer@physics.ox.ac.uk>
+Maximilian Gelbrecht <maximilian.gelbrecht@posteo.de>
+Daisuke Hotta <88590419+hottad@users.noreply.github.com> <dhotta@obs229.local>
+Brian Groenke <brian.groenke@pik-potsdam.de> <bgroe8@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add mailmap to merge multiple developers for repo statistics [#785](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/785)
 - Restart from file for ocean and land [#784](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/784)
 - Overwrite output folder option [#782](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/782)
 - Update compat entries [#777](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/777)


### PR DESCRIPTION
For tools like `git shortlog -nse` or `git-ship-of-theseus` it is very nice to have git collapse all commits by the same author.

