### PR TITLE
Adapt for models for GPU parametrization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Initial conditions revised to take in a `SpectralGrid` to ensure correct number type [#927](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/927)[#928](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/928)
 - Diagnostic and prognostic variables partially revised to NamedTuples and variables system introduced to allow to add to them modularly [#885](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/885)
-- Parameterizations with KernelAbstractions [#873](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/873) [#878](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/878) [#924](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/924)
+- Parameterizations with KernelAbstractions [#873](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/873) [#878](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/878) [#924](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/924) [#930](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/930)
 - `set!(::Field,::Functions,...)` works now on GPU (however by explicitly transfering between GPU and CPU) [#925](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/925)
 - Fixes round trip transform tests [#921](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/921)
 - Updated docs CairoMakie compatibility to "0.12, 0.13, 0.14, 0.15"

--- a/src/models/abstract_models.jl
+++ b/src/models/abstract_models.jl
@@ -115,10 +115,3 @@ _get_param(model, obj) = error("Unknown parameterization type: $(typeof(obj)), n
 _get_param_name(model, field::Symbol) = field
 _get_param_name(model, obj::Pair{Symbol}) = obj.first
 _get_param_name(model, obj) = error("Unknown parameterization type: $(typeof(obj)), needs to be <:Symbol or <:Pair{Symbol, obj}")
-
-function Adapt.adapt_structure(to, model::ModelType) where ModelType <: PrimitiveEquation
-    return ModelType(NamedTuple{fieldnames(model)}(
-        field in merge(model.model_parameters, model.parameterizations) ? adapt_structure(to, getfield(model, field)) : nothing 
-        for field in fieldnames(ModelType)
-    )...)
-end 

--- a/src/models/abstract_models.jl
+++ b/src/models/abstract_models.jl
@@ -52,28 +52,6 @@ model_type(::Type{<:PrimitiveDry}) = PrimitiveDryModel
 model_type(::Type{<:PrimitiveWet}) = PrimitiveWetModel
 model_type(model::AbstractModel) = model_type(typeof(model))
 
-# model dummy: Empty concrete instances
-struct BarotropicDummy <: Barotropic end
-struct ShallowWaterDummy <: ShallowWater end
-struct PrimitiveDryDummy <: PrimitiveDry end
-struct PrimitiveWetDummy <: PrimitiveWet end
-
-Adapt.@adapt_structure BarotropicDummy
-Adapt.@adapt_structure ShallowWaterDummy
-Adapt.@adapt_structure PrimitiveDryDummy
-Adapt.@adapt_structure PrimitiveWetDummy
-
-model_dummy(::Type{<:Barotropic}) = BarotropicDummy()
-model_dummy(::Type{<:ShallowWater}) = ShallowWaterDummy()
-model_dummy(::Type{<:PrimitiveDry}) = PrimitiveDryDummy()
-model_dummy(::Type{<:PrimitiveWet}) = PrimitiveWetDummy()
-model_dummy(model::AbstractModel) = model_dummy(typeof(model))
-
-model_type(::Type{BarotropicDummy}) = BarotropicDummy
-model_type(::Type{ShallowWaterDummy}) = ShallowWaterDummy
-model_type(::Type{PrimitiveDryDummy}) = PrimitiveDryDummy
-model_type(::Type{PrimitiveWetDummy}) = PrimitiveWetDummy
-
 initialize!(model::AbstractModel, ps::Union{ComponentVector, SpeedyParams}; kwargs...) =
     initialize!(reconstruct(model, ps); kwargs...)
 
@@ -94,7 +72,6 @@ end
 
 # Functions to get parameters and parameterization to 
 # a) initialize variables 
-# b) assemble compnents necessary for column parameterizations
 """$(TYPEDSIGNATURES)
 Extract the model components with parameters needed for the parameterizations
 as NamedTuple. These are the GPU-compatible components of the model."""
@@ -130,12 +107,6 @@ get_extra_parameterizations(model::Barotropic) = NamedTuple()
 get_parameterizations(model::ShallowWater) = NamedTuple()
 get_extra_parameterizations(model::ShallowWater) = NamedTuple()
 
-"""$(TYPEDSIGNATURES)
-Extract the parameterizations from the model including land and ocean, to infer variables."""
-function get_all_parameterizations(model::PrimitiveEquation)
-    return merge(get_parameterizations(model), get_extra_parameterizations(model))
-end
-
 # helper function to extract parameterizations from model tuples
 _get_param(model, field::Symbol) = getfield(model, field)
 _get_param(model, obj::Pair{Symbol}) = obj.second
@@ -144,3 +115,10 @@ _get_param(model, obj) = error("Unknown parameterization type: $(typeof(obj)), n
 _get_param_name(model, field::Symbol) = field
 _get_param_name(model, obj::Pair{Symbol}) = obj.first
 _get_param_name(model, obj) = error("Unknown parameterization type: $(typeof(obj)), needs to be <:Symbol or <:Pair{Symbol, obj}")
+
+function Adapt.adapt_structure(to, model::ModelType) where ModelType <: PrimitiveEquation
+    return ModelType(NamedTuple{fieldnames(model)}(
+        field in merge(model.model_parameters, model.parameterizations) ? adapt_structure(to, getfield(model, field)) : nothing 
+        for field in fieldnames(ModelType)
+    )...)
+end 

--- a/src/models/barotropic.jl
+++ b/src/models/barotropic.jl
@@ -10,7 +10,7 @@ with `spectral_grid::SpectralGrid` used to initalize all non-default components
 passed on as keyword arguments, e.g. `planet=Earth(spectral_grid)`. Fields, representing
 model components, are
 $(TYPEDFIELDS)"""
-@kwdef mutable struct BarotropicModel{
+@kwdef struct BarotropicModel{
     SG,     # <:SpectralGrid
     AR,     # <:AbstractArchitecture,
     GE,     # <:AbstractGeometry,

--- a/src/models/primitive_dry.jl
+++ b/src/models/primitive_dry.jl
@@ -192,3 +192,11 @@ function initialize!(model::PrimitiveDry; time::DateTime = DEFAULT_DATE)
     # pack prognostic, diagnostic variables and model into a simulation
     return Simulation(prognostic_variables, diagnostic_variables, model)
 end
+
+function Adapt.adapt_structure(to, model::PrimitiveDryModel) 
+    adapt_fields = (model.model_parameters..., model.parameterizations...)
+    return PrimitiveDryModel(NamedTuple{fieldnames(PrimitiveDryModel)}(
+        field in adapt_fields ? adapt_structure(to, getfield(model, field)) : nothing 
+        for field in fieldnames(PrimitiveDryModel)
+    )...)
+end 

--- a/src/models/primitive_dry.jl
+++ b/src/models/primitive_dry.jl
@@ -108,7 +108,7 @@ $(TYPEDFIELDS)"""
     
     # Tuples with symbols or instances of all parameterizations and parameter functions
     # Used to initiliaze variables and for the column-based parameterizations
-    model_parameters::TS1 = (:architecture, :time_stepping, :orography, :geopotential, :atmosphere, 
+    model_parameters::TS1 = (:time_stepping, :orography, :geopotential, :atmosphere, 
                                 :planet, :geometry, :land_sea_mask)
     parameterizations::TS2 = (  # mixing
                                 :vertical_diffusion, :convection,

--- a/src/models/primitive_dry.jl
+++ b/src/models/primitive_dry.jl
@@ -10,7 +10,7 @@ with `spectral_grid::SpectralGrid` used to initalize all non-default components
 passed on as keyword arguments, e.g. `planet=Earth(spectral_grid)`. Fields, representing
 model components, are
 $(TYPEDFIELDS)"""
-@kwdef mutable struct PrimitiveDryModel{
+@kwdef struct PrimitiveDryModel{
     SG,     # <:SpectralGrid
     AR,     # <:AbstractArchitecture,
     GE,     # <:AbstractGeometry,
@@ -50,6 +50,7 @@ $(TYPEDFIELDS)"""
     TS1,    # <:Tuple{Symbol}
     TS2,    # <:Tuple{Symbol}
     TS3,    # <:Tuple{Symbol}
+    PV      # <:Val
 } <: PrimitiveDry
 
     spectral_grid::SG
@@ -108,7 +109,7 @@ $(TYPEDFIELDS)"""
     # Tuples with symbols or instances of all parameterizations and parameter functions
     # Used to initiliaze variables and for the column-based parameterizations
     model_parameters::TS1 = (:architecture, :time_stepping, :orography, :geopotential, :atmosphere, 
-                                :planet, :geometry, :land_sea_mask, :class => PrimitiveDryDummy())
+                                :planet, :geometry, :land_sea_mask)
     parameterizations::TS2 = (  # mixing
                                 :vertical_diffusion, :convection,
 
@@ -121,6 +122,10 @@ $(TYPEDFIELDS)"""
                                 # perturbations
                                 :stochastic_physics)
     extra_parameterizations::TS3 = (:solar_zenith, :land, :ocean)
+
+    # DERIVED 
+    # used to infer parameterizations at compile-time 
+    params::PV = Val(parameterizations)
 end
 
 prognostic_variables(::Type{<:PrimitiveDry}) = (:vor, :div, :temp, :pres)

--- a/src/models/primitive_wet.jl
+++ b/src/models/primitive_wet.jl
@@ -10,7 +10,7 @@ with `spectral_grid::SpectralGrid` used to initalize all non-default components
 passed on as keyword arguments, e.g. `planet=Earth(spectral_grid)`. Fields, representing
 model components, are
 $(TYPEDFIELDS)"""
-@kwdef mutable struct PrimitiveWetModel{
+@kwdef struct PrimitiveWetModel{
     SG,     # <:SpectralGrid
     AR,     # <:AbstractArchitecture,
     GE,     # <:AbstractGeometry,
@@ -54,6 +54,7 @@ $(TYPEDFIELDS)"""
     TS1,    # <:Tuple{Symbol}
     TS2,    # <:Tuple{Symbol}
     TS3,    # <:Tuple{Symbol}
+    PV,     # <:Val
 } <: PrimitiveWet
 
     spectral_grid::SG
@@ -118,7 +119,7 @@ $(TYPEDFIELDS)"""
     # Used to initiliaze variables and for the column-based parameterizations
     # also determine order in which parameterizations are called
     model_parameters::TS1 = (:architecture, :time_stepping, :orography, :geopotential, :atmosphere, 
-                                :planet, :geometry, :land_sea_mask, :clausius_clapeyron, :class => PrimitiveWetDummy())
+                                :planet, :geometry, :land_sea_mask, :clausius_clapeyron)
     parameterizations::TS2 = (  # mixing and precipitation
                                 :vertical_diffusion, :large_scale_condensation, :convection,
 
@@ -133,6 +134,11 @@ $(TYPEDFIELDS)"""
                                 :stochastic_physics,
                             )
     extra_parameterizations::TS3 = (:solar_zenith, :land, :ocean)
+
+    # DERIVED 
+    # used to infer parameterizations at compile-time 
+    params::PV = Val(parameterizations)
+
 end
 
 prognostic_variables(::Type{<:PrimitiveWet}) = (:vor, :div, :temp, :humid, :pres)

--- a/src/models/primitive_wet.jl
+++ b/src/models/primitive_wet.jl
@@ -121,7 +121,7 @@ $(TYPEDFIELDS)"""
     # Tuples with symbols or instances of all parameterizations and parameter functions
     # Used to initiliaze variables and for the column-based parameterizations
     # also determine order in which parameterizations are called
-    model_parameters::TS1 = (:architecture, :time_stepping, :orography, :geopotential, :atmosphere, 
+    model_parameters::TS1 = (:time_stepping, :orography, :geopotential, :atmosphere, 
                                 :planet, :geometry, :land_sea_mask, :clausius_clapeyron)
     parameterizations::TS2 = (  # mixing and precipitation
                                 :vertical_diffusion, :large_scale_condensation, :convection,

--- a/src/models/shallow_water.jl
+++ b/src/models/shallow_water.jl
@@ -10,7 +10,7 @@ with `spectral_grid::SpectralGrid` used to initalize all non-default components
 passed on as keyword arguments, e.g. `planet=Earth(spectral_grid)`. Fields, representing
 model components, are
 $(TYPEDFIELDS)"""
-@kwdef mutable struct ShallowWaterModel{
+@kwdef struct ShallowWaterModel{
     SG,     # <:SpectralGrid
     AR,     # <:AbstractArchitecture,
     GE,     # <:AbstractGeometry,

--- a/src/physics/vertical_diffusion.jl
+++ b/src/physics/vertical_diffusion.jl
@@ -80,19 +80,18 @@ end
 
 # function barrier
 parameterization!(ij, diagn, progn, diffusion::BulkRichardsonDiffusion, model) =
-    vertical_diffusion!(ij, diagn, diffusion, model.atmosphere, model.planet, model.orography, model.geopotential, model.class)
+    vertical_diffusion!(ij, diagn, diffusion, model)
 
 function vertical_diffusion!(
     ij,
     diagn,
     diffusion::BulkRichardsonDiffusion,
-    atmosphere,
-    planet,
-    orography,
-    geopot,
-    model_class,
+    model
 )
+
+    (; atmosphere, planet, orography) = model 
     (; diffuse_momentum, diffuse_static_energy, diffuse_humidity) = diffusion
+    geopot = model.geopotential
 
     # escape immediately if all diffusions disabled
     any((diffuse_momentum, diffuse_static_energy, diffuse_humidity)) || return nothing
@@ -111,7 +110,7 @@ function vertical_diffusion!(
 
     diffuse_momentum                                    && _vertical_diffusion!(ij, u_tend, u, K, kₕ, diffusion)
     diffuse_momentum                                    && _vertical_diffusion!(ij, v_tend, v, K, kₕ, diffusion)
-    model_class isa PrimitiveWet && diffuse_humidity    && _vertical_diffusion!(ij, humid_tend, humid, K, kₕ, diffusion)
+    model isa PrimitiveWet && diffuse_humidity    && _vertical_diffusion!(ij, humid_tend, humid, K, kₕ, diffusion)
 
     if diffuse_static_energy
         # compute dry static energy on the fly


### PR DESCRIPTION
I couldn't figure out how to do it with the NamedTuples. 

I like this approach of actually having a model type in the parametrization just with most field `nothing` conceptually actually better. It's simpler. I saves some of the dummy types etc and some other code. 

The type instability in Julia 1.11 that @code_warntype reported is gone. Performance is similar. With this we are down to ~800 bytes allocation on CPU and ~5% better performance, on GPU it slightly increased to 250KiB, and performance is ~10% worse. The problem on GPU was that apperatenly too complex` @genreated ` functions don't work any more on GPU?  I think we can probably still fine-tune this a bit. 

The model types are now all non-mutable with this change. 