### PR TITLE
Variable system name `allocate` instead of `Base.zero`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Variable system: rename function that allocates new variables from `Base.zero` to `allocate` [#1087](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1087)
+
 ## v0.20.1
 
 - Implement CO2 and greenhouse gases [#993](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/993)

--- a/SpeedyWeather/src/variables/dimensions.jl
+++ b/SpeedyWeather/src/variables/dimensions.jl
@@ -1,85 +1,85 @@
 """Dimension for the simulation clock and time tracking."""
 struct ClockDim <: AbstractVariableDim end
-Base.zero(::AbstractVariable{ClockDim}, model::AbstractModel) = Clock(model.architecture)
+allocate(::AbstractVariable{ClockDim}, model::AbstractModel) = Clock(model.architecture)
 
 """Dimension for scalar variables holding single numerical values as RefValue.
 Default value is 0, but can be set via ScalarDim, e.g. ScalarDim(1) for a default value of 1."""
 @kwdef struct ScalarDim{T} <: AbstractVariableDim
     value::T = zero(DEFAULT_NF)                                 # default value via ScalarDim(1)
 end
-Base.zero(v::AbstractVariable{<:ScalarDim}, model::AbstractModel) = Ref(convert(model.spectral_grid.NF, v.dims.value))
+allocate(v::AbstractVariable{<:ScalarDim}, model::AbstractModel) = Ref(convert(model.spectral_grid.NF, v.dims.value))
 
 """Dimension for 2D grid variables on the horizontal grid."""
 struct Grid2D <: AbstractVariableDim end
-Base.zero(::AbstractVariable{Grid2D}, model::AbstractModel) = zeros(model.spectral_grid.GridVariable2D, model.spectral_grid.grid)
+allocate(::AbstractVariable{Grid2D}, model::AbstractModel) = zeros(model.spectral_grid.GridVariable2D, model.spectral_grid.grid)
 
 """Dimension for 3D grid variables on the horizontal grid with vertical levels."""
 struct Grid3D <: AbstractVariableDim end
-Base.zero(::AbstractVariable{Grid3D}, model::AbstractModel) = zeros(model.spectral_grid.GridVariable3D, model.spectral_grid.grid, get_nlayers(model))
+allocate(::AbstractVariable{Grid3D}, model::AbstractModel) = zeros(model.spectral_grid.GridVariable3D, model.spectral_grid.grid, get_nlayers(model))
 
 """Dimension for 3D land surface variables."""
 struct Land3D <: AbstractVariableDim end
-Base.zero(::AbstractVariable{Land3D}, model::AbstractModel) = zeros(model.spectral_grid.GridVariable3D, model.spectral_grid.grid, get_nlayers(model.land))
+allocate(::AbstractVariable{Land3D}, model::AbstractModel) = zeros(model.spectral_grid.GridVariable3D, model.spectral_grid.grid, get_nlayers(model.land))
 
 """Dimension for 3D ocean variables."""
 struct Ocean3D <: AbstractVariableDim end
-Base.zero(::AbstractVariable{Ocean3D}, model::AbstractModel) = zeros(model.spectral_grid.GridVariable3D, model.spectral_grid.grid, get_nlayers(model.ocean))
+allocate(::AbstractVariable{Ocean3D}, model::AbstractModel) = zeros(model.spectral_grid.GridVariable3D, model.spectral_grid.grid, get_nlayers(model.ocean))
 
 """Dimension for 2D spectral variables."""
 struct Spectral2D <: AbstractVariableDim end
-Base.zero(::AbstractVariable{Spectral2D}, model::AbstractModel) = zeros(model.spectral_grid.SpectralVariable2D, model.spectral_grid.spectrum)
+allocate(::AbstractVariable{Spectral2D}, model::AbstractModel) = zeros(model.spectral_grid.SpectralVariable2D, model.spectral_grid.spectrum)
 
 """Dimension for 3D spectral variables with e.g. `n` vertical levels."""
 @kwdef struct Spectral3D <: AbstractVariableDim
     n::Int = 0
 end
-Base.zero(v::AbstractVariable{Spectral3D}, model::AbstractModel) = zeros(model.spectral_grid.SpectralVariable3D, model.spectral_grid.spectrum, v.dims.n == 0 ? get_nlayers(model) : v.dims.n)
+allocate(v::AbstractVariable{Spectral3D}, model::AbstractModel) = zeros(model.spectral_grid.SpectralVariable3D, model.spectral_grid.spectrum, v.dims.n == 0 ? get_nlayers(model) : v.dims.n)
 
 """Dimension for 1D variables as a function of latitude only."""
 struct Latitude1D <: AbstractVariableDim end
-Base.zero(::AbstractVariable{Latitude1D}, model::AbstractModel) = fill!(model.spectral_grid.VectorType(undef, model.spectral_grid.nlat), 0)
+allocate(::AbstractVariable{Latitude1D}, model::AbstractModel) = fill!(model.spectral_grid.VectorType(undef, model.spectral_grid.nlat), 0)
 
 """Dimension for 1D vertical level variables."""
 struct Vertical1D <: AbstractVariableDim end
-Base.zero(::AbstractVariable{Vertical1D}, model::AbstractModel) = fill!(model.spectral_grid.VectorType(undef, get_nlayers(model)), 0)
+allocate(::AbstractVariable{Vertical1D}, model::AbstractModel) = fill!(model.spectral_grid.VectorType(undef, get_nlayers(model)), 0)
 
 """Dimension for 4D grid variables with customizable extra dimension."""
 @kwdef struct Grid4D <: AbstractVariableDim
     n::Int = 1                                                  # length of 4th dimension
 end
-Base.zero(v::AbstractVariable{Grid4D}, model::AbstractModel) = zeros(model.spectral_grid.GridVariable3D, model.spectral_grid.grid, get_nlayers(model), v.dims.n)
+allocate(v::AbstractVariable{Grid4D}, model::AbstractModel) = zeros(model.spectral_grid.GridVariable3D, model.spectral_grid.grid, get_nlayers(model), v.dims.n)
 
 """Dimension for 4D spectral variables with customizable extra dimension."""
 @kwdef struct Spectral4D <: AbstractVariableDim
     n::Int = 1
 end
-Base.zero(v::AbstractVariable{Spectral4D}, model::AbstractModel) = zeros(model.spectral_grid.SpectralVariable3D, model.spectral_grid.spectrum, get_nlayers(model), v.dims.n)
+allocate(v::AbstractVariable{Spectral4D}, model::AbstractModel) = zeros(model.spectral_grid.SpectralVariable3D, model.spectral_grid.spectrum, get_nlayers(model), v.dims.n)
 
 """Dimension for generic vector data of arbitrary length."""
 @kwdef struct VectorDim <: AbstractVariableDim
     n::Int = 1
 end
-Base.zero(v::AbstractVariable{VectorDim}, model::AbstractModel) = fill!(model.spectral_grid.VectorType(undef, v.dims.n), 0)
+allocate(v::AbstractVariable{VectorDim}, model::AbstractModel) = fill!(model.spectral_grid.VectorType(undef, v.dims.n), 0)
 
 """Dimension for particle system vectors."""
 @kwdef struct ParticleVectorDim <: AbstractVariableDim
     n::Int = 1
 end
-Base.zero(v::AbstractVariable{ParticleVectorDim}, model::AbstractModel) = zeros(model.spectral_grid.ParticleVectorType, v.dims.n)
+allocate(v::AbstractVariable{ParticleVectorDim}, model::AbstractModel) = zeros(model.spectral_grid.ParticleVectorType, v.dims.n)
 
 """Dimension for matrix data of arbitrary dimensions."""
 @kwdef struct MatrixDim <: AbstractVariableDim
     m::Int = 1
     n::Int = 1
 end
-Base.zero(v::AbstractVariable{MatrixDim}, model::AbstractModel) = fill!(model.spectral_grid.MatrixType(undef, v.dims.m, v.dims.n), 0)
+allocate(v::AbstractVariable{MatrixDim}, model::AbstractModel) = fill!(model.spectral_grid.MatrixType(undef, v.dims.m, v.dims.n), 0)
 
 """Dimension for spectral transform scratch memory."""
 struct TransformScratchMemory <: AbstractVariableDim end
-Base.zero(::AbstractVariable{TransformScratchMemory}, model::AbstractModel) = model.spectral_transform.scratch_memory
+allocate(::AbstractVariable{TransformScratchMemory}, model::AbstractModel) = model.spectral_transform.scratch_memory
 
 """Dimension for particle locator tracking in space."""
 @kwdef struct LocatorDim <: AbstractVariableDim
     n::Int = 1                                                  # number of locations to track, e.g. for particle advection
 end
-Base.zero(::AbstractVariable{LocatorDim}, model::AbstractModel) = RingGrids.AnvilLocator(model.spectral_grid.NF, model.particle_advection.nparticles; architecture = model.spectral_grid.architecture)
+allocate(::AbstractVariable{LocatorDim}, model::AbstractModel) = RingGrids.AnvilLocator(model.spectral_grid.NF, model.particle_advection.nparticles; architecture = model.spectral_grid.architecture)

--- a/SpeedyWeather/src/variables/variables.jl
+++ b/SpeedyWeather/src/variables/variables.jl
@@ -210,7 +210,7 @@ function allocate(group, model)
 
     # variables without namespace identified by empty symbol Symbol() go directly into the main NamedTuple
     # that way we have variables.prognostic.vorticity skipping the namespace between prognostic and vor
-    nt1 = NamedTuple{Tuple(map(v -> v.name, group[Symbol()]))}(Tuple(map(var -> zero(var, model), group[Symbol()])))
+    nt1 = NamedTuple{Tuple(map(v -> v.name, group[Symbol()]))}(Tuple(map(var -> allocate(var, model), group[Symbol()])))
 
     # other variables grouped by namespace
     # e.g. variables.prognostic.ocean.sea_surface_temperature, variables.prognostic.land.soil_moisture, etc.
@@ -218,7 +218,7 @@ function allocate(group, model)
         Tuple(
             map(
                 ns ->
-                NamedTuple{Tuple(map(v -> v.name, group[ns]))}(Tuple(map(var -> zero(var, model), group[ns])))
+                NamedTuple{Tuple(map(v -> v.name, group[ns]))}(Tuple(map(var -> allocate(var, model), group[ns])))
                 , namespaces
             )
         )

--- a/docs/src/variable_system.md
+++ b/docs/src/variable_system.md
@@ -112,7 +112,7 @@ a dictionary dimension.
 
 ```@example variable_system
 struct MyDictDim <: SpeedyWeather.AbstractVariableDim end
-Base.zero(::SpeedyWeather.AbstractVariable{MyDictDim}, model::AbstractModel) = Dict()
+SpeedyWeather.allocate(::SpeedyWeather.AbstractVariable{MyDictDim}, model::AbstractModel) = Dict()
 ```
 
 and use like


### PR DESCRIPTION
`allocate` is a bit more general than extending `Base.zero`

cc @bgroenks96 