### PR TITLE
Hotfix: remove explicit KA import to avoid import warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Adjusted legendre transform kernels to work with KernelAbstractions [#736](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/736)
+- Adjusted legendre transform kernels to work with KernelAbstractions [#736](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/736)[#737](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/737)
 - Interpolation now works on GPU [#764](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/764)
 - A minimal barotropic model now runs on GPU [#733](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/733)
 - Fix Haversine rounding errors with type promotion [#787](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/787)

--- a/src/SpeedyTransforms/legendre_ka.jl
+++ b/src/SpeedyTransforms/legendre_ka.jl
@@ -3,8 +3,6 @@
 import SpeedyWeather.LowerTriangularArrays: lm2i, get_lm_range, get_2lm_range
 import Atomix 
 
-using KernelAbstractions
-
 # (inverse) legendre transform kernel, called from _legendre!
 @kernel inbounds=true function inverse_legendre_kernel!(
     g_north,                        # Scratch storage for legendre coefficients


### PR DESCRIPTION
There was an explicit `using KernelAbstractions` in SpeedyTransforms, which caused a warning when importing SpeedyWeather because the naming conflict with `CPU` and `GPU`. 