### PR TITLE
Fix link in Docstring of `OneBandLongwave`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a wrong reference in the documentation [#1092](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1092)
 - `ZarrOutput` for writing simulation output to a Zarr store, implemented as a Zarr.jl extension [#1076](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1076)
 - Add non-unicode function name aliases laplace, inverse_laplace, gradient [#1078](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1078)
 

--- a/SpeedyWeather/src/parameterizations/radiation/longwave_radiation.jl
+++ b/SpeedyWeather/src/parameterizations/radiation/longwave_radiation.jl
@@ -156,7 +156,7 @@ end
 
 export OneBandLongwave
 """One-band longwave radiation scheme with transmissivity and radiative transfer components.
-Following Frierson, 2006, JAS, https://doi.org/10.1175/JAS3706.1. Fields are $(TYPEDFIELDS)"""
+Following Frierson, 2006, JAS, https://doi.org/10.1175/JAS3753.1. Fields are $(TYPEDFIELDS)"""
 @parameterized @kwdef struct OneBandLongwave{T, R} <: AbstractLongwave
     @component transmissivity::T
     @component radiative_transfer::R


### PR DESCRIPTION
No idea how that wrong reference got there, but @SieglStefan found it. Thanks!