### PR TITLE
Call callbacks before output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
+- Call callbacks before output not after [#852](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/852)
 - Split extensions across subpackages [#846](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/846)
 
-## v0.17
+## v0.17
 
 - More documentation on GPU and on_architecture [#845](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/845)
 - The documentation has a logo now as well [#842](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/842)

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -258,8 +258,8 @@ function first_timesteps!(
     timestep!(clock, Δt_millisec) 
     
     # do output and callbacks after the first proper (from i=0 to i=1) time step
-    output!(model.output, Simulation(progn, diagn, model))
     callback!(model.callbacks, progn, diagn, model)
+    output!(model.output, Simulation(progn, diagn, model))
 
     # from now on precomputed implicit terms with 2Δt
     initialize!(implicit, 2Δt, diagn, model) 
@@ -390,10 +390,10 @@ function timestep!(simulation::AbstractSimulation)
     else                                                # 3rd and further timesteps after Δt as normal
         timestep!(progn, diagn, 2Δt, model)             # calculate tendencies and leapfrog forward
         timestep!(clock, Δt_millisec)                   # time of lf=2 and diagn after timestep!
-
+        
         progress!(feedback, progn)                      # updates the progress meter bar
-        output!(output, simulation)                     # do output?
         callback!(model.callbacks, progn, diagn, model) # any callbacks?
+        output!(output, simulation)                     # do output?
     end
 end
 


### PR DESCRIPTION
Suggest by Davide @DavSab1 at NCAS CMSS so that one can use a callback to define an SST anomaly via a callback that adds to a seasonal ocean climatology, e.g.

```julia
spectral_grid = SpectralGrid(trunc=31, Grid=OctaminimalGaussianGrid)

# use a seasonal ocean from file that overwrites SST on every time step
ocean = SeasonalOceanClimatology(spectral_grid)

# define a callback that adds an SST anomaly
struct SSTAnomaly <: SpeedyWeather.AbstractCallback end

# initialize just calls the callback too
SpeedyWeather.initialize!(callback::SSTAnomaly, args...) = SpeedyWeather.callback!(callback, args...)

function SpeedyWeather.callback!(
    callback::SSTAnomaly,
    progn::PrognosticVariables,
    diagn::DiagnosticVariables,
    model::AbstractModel,
)
    set!(progn.ocean.sea_surface_temperature, (λ, ϕ) -> ϕ < 0 ? -5 : 0, model.geometry, add=true)
end

SpeedyWeather.finalize!(calllback::SSTAnomaly, args...) = nothing

# create that callback and add it to the model
callback = SSTAnomaly()
add!(model, callback)

# adjust output
add!(model, SpeedyWeather.OceanOutput()...)
model.output.output_dt = Day(1)

# run simulation
run!(simulation, period=Day(30), output=true)
```

however, at the moment we call first the output then the callbacks which doesn't really make sense to me as I see the callbacks to e.g. change fields which should then be reflected in the output. What's not possible now would be to let the callback change the netcdf output directly which is fine. E.g. from above

<img width="914" height="414" alt="image" src="https://github.com/user-attachments/assets/6dddad0d-63bc-40f2-a428-93a5b8b0e2e9" />

