### PR TITLE
Architectures: Add tests and fix subarray bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed a bug for `SubArrays` not working with `Architectures.ismatching` [#1049
+](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1049)
 - Dependency for DomainSets updated to v0.7 and v0.8 [#1045](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1045) [#1047](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1047)
 - [BREAKING] WriteModelComponentFile and ManualOrography [#1040](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1040)
 - `JLD2Output` revised to be able to select groups, additional `ArrayOutput` option to output to RAM [#1026](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1026)

--- a/SpeedyWeatherInternals/src/Architectures/Architectures.jl
+++ b/SpeedyWeatherInternals/src/Architectures/Architectures.jl
@@ -123,6 +123,7 @@ compatible_array_types(arch::AbstractArchitecture) = (array_type(arch),) # fallb
 ismatching(arch::Type{<:AbstractArchitecture}, array_T::Type{<:AbstractArray}) = any(arch_array -> array_T <: arch_array, compatible_array_types(arch))
 ismatching(arch::AbstractArchitecture, array_T::Type{<:AbstractArray}) = ismatching(typeof(arch), array_T)
 ismatching(arch::AbstractArchitecture, array::AbstractArray) = ismatching(arch, typeof(array))
+ismatching(arch::AbstractArchitecture, a::SubArray) = ismatching(arch, parent(a))
 
 # TODO: currently we just chech matching array types, sufficient?
 ismatching(arch_1::AbstractArchitecture, arch_2::AbstractArchitecture) = array_type(arch_1) == array_type(arch_2)

--- a/SpeedyWeatherInternals/test/Project.toml
+++ b/SpeedyWeatherInternals/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/SpeedyWeatherInternals/test/architectures.jl
+++ b/SpeedyWeatherInternals/test/architectures.jl
@@ -1,7 +1,8 @@
 using JLArrays
+using SpeedyWeatherInternals.Architectures
+import SpeedyWeatherInternals.Architectures: AbstractCPU
 
-const AbstractCPU = SpeedyWeatherInternals.Architectures.AbstractCPU
-const JLGPU = GPU{JLArrays.JLBackend}
+const JLGPU = SpeedyWeather.GPU{JLArrays.JLBackend}
 
 @testset "CPU architecture" begin
     arch = CPU()
@@ -172,19 +173,3 @@ end
     @test keys(nt_gpu) == (:x, :y)
 end
 
-@testset "convert_to_device" begin
-    cpu = CPU()
-    jlgpu = GPU(JLArrays.JLBackend())
-    args = (rand(Float32, 2), 1.0)
-
-    # CPU: pass-through
-    @test convert_to_device(cpu, args) === args
-end
-
-@testset "synchronize" begin
-    cpu = CPU()
-    jlgpu = GPU(JLArrays.JLBackend())
-    # just must not error
-    @test (synchronize(cpu); true)
-    @test (synchronize(jlgpu); true)
-end

--- a/SpeedyWeatherInternals/test/architectures.jl
+++ b/SpeedyWeatherInternals/test/architectures.jl
@@ -1,8 +1,8 @@
 using JLArrays
 using SpeedyWeatherInternals.Architectures
-import SpeedyWeatherInternals.Architectures: AbstractCPU
+import SpeedyWeatherInternals.Architectures: AbstractCPU, CPU, GPU
 
-const JLGPU = SpeedyWeather.GPU{JLArrays.JLBackend}
+const JLGPU = GPU{JLArrays.JLBackend}
 
 @testset "CPU architecture" begin
     arch = CPU()

--- a/SpeedyWeatherInternals/test/architectures.jl
+++ b/SpeedyWeatherInternals/test/architectures.jl
@@ -1,1 +1,190 @@
+using JLArrays
 
+const AbstractCPU = SpeedyWeatherInternals.Architectures.AbstractCPU
+const JLGPU = GPU{JLArrays.JLBackend}
+
+@testset "CPU architecture" begin
+    arch = CPU()
+    arch_static = CPUStatic()
+
+    @test arch isa AbstractCPU
+    @test arch isa AbstractArchitecture
+    @test arch_static isa AbstractCPU
+
+    @test array_type(arch) == Array
+    @test array_type(CPU) == Array
+    @test array_type(arch, Float32, 2) == Array{Float32, 2}
+
+    @test compatible_array_types(arch) == (Array,)
+    @test compatible_array_types(CPU) == (Array,)
+
+    @test repr(arch) == "CPU"
+end
+
+@testset "JLGPU architecture" begin
+    arch = GPU(JLArrays.JLBackend())
+
+    @test arch isa GPU
+    @test arch isa AbstractArchitecture
+
+    @test array_type(arch) == JLArray
+    @test array_type(arch, Float32, 2) == JLArray{Float32, 2}
+
+    @test JLArray in compatible_array_types(arch)
+    @test JLArrays.JLDeviceArray in compatible_array_types(arch)
+end
+
+@testset "architecture() inference" begin
+    # scalars / nothing
+    @test architecture(1.0) === nothing
+    @test architecture(1f0) === nothing
+    @test architecture() === nothing
+
+    # CPU arrays
+    a = rand(Float32, 4)
+    @test architecture(a) isa CPU
+    @test architecture(Array) isa CPU
+    @test architecture(Array{Float32, 2}) isa CPU
+
+    # SubArray of a CPU array: must be CPU
+    v = view(a, :)
+    @test architecture(v) isa CPU
+
+    # JLArray
+    ja = JLArray(a)
+    @test architecture(ja) isa JLGPU
+    @test architecture(JLArray) isa JLGPU
+
+    # Architecture of an architecture
+    cpu = CPU()
+    @test architecture(cpu) === cpu
+end
+
+@testset "ismatching" begin
+    cpu = CPU()
+    jlgpu = GPU(JLArrays.JLBackend())
+
+    a_cpu = rand(Float32, 4)
+    a_jl = JLArray(a_cpu)
+
+    # plain arrays
+    @test ismatching(cpu, a_cpu)
+    @test ismatching(cpu, Array{Float32, 1})
+    @test ismatching(cpu, Array)
+    @test !ismatching(cpu, a_jl)
+    @test !ismatching(cpu, JLArray{Float32, 1})
+
+    # SubArray of CPU array must match CPU
+    @test ismatching(cpu, view(a_cpu, :))
+    @test ismatching(cpu, view(a_cpu, 1:2))
+
+    # JLArray matches JLGPU
+    @test ismatching(jlgpu, a_jl)
+    @test ismatching(jlgpu, JLArray{Float32, 1})
+    @test !ismatching(jlgpu, a_cpu)
+
+    # type-based dispatch
+    @test ismatching(CPU, Array)
+    @test !ismatching(CPU, JLArray)
+
+    # arch vs arch
+    @test ismatching(cpu, CPU())
+    @test ismatching(jlgpu, GPU(JLArrays.JLBackend()))
+    @test !ismatching(cpu, jlgpu)
+end
+
+@testset "nonparametric_type" begin
+    @test nonparametric_type(Array{Float32, 1}) == Array
+    @test nonparametric_type(Array{Float64, 3}) == Array
+    @test nonparametric_type(JLArray{Float32, 2}) == JLArray
+
+    # SubArray strips down to the parent nonparametric type
+    a = rand(Float32, 4)
+    v = view(a, :)
+    @test nonparametric_type(typeof(v)) == Array
+
+    ja = JLArray(a)
+    jv = view(ja, :)
+    @test nonparametric_type(typeof(jv)) == JLArray
+end
+
+@testset "on_architecture CPU" begin
+    cpu = CPU()
+    jlgpu = GPU(JLArrays.JLBackend())
+
+    a = rand(Float32, 4, 2)
+    ja = JLArray(a)
+
+    # CPU → CPU: identity
+    @test on_architecture(cpu, a) === a
+    @test on_architecture(cpu, a) isa Array
+
+    # JLGPU → CPU: materialises to Array
+    @test on_architecture(cpu, ja) isa Array
+    @test Array(ja) ≈ on_architecture(cpu, ja)
+
+    # CPU → JLGPU
+    ja2 = on_architecture(jlgpu, a)
+    @test ja2 isa JLArray
+    @test Array(ja2) ≈ a
+
+    # JLGPU → JLGPU: identity
+    @test on_architecture(jlgpu, ja) === ja
+
+    # SubArray of CPU array → JLGPU
+    v = view(a, :, 1)
+    jv = on_architecture(jlgpu, v)
+    @test jv isa JLArray
+    @test Array(jv) ≈ v
+
+    # SubArray of JLArray → CPU
+    jvsub = view(ja, :, 1)
+    av = on_architecture(cpu, jvsub)
+    @test av isa Array
+    @test av ≈ Array(view(ja, :, 1))
+
+    # pass-throughs
+    @test on_architecture(cpu, 3.14) === 3.14
+    sr = 1.0:0.1:2.0
+    @test on_architecture(cpu, sr) === sr
+    @test on_architecture(jlgpu, sr) === sr
+end
+
+@testset "on_architecture Tuple / NamedTuple" begin
+    cpu = CPU()
+    jlgpu = GPU(JLArrays.JLBackend())
+
+    a1 = rand(Float32, 3)
+    a2 = rand(Float64, 2)
+    t = (a1, a2)
+
+    t_gpu = on_architecture(jlgpu, t)
+    @test t_gpu[1] isa JLArray
+    @test t_gpu[2] isa JLArray
+
+    t_back = on_architecture(cpu, t_gpu)
+    @test t_back[1] isa Array
+    @test t_back[2] isa Array
+
+    nt = (x = a1, y = a2)
+    nt_gpu = on_architecture(jlgpu, nt)
+    @test nt_gpu.x isa JLArray
+    @test keys(nt_gpu) == (:x, :y)
+end
+
+@testset "convert_to_device" begin
+    cpu = CPU()
+    jlgpu = GPU(JLArrays.JLBackend())
+    args = (rand(Float32, 2), 1.0)
+
+    # CPU: pass-through
+    @test convert_to_device(cpu, args) === args
+end
+
+@testset "synchronize" begin
+    cpu = CPU()
+    jlgpu = GPU(JLArrays.JLBackend())
+    # just must not error
+    @test (synchronize(cpu); true)
+    @test (synchronize(jlgpu); true)
+end


### PR DESCRIPTION
Milan: Motivation, this

```julia
    try
        v = path(variable, simulation)
        ts = simulation.model.time_stepping
        has_step = (is3D(variable) && ndims(v) == 3) ||
                    (is2D(variable) && ndims(v) == 2)
        v = has_step ? get_prognostic_step(v, ts, output) : v

        # TODO somehow this throws an error with a view
        raw = on_architecture(CPU(), v)
        RingGrids.interpolate!(var, raw, output.interpolator)
    catch FieldError
        var .= variable.missing_value
    end
```

threw an error in #1035 because there we need to view an array before passing to `on_architecture`. This was actually tricky to find out because of the `try` block no error was thrown.