### PR TITLE
Fix Haversine rounding errors with type promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix Haversine rounding errors with type promotion [#787](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/787)
 - Add mailmap to merge multiple developers for repo statistics [#785](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/785)
 - Restart from file for ocean and land [#784](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/784)
 - Overwrite output folder option [#782](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/782)

--- a/src/RingGrids/geodesics.jl
+++ b/src/RingGrids/geodesics.jl
@@ -24,8 +24,8 @@ function Haversine(             # functor for Haversine struct
     lonlat2::Tuple;             # point 2
     radius = DEFAULT_RADIUS,    # radius of the sphere [m]
 )
-    lon1, lat1 = lonlat1
-    lon2, lat2 = lonlat2    
+    # promote lon and lat to common precision to avoid rounding errors in Haversine formula
+    lon1, lat1, lon2, lat2 = promote(lonlat1..., lonlat2...)    
 
     φ1 = deg2rad(lat1)
     φ2 = deg2rad(lat2)

--- a/test/grids/geodesics.jl
+++ b/test/grids/geodesics.jl
@@ -86,3 +86,18 @@ end
         @test typeof(spherical_distance(p1, p2)) == Float64
     end
 end
+
+@testset "Haversine: Rounding errors" begin
+    
+    # some coordinates in Float64
+    λ₀ = -56.2842
+    φ₀ = 76.07610000000003
+
+    # others in Float32, they are alsmost antipoles
+    λ = 123.75f0
+    φ = -76.070244f0
+
+    # this used to error from sqrt of negative number
+    # just test for almost antipodal points (and therefore no error)
+    @test spherical_distance((λ, φ), (λ₀, φ₀), radius=360/2π) > 179
+end


### PR DESCRIPTION
Fixes a rounding error found by @AnasAbdelR that occurs in the Haversine formula when used with some coordinates provided in Float32 others in Float64. We now do a type promotion of all coordinates that seems to fit it.

From https://github.com/SpeedyWeather/RainMaker.jl/issues/62#issuecomment-3097268107

@treigerm ☝🏼 as you wrote this function originally 