### PR TITLE
Fix admonition and typo on GPU-and-Architectures docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix admonition and typo on GPU-and-Architectures docs [#807](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/807)
 - Make all land model components mutable [#810](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/810)
 - More work towards PrimitiveDryModel on GPU [#792](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/792)
 - Jeevanjee surface fluxes and soil moisture field capacity  [#794](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/794) [#788](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/788)

--- a/docs/src/architectures_gpu.md
+++ b/docs/src/architectures_gpu.md
@@ -1,9 +1,9 @@
 # GPU & Architectures
 
-!!! warn Work in progress
+!!! warning "Work in progress"
     The GPU support of SpeedyWeather.jl is still work in progress and some parts of this documentation might not be always updated to the latest state. We will extend this documentation over time. Don't hesitate to contact us via GitHub issues or mail when you have questions or want to collaborate.
 
-Some of SpeedyWeather.jl already supports GPU acceleration, e.g. the barotropic model. Our development focusses on CUDA GPUs, but other architectures are thinkable in the future as well, as our approach relies on the device agnostic `KernelAbstractions.jl`. The SpeedyWeather.jl submodule `Architectures` encodes all the information of the device we run our models on. In order to initialize a model on a GPU, we need to load the `CUDA` package and pass the architecture to the model constructor. For example, to initialize a barotropic model on a GPU, we can do the following:  
+Some of SpeedyWeather.jl already supports GPU acceleration, e.g. the barotropic model. Our development focuses on CUDA GPUs, but other architectures are thinkable in the future as well, as our approach relies on the device agnostic `KernelAbstractions.jl`. The SpeedyWeather.jl submodule `Architectures` encodes all the information of the device we run our models on. In order to initialize a model on a GPU, we need to load the `CUDA` package and pass the architecture to the model constructor. For example, to initialize a barotropic model on a GPU, we can do the following:  
 
 ```julia
 using SpeedyWeather, CUDA 


### PR DESCRIPTION
Small fix for the [GPU and Architectures docs](https://speedyweather.github.io/SpeedyWeatherDocumentation/dev/architectures_gpu/#GPU-and-Architectures), correcting the admonition block formatting and a minor typo I came across while browsing the documentation.