### PR TITLE
Also have non-unicode spectral gradient operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add non-unicode function name aliases laplace, inverse_laplace, gradient [#1078](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1078)
 - [BREAKING] `output_dt` renamed to `interval` [#1075](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1075)
 - `set!(output, model; interval)` to change output frequency after model initialization [#1075](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1075)
 - Documentation hero page and docs rendering [#1071](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1071) [#1072](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1072)

--- a/SpeedyTransforms/src/SpeedyTransforms.jl
+++ b/SpeedyTransforms/src/SpeedyTransforms.jl
@@ -44,7 +44,10 @@ export curl,
     UV_from_vor!,
     UV_from_vordiv!,
     ∇²!, ∇⁻²!, ∇!,
-    ∇², ∇⁻², ∇
+    ∇², ∇⁻², ∇,
+    laplace, inverse_laplace,
+    laplace!, inverse_laplace!,
+    gradient, gradient!
 
 # TRUNCATION
 export spectral_truncation,

--- a/SpeedyTransforms/src/spectral_gradients.jl
+++ b/SpeedyTransforms/src/spectral_gradients.jl
@@ -564,3 +564,11 @@ function ∇(field::AbstractField; kwargs...)
     S = SpectralTransform(field, one_more_degree = true)
     return ∇(field, S; kwargs...)
 end
+
+# for people that don't have unicode support on their keyboard
+laplace = ∇²
+laplace = ∇²!
+inverse_laplace = ∇⁻²
+inverse_laplace! = ∇⁻²!
+gradient = ∇
+gradient! = ∇!

--- a/SpeedyTransforms/src/spectral_gradients.jl
+++ b/SpeedyTransforms/src/spectral_gradients.jl
@@ -567,7 +567,7 @@ end
 
 # for people that don't have unicode support on their keyboard
 laplace = ∇²
-laplace = ∇²!
+laplace! = ∇²!
 inverse_laplace = ∇⁻²
 inverse_laplace! = ∇⁻²!
 gradient = ∇

--- a/SpeedyWeather/src/SpeedyWeather.jl
+++ b/SpeedyWeather/src/SpeedyWeather.jl
@@ -102,6 +102,8 @@ export MatrixSpectralTransform
 export transform, transform!
 export curl, divergence, curl!, divergence!
 export ∇, ∇², ∇⁻², ∇!, ∇²!, ∇⁻²!
+export laplace, inverse_laplace, laplace!, inverse_laplace!
+export gradient, gradient!
 export power_spectrum
 
 import SpeedyTransforms: AbstractSpectralTransform, prettymemory


### PR DESCRIPTION
As requested by William Greenall (@wegreenall)

introduces the following aliases

```julia
laplace = ∇²
laplace! = ∇²!
inverse_laplace = ∇⁻²
inverse_laplace! = ∇⁻²!
gradient = ∇
gradient! = ∇!
```

for the (only) unicode-based exported functions we have. I think it's a good philosophy to have user-facing code ascii only. Internally I'm still a big fan of greek symbols etc.