### PR TITLE
Recompute Legendre polynomials on the fly instead of precomputing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Recompute the Legendre polynomials on the fly instead of precomputing them, via a new `recompute_legendre` keyword of `SpectralTransform` and a new `SpeedyTransforms.ScaledLegendre` module, turning their `O(T³)` memory into `O(T²)` [#1244](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1244)
 - Lazy batching of FTT plans on GPU to increase performance of models other than the `PrimitiveWetModel` [#1234](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1234)
 - Remove dead code: unused `get_2lm_range` [#1243](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1243)
 - Add a central, BibTeX-backed documentation bibliography with DocumenterCitations [#478](https://github.com/SpeedyWeather/SpeedyWeather.jl/issues/478)

--- a/SpeedyTransforms/Project.toml
+++ b/SpeedyTransforms/Project.toml
@@ -1,6 +1,6 @@
 name = "SpeedyTransforms"
 uuid = "ed023a3f-7a3c-42dd-bab6-68c21c8c3105"
-version = "0.3.0-DEV"
+version = "0.2.1+DEV"
 authors = ["SpeedyTransforms contributors"]
 
 [deps]

--- a/SpeedyTransforms/Project.toml
+++ b/SpeedyTransforms/Project.toml
@@ -1,6 +1,6 @@
 name = "SpeedyTransforms"
 uuid = "ed023a3f-7a3c-42dd-bab6-68c21c8c3105"
-version = "0.2.1+DEV"
+version = "0.3.0-DEV"
 authors = ["SpeedyTransforms contributors"]
 
 [deps]

--- a/SpeedyTransforms/src/SpeedyTransforms.jl
+++ b/SpeedyTransforms/src/SpeedyTransforms.jl
@@ -59,6 +59,11 @@ export power_spectrum
 # UTILS
 export wrapped_view
 
+include("scaled_legendre.jl")
+using .ScaledLegendre
+
+include("legendre_polynomials.jl")
+
 include("aliasing.jl")
 include("legendre_shortcuts.jl")
 include("scratch_memory.jl")

--- a/SpeedyTransforms/src/legendre.jl
+++ b/SpeedyTransforms/src/legendre.jl
@@ -1,3 +1,32 @@
+"""$(TYPEDSIGNATURES)
+Return the Legendre polynomials for latitude ring `j`, as a vector indexed by the running `lm`
+index (all orders `m`, all degrees `l`, one ring). For `PrecomputedLegendre` this is a `view` into
+the precomputed table; for `RecomputedLegendre` it fills the struct's `ring` scratch vector by
+recomputing every column (looping over orders `m`) via `ScaledLegendre.legendre_column!` and
+returns it. Meant to be hoisted to the top of the `j` loop in the CPU `_legendre!` methods below,
+so the recursion for `RecomputedLegendre` is amortised over every order and every layer of one
+ring — one recursion pass per ring per transform, run in `Float64` when `NF == Float64` and in
+double-single arithmetic otherwise (see `ScaledLegendre`), so CPU and GPU agree."""
+legendre_ring!(legendre::PrecomputedLegendre, j::Integer) = view(legendre.polynomials.data, :, j)
+
+function legendre_ring!(legendre::RecomputedLegendre, j::Integer)
+    (; lmax, ring, x, αhi, αlo, βhi, βlo, sectoral_hi, sectoral_lo, sectoral_scale) = legendre
+    mmax = size(sectoral_hi, 2)
+    lm_offset = 0
+    @inbounds for m in 1:mmax
+        ncolumn = lmax - m + 1
+        out = view(ring, (lm_offset + 1):(lm_offset + ncolumn))
+        ScaledLegendre.legendre_column!(
+            out, x[j],
+            αhi, αlo, βhi, βlo,
+            lm_offset, ncolumn,
+            sectoral_hi[j, m], sectoral_lo[j, m], sectoral_scale[j, m],
+        )
+        lm_offset += ncolumn
+    end
+    return ring
+end
+
 # (inverse) legendre transform kernel, called from _legendre!
 @inline function _fused_oddeven_matvec!(
         north::AbstractVector,      # output, accumulator vector, northern latitudes
@@ -45,7 +74,7 @@ function _legendre!(
     )
     (; nlat_half) = S.grid                  # dimensions
     (; lmax, mmax) = S.spectrum            # 1-based max degree l, order m of spherical harmonics
-    (; legendre_polynomials) = S            # precomputed Legendre polynomials
+    legendre = S.legendre                   # precomputed or recomputed Legendre polynomials
     (; mmax_truncation) = S                 # Legendre shortcut, shortens loop over m, 1-based
     (; coslat⁻¹, lon_offsets) = S
     nlayers = axes(specs, 2)                # get number of layers of specs for fewer layers than precomputed in S
@@ -69,6 +98,8 @@ function _legendre!(
         g_north[:, nlayers, j] .= 0       # reset scratch memory
         g_south[:, nlayers, j] .= 0       # reset scratch memory
 
+        legendre_j = legendre_ring!(legendre, j)  # precomputed view or recomputed ring, amortised over m, k
+
         # INVERSE LEGENDRE TRANSFORM by looping over wavenumbers l, m
         lm = 1                              # single running index for non-zero l, m indices
         for m in 1:(mmax_truncation[j] + 1)   # Σ_{m=0}^{mmax}, but 1-based index, shortened to mmax_truncation
@@ -76,7 +107,7 @@ function _legendre!(
 
             # view on lower triangular column, but batched in vertical
             spec_view = view(specs.data, lm:lm_end, :)
-            legendre_view = view(legendre_polynomials.data, lm:lm_end, j)
+            legendre_view = view(legendre_j, lm:lm_end)
 
             # dot product but split into even and odd harmonics on the fly for better performance
             # function is 1-based (odd, even, odd, ...) but here use 0-based indexing to name
@@ -139,7 +170,7 @@ function _legendre!(                        # GRID TO SPECTRAL
     (; nlat) = S                            # dimensions
     (; nlat_half) = S.grid
     (; lmax, mmax) = S.spectrum             # 1-based max degree l, order m of spherical harmonics
-    (; legendre_polynomials) = S            # precomputed Legendre polynomials
+    legendre = S.legendre                   # precomputed or recomputed Legendre polynomials
     (; mmax_truncation) = S                 # Legendre shortcut, shortens loop over m, 1-based
     (; solid_angles, lon_offsets) = S
     nlayers = axes(specs, 2)                # get number of layers of specs for fewer layers than precomputed in S
@@ -168,6 +199,8 @@ function _legendre!(                        # GRID TO SPECTRAL
         # SOLID ANGLES including quadrature weights (sinθ Δθ) and azimuth (Δϕ) on ring j
         ΔΩ = solid_angles[j]                # = sinθ Δθ Δϕ, solid angle for a grid point
 
+        legendre_j = legendre_ring!(legendre, j)  # precomputed view or recomputed ring, amortised over m, k
+
         lm = 1                              # single running index for spherical harmonics
         for m in 1:(mmax_truncation[j] + 1)   # Σ_{m=0}^{mmax}, but 1-based index, shortened to mmax_truncation
 
@@ -185,7 +218,7 @@ function _legendre!(                        # GRID TO SPECTRAL
             # integration over l = m:lmax+1
             lm_end = lm + lmax - m + 1                      # last index in column m
             spec_view = view(specs.data, lm:lm_end, :)
-            legendre_view = view(legendre_polynomials.data, lm:lm_end, j)
+            legendre_view = view(legendre_j, lm:lm_end)
 
             _fused_oddeven_outer_product_accumulate!(spec_view, legendre_view, even, odd)
 

--- a/SpeedyTransforms/src/legendre.jl
+++ b/SpeedyTransforms/src/legendre.jl
@@ -10,14 +10,14 @@ double-single arithmetic otherwise (see `ScaledLegendre`), so CPU and GPU agree.
 legendre_ring!(legendre::PrecomputedLegendre, j::Integer) = view(legendre.polynomials.data, :, j)
 
 function legendre_ring!(legendre::RecomputedLegendre, j::Integer)
-    (; lmax, ring, x, αhi, αlo, βhi, βlo, sectoral_hi, sectoral_lo, sectoral_scale) = legendre
+    (; lmax, ring, xhi, xlo, αhi, αlo, βhi, βlo, sectoral_hi, sectoral_lo, sectoral_scale) = legendre
     mmax = size(sectoral_hi, 2)
     lm_offset = 0
     @inbounds for m in 1:mmax
         ncolumn = lmax - m + 1
         out = view(ring, (lm_offset + 1):(lm_offset + ncolumn))
         ScaledLegendre.legendre_column!(
-            out, x[j],
+            out, xhi[j], xlo[j],
             αhi, αlo, βhi, βlo,
             lm_offset, ncolumn,
             sectoral_hi[j, m], sectoral_lo[j, m], sectoral_scale[j, m],

--- a/SpeedyTransforms/src/legendre_ka.jl
+++ b/SpeedyTransforms/src/legendre_ka.jl
@@ -67,6 +67,99 @@ multiply and add where it does not, whereas `fma` would force a slow software em
 end
 
 
+# (inverse) legendre transform kernel for the RECOMPUTED polynomials, called from _legendre!
+# Same thread layout as `inverse_legendre_kernel!` above — one thread per (ring j, order m, layer
+# k), taken from `jm_indices` — but instead of loading the precomputed polynomials it runs the
+# ScaledLegendre column recursion in registers as it walks down the column, so nothing is read from
+# global memory per harmonic except the α/β recursion coefficients. Those are indexed by lm alone,
+# which is identical for every thread of a warp (a warp holds neighbouring rings at the *same*
+# order), so they broadcast out of cache instead of being fetched per thread.
+@kernel inbounds = true function inverse_legendre_recompute_kernel!(
+        g_north,                        # Scratch storage for legendre coefficients
+        g_south,                        # before fft
+        specs_data,                     # Data passed from spectral grid
+        αhi, αlo, βhi, βlo,             # input, recursion coefficients (double-single), by lm
+        sectoral_hi, sectoral_lo,       # input, starting values λ_m^m (double-single), (j, m)
+        sectoral_scale,                 # input, their extended-exponent scale, (j, m)
+        xhi, xlo,                       # input, cos(colat) (double-single), by j
+        lon_offsets,                    # input, longitude offset rotation per (m, j)
+        jm_indices,                     # precomputed (j, m, lm_offset, column length) per row
+    )
+    i, k = @index(Global, NTuple)
+
+    j = jm_indices[i, 1]
+    m = jm_indices[i, 2]
+    lm_offset = jm_indices[i, 3]        # offset to index the lower triangular column directly
+    ncolumn = jm_indices[i, 4]          # number of degrees at order m, lmax-m
+
+    NF = eltype(αhi)
+    # "even" and "odd" coined with 0-based indexing, i.e. the even l=0 mode is 1st element
+    even_k = zero(eltype(g_north))      # dot product with elements 1, 3, 5, ...
+    odd_k = zero(eltype(g_south))       # dot product with elements 2, 4, 6, ...
+
+    # ncolumn == 0 marks the rows beyond the Legendre truncation, which only write zeros; skipping
+    # here also keeps the sectoral lookup below in bounds, as those rows carry an order m that can
+    # exceed mmax (they exist to cover the Fourier frequencies, see `jm_indices`' construction)
+    if ncolumn > 0
+        xh, xl = xhi[j], xlo[j]
+        p1h, p1l = sectoral_hi[j, m], sectoral_lo[j, m]  # λ_{l-1}^m, starting at the sectoral mode
+        p2h, p2l = zero(NF), zero(NF)                    # λ_{l-2}^m ≡ 0 above the sectoral mode
+        s = Int32(sectoral_scale[j, m])
+
+        # PHASE 1: climb out of the underflow region (λ_m^m ~ sinθ^m is far below floatmin near the
+        # poles at high m). Every value here is zero to working precision by the `scale_shift`
+        # invariant, so nothing is accumulated and the recursion just steps. If the column ends
+        # before s reaches 0 the whole column is negligible and this thread writes zeros, which is
+        # also what the precomputed path produces there.
+        q = 1
+        while q <= ncolumn && s > 0
+            p1h, p1l, p2h, p2l, s = ScaledLegendre.legendre_advance(
+                αhi[lm_offset + q + 1], αlo[lm_offset + q + 1],
+                βhi[lm_offset + q + 1], βlo[lm_offset + q + 1],
+                xh, xl, p1h, p1l, p2h, p2l, s,
+            )
+            q += 1
+        end
+
+        # PHASE 2: the hot loop, two recursion steps per iteration so the even/odd (north/south
+        # symmetry) split of the dot product survives without a branch or a parity test inside.
+        # `a` collects positions q_first, q_first+2, ..., `b` the ones in between; which of the two
+        # is the "even" sum depends only on the parity of where phase 1 left off.
+        q_first = q
+        a = zero(eltype(g_north))
+        b = zero(eltype(g_south))
+        while q < ncolumn                   # a full pair still fits
+            a = muladd_complex(ScaledLegendre.legendre_value(p1h, p1l), specs_data[lm_offset + q, k], a)
+            p1h, p1l, p2h, p2l, s = ScaledLegendre.legendre_advance(
+                αhi[lm_offset + q + 1], αlo[lm_offset + q + 1],
+                βhi[lm_offset + q + 1], βlo[lm_offset + q + 1],
+                xh, xl, p1h, p1l, p2h, p2l, s,
+            )
+            b = muladd_complex(ScaledLegendre.legendre_value(p1h, p1l), specs_data[lm_offset + q + 1, k], b)
+            p1h, p1l, p2h, p2l, s = ScaledLegendre.legendre_advance(
+                αhi[lm_offset + q + 2], αlo[lm_offset + q + 2],
+                βhi[lm_offset + q + 2], βlo[lm_offset + q + 2],
+                xh, xl, p1h, p1l, p2h, p2l, s,
+            )
+            q += 2
+        end
+
+        if q == ncolumn                     # odd number of remaining degrees, do the last one
+            a = muladd_complex(ScaledLegendre.legendre_value(p1h, p1l), specs_data[lm_offset + ncolumn, k], a)
+        end
+
+        # 1-based positions: an odd position is an even degree l-m, hence the parity test
+        even_k, odd_k = isodd(q_first) ? (a, b) : (b, a)
+    end
+
+    # CORRECT FOR LONGITUDE OFFSETTS (if grid points don't start at 0°E), see the kernel above
+    o = ncolumn > 0 ? lon_offsets[m, j] : zero(eltype(lon_offsets))
+
+    g_north[m, k, j] = o * (even_k + odd_k)
+    g_south[m, k, j] = o * (even_k - odd_k)
+end
+
+
 """$(TYPEDSIGNATURES)
 Inverse Legendre transform, adapted for KernelAbstractions (GPU usage) and batched across j (lattitude),
 k (vertical layers) and m (spherical harmonic order). Not to be used directly,
@@ -81,11 +174,7 @@ function _legendre!(
     ) where {NF}
 
     (; nlat_half) = S.grid              # dimensions
-    S.legendre isa RecomputedLegendre && throw(ArgumentError(
-        "recompute_legendre = true is not yet supported on GPU (the recomputed GPU kernels are " *
-            "step 3 of docs/dev/2026-09/recompute-legendre-polynomials.md); use recompute_legendre = false."
-    ))
-    legendre_polynomials_transposed = S.legendre.polynomials_transposed  # precomputed Legendre polynomials, (j, lm)
+    legendre = S.legendre               # precomputed or recomputed Legendre polynomials
     (; jm_indices) = S                  # (j, m) loop indices precomputed for threads
     (; coslat⁻¹, lon_offsets) = S
     nlayers = size(specs, 2)            # get number of layers of specs for fewer layers than precomputed in S
@@ -104,20 +193,39 @@ function _legendre!(
     # no need to reset g_north/g_south here: every frequency the Fourier transform reads is
     # written by the kernel below, the rows beyond the Legendre truncation with zeros
 
-    # Launch the kernel with the specified configuration
-    launch!(
-        S.architecture,
-        ArrayWorkOrder,
-        (S.jm_index_size, nlayers),
-        inverse_legendre_kernel!,
-        g_north,
-        g_south,
-        specs.data,
-        legendre_polynomials_transposed,
-        lon_offsets,
-        jm_indices,
-        nlat_half
-    )
+    # Launch the kernel with the specified configuration. The two modes differ only in where the
+    # polynomials come from — a global-memory load from the transposed table, or the recursion run
+    # in registers — so the thread layout and the work size are identical.
+    if legendre isa RecomputedLegendre
+        launch!(
+            S.architecture,
+            ArrayWorkOrder,
+            (S.jm_index_size, nlayers),
+            inverse_legendre_recompute_kernel!,
+            g_north,
+            g_south,
+            specs.data,
+            legendre.αhi, legendre.αlo, legendre.βhi, legendre.βlo,
+            legendre.sectoral_hi, legendre.sectoral_lo, legendre.sectoral_scale,
+            legendre.xhi, legendre.xlo,
+            lon_offsets,
+            jm_indices
+        )
+    else
+        launch!(
+            S.architecture,
+            ArrayWorkOrder,
+            (S.jm_index_size, nlayers),
+            inverse_legendre_kernel!,
+            g_north,
+            g_south,
+            specs.data,
+            legendre.polynomials_transposed,   # precomputed Legendre polynomials, (j, lm)
+            lon_offsets,
+            jm_indices,
+            nlat_half
+        )
+    end
 
     # unscale by cosine of latitude on the fly if requested
     if unscale_coslat
@@ -132,17 +240,23 @@ end
 # each summing over the latitude rings that contribute at its order m. That way every coefficient
 # is written by exactly one thread, so no atomic accumulation (and no reset of specs) is needed,
 # and neighbouring threads read/write neighbouring coefficients.
+# `lm_offset` shifts the thread index onto a contiguous *block* of coefficients: it is 0 for the
+# precomputed path (one launch covering every coefficient, `legendre_polynomials_data` the whole
+# table) and the base of the current tile for the recomputed path, where the launch is repeated per
+# tile and `legendre_polynomials_data` holds only that tile's rows, see the recompute kernel below.
 @kernel inbounds = true function forward_legendre_kernel!(
         specs_data,                 # output, spherical harmonic coefficients
-        legendre_polynomials_data,  # input, Legendre polynomials
+        legendre_polynomials_data,  # input, Legendre polynomials, (lm - lm_offset, j)
         f_north,                    # input, Fourier-transformed northern latitudes
         f_south,                    # input, southern latitudes
         lon_offsets,                # input, longitude offset rotation per (m, j)
         solid_angles,               # input, solid angles for each latitude
         lm_indices,                 # precomputed (m, hemisphere sign, row range) per coefficient
         jm_indices,                 # precomputed (j, m, lm_offset, column length) per row
+        lm_offset,                  # index of the coefficient just before this launch's block
     )
-    lm, k = @index(Global, NTuple)
+    lm_local, k = @index(Global, NTuple)
+    lm = lm_local + lm_offset       # global coefficient index
 
     m = lm_indices[lm, 1]           # order m of this coefficient
     # north + south for even, north - south for odd degrees l-m, the symmetry split
@@ -158,10 +272,53 @@ end
         ΔΩ_rotated = solid_angles[j] * conj(lon_offsets[m, j])
 
         f = muladd_complex(hemisphere_sign, f_south[m, k, j], f_north[m, k, j])
-        spec = muladd_complex(legendre_polynomials_data[lm, j], ΔΩ_rotated * f, spec)
+        spec = muladd_complex(legendre_polynomials_data[lm_local, j], ΔΩ_rotated * f, spec)
     end
 
     specs_data[lm, k] = spec
+end
+
+# Recompute one tile of the Legendre polynomials for the forward transform, called from _legendre!
+# One thread per (ring j, order m) walking the whole column at that order down into `tile`, which
+# holds a contiguous block of orders in the same (lm, j) layout the precomputed table uses — so
+# `forward_legendre_kernel!` above reads it with exactly the same indexing and the same coalescing.
+# The ring j is the *fast* thread index so that neighbouring threads of a warp share the order m
+# and therefore the α/β lookups (broadcast from cache) and the column length (no divergence); the
+# writes down a column are strided, which is the right trade because the tile is written once per
+# transform but read once per layer.
+@kernel inbounds = true function recompute_legendre_tile_kernel!(
+        tile,                       # output, one tile of Legendre polynomials, (lm - lm_base, j)
+        αhi, αlo, βhi, βlo,         # input, recursion coefficients (double-single), by lm
+        sectoral_hi, sectoral_lo,   # input, starting values λ_m^m (double-single), (j, m)
+        sectoral_scale,             # input, their extended-exponent scale, (j, m)
+        xhi, xlo,                   # input, cos(colat) (double-single), by j
+        lmax,                       # 1-based number of degrees, to get each column's length
+        m_first,                    # first order m of this tile
+        lm_base,                    # index of the coefficient just before this tile's first column
+    )
+    j, mi = @index(Global, NTuple)
+    m = m_first + mi - 1
+    ncolumn = lmax - m + 1                              # degrees at order m
+
+    # index just before this column's first entry, LowerTriangularArrays.lm2i(m, m, lmax) - 1
+    lm_column = m + (m - 1) * lmax - m * (m - 1) ÷ 2 - 1
+    row = lm_column - lm_base                           # same, but relative to this tile
+
+    NF = eltype(tile)
+    xh, xl = xhi[j], xlo[j]
+    p1h, p1l = sectoral_hi[j, m], sectoral_lo[j, m]     # λ_{l-1}^m, starting at the sectoral mode
+    p2h, p2l = zero(NF), zero(NF)                       # λ_{l-2}^m ≡ 0 above the sectoral mode
+    s = Int32(sectoral_scale[j, m])
+
+    # identical to ScaledLegendre.legendre_column!, written out here because the output is a
+    # strided column of a matrix rather than a contiguous vector
+    for q in 1:ncolumn
+        tile[row + q, j] = s == 0 ? ScaledLegendre.legendre_value(p1h, p1l) : zero(NF)
+        i = lm_column + q + 1
+        p1h, p1l, p2h, p2l, s = ScaledLegendre.legendre_advance(
+            αhi[i], αlo[i], βhi[i], βlo[i], xh, xl, p1h, p1l, p2h, p2l, s,
+        )
+    end
 end
 
 function _legendre!(                        # GRID TO SPECTRAL
@@ -171,13 +328,11 @@ function _legendre!(                        # GRID TO SPECTRAL
         scratch_memory::ColumnScratchMemory,    # scratch memory (not used here, but for CPU _legendre!)
         S::SpectralTransform{NF, <:Architectures.GPU},        # precomputed transform
     ) where {NF}
-    S.legendre isa RecomputedLegendre && throw(ArgumentError(
-        "recompute_legendre = true is not yet supported on GPU (the recomputed GPU kernels are " *
-            "step 3 of docs/dev/2026-09/recompute-legendre-polynomials.md); use recompute_legendre = false."
-    ))
-    legendre_polynomials = S.legendre.polynomials   # precomputed Legendre polynomials
+    legendre = S.legendre                   # precomputed or recomputed Legendre polynomials
     (; lm_indices, jm_indices) = S          # coefficient indices precomputed for threads
     (; solid_angles, lon_offsets) = S
+    (; lmax) = S.spectrum                   # 1-based max degree l
+    (; nlat_half) = S.grid
 
     nlayers = size(specs, 2)                # get number of layers of specs for fewer layers than precomputed in S
 
@@ -190,19 +345,67 @@ function _legendre!(                        # GRID TO SPECTRAL
     @boundscheck nlayers <= S.nlayers || throw(DimensionMismatch(S, specs))
 
 
-    launch!(
-        S.architecture,
-        ArrayWorkOrder,
-        (size(specs.data, 1), nlayers),
-        forward_legendre_kernel!,
-        specs.data,
-        legendre_polynomials.data,
-        f_north,
-        f_south,
-        lon_offsets,
-        solid_angles,
-        lm_indices,
-        jm_indices
-    )
+    if legendre isa RecomputedLegendre
+        # The forward transform is parallelised over its output coefficients, summing over rings,
+        # which runs orthogonally to the recursion (down a column at fixed order) — so unlike the
+        # inverse it cannot recompute in registers. Instead recompute into a `tile` buffer, one
+        # contiguous block of orders m at a time. A block of orders is a contiguous range of lm in
+        # the lower-triangular layout, so every coefficient belongs to exactly one tile and is
+        # written exactly once: no accumulation across tiles and the result does not depend on the
+        # tile size. The recompute cost is per transform call, not per layer, so it amortises over
+        # nlayers. See `tile_order_blocks` for how the blocks are sized.
+        (; tile, tile_orders) = legendre
+        for block in tile_orders
+            m_first, m_last = first(block), last(block)
+            lm_base = first(LowerTriangularArrays.get_lm_range(m_first, lmax - 1)) - 1
+            n_lm = last(LowerTriangularArrays.get_lm_range(m_last, lmax - 1)) - lm_base
+
+            launch!(
+                S.architecture,
+                ArrayWorkOrder,
+                (nlat_half, length(block)),
+                recompute_legendre_tile_kernel!,
+                tile,
+                legendre.αhi, legendre.αlo, legendre.βhi, legendre.βlo,
+                legendre.sectoral_hi, legendre.sectoral_lo, legendre.sectoral_scale,
+                legendre.xhi, legendre.xlo,
+                lmax,
+                m_first,
+                lm_base
+            )
+
+            launch!(
+                S.architecture,
+                ArrayWorkOrder,
+                (n_lm, nlayers),
+                forward_legendre_kernel!,
+                specs.data,
+                tile,
+                f_north,
+                f_south,
+                lon_offsets,
+                solid_angles,
+                lm_indices,
+                jm_indices,
+                lm_base
+            )
+        end
+    else
+        launch!(
+            S.architecture,
+            ArrayWorkOrder,
+            (size(specs.data, 1), nlayers),
+            forward_legendre_kernel!,
+            specs.data,
+            legendre.polynomials.data,      # precomputed Legendre polynomials, (lm, j)
+            f_north,
+            f_south,
+            lon_offsets,
+            solid_angles,
+            lm_indices,
+            jm_indices,
+            0                               # no offset: one launch covers every coefficient
+        )
+    end
     return nothing
 end

--- a/SpeedyTransforms/src/legendre_ka.jl
+++ b/SpeedyTransforms/src/legendre_ka.jl
@@ -81,7 +81,11 @@ function _legendre!(
     ) where {NF}
 
     (; nlat_half) = S.grid              # dimensions
-    (; legendre_polynomials_transposed) = S     # precomputed Legendre polynomials, (j, lm)
+    S.legendre isa RecomputedLegendre && throw(ArgumentError(
+        "recompute_legendre = true is not yet supported on GPU (the recomputed GPU kernels are " *
+            "step 3 of docs/dev/2026-09/recompute-legendre-polynomials.md); use recompute_legendre = false."
+    ))
+    legendre_polynomials_transposed = S.legendre.polynomials_transposed  # precomputed Legendre polynomials, (j, lm)
     (; jm_indices) = S                  # (j, m) loop indices precomputed for threads
     (; coslat⁻¹, lon_offsets) = S
     nlayers = size(specs, 2)            # get number of layers of specs for fewer layers than precomputed in S
@@ -167,7 +171,11 @@ function _legendre!(                        # GRID TO SPECTRAL
         scratch_memory::ColumnScratchMemory,    # scratch memory (not used here, but for CPU _legendre!)
         S::SpectralTransform{NF, <:Architectures.GPU},        # precomputed transform
     ) where {NF}
-    (; legendre_polynomials) = S            # precomputed Legendre polynomials
+    S.legendre isa RecomputedLegendre && throw(ArgumentError(
+        "recompute_legendre = true is not yet supported on GPU (the recomputed GPU kernels are " *
+            "step 3 of docs/dev/2026-09/recompute-legendre-polynomials.md); use recompute_legendre = false."
+    ))
+    legendre_polynomials = S.legendre.polynomials   # precomputed Legendre polynomials
     (; lm_indices, jm_indices) = S          # coefficient indices precomputed for threads
     (; solid_angles, lon_offsets) = S
 

--- a/SpeedyTransforms/src/legendre_polynomials.jl
+++ b/SpeedyTransforms/src/legendre_polynomials.jl
@@ -88,8 +88,12 @@ struct RecomputedLegendre{NF, VectorType, MatrixType, IntMatrixType, RingType} <
     sectoral_hi::MatrixType
     sectoral_lo::MatrixType
     sectoral_scale::IntMatrixType
-    "cos(colat), length nlat_half, in number format NF."
-    x::VectorType
+    "cos(colat) as a double-single pair, length nlat_half each, in number format NF. Split rather
+    than stored as a single NF value because it multiplies the running state at *every* recursion
+    step: rounding it to Float32 alone would inject a relative error of eps(Float32) that the
+    double-single arithmetic downstream cannot recover. `xlo` is exactly zero for NF == Float64."
+    xhi::VectorType
+    xlo::VectorType
     "CPU-only scratch: one recomputed ring (all columns) at a time, length nonzeros(spectrum) on
     CPU, length 0 on GPU."
     ring::RingType
@@ -114,10 +118,12 @@ function Architectures.on_architecture(arch::AbstractArchitecture, L::Recomputed
     sectoral_hi = on_architecture(arch, L.sectoral_hi)
     sectoral_lo = on_architecture(arch, L.sectoral_lo)
     sectoral_scale = on_architecture(arch, L.sectoral_scale)
-    x = on_architecture(arch, L.x)
+    xhi = on_architecture(arch, L.xhi)
+    xlo = on_architecture(arch, L.xlo)
     tile = on_architecture(arch, L.tile)
     return RecomputedLegendre{NF, typeof(αhi), typeof(sectoral_hi), typeof(sectoral_scale), typeof(L.ring)}(
-        L.lmax, αhi, αlo, βhi, βlo, sectoral_hi, sectoral_lo, sectoral_scale, x, L.ring, tile, L.tile_orders,
+        L.lmax, αhi, αlo, βhi, βlo, sectoral_hi, sectoral_lo, sectoral_scale,
+        xhi, xlo, L.ring, tile, L.tile_orders,
     )
 end
 
@@ -166,7 +172,11 @@ function RecomputedLegendre(
     # and only split into the NF double-single representation at the end, see ScaledLegendre.
     αhi, αlo, βhi, βlo = ScaledLegendre.recursion_coefficients(NF, lmax, mmax)
     sectoral_hi, sectoral_lo, sectoral_scale = ScaledLegendre.sectoral_modes(NF, cos_colat, mmax)
-    x = NF.(cos_colat)
+    xhi = zeros(NF, nlat_half)
+    xlo = zeros(NF, nlat_half)
+    for j in 1:nlat_half        # split through Float64, see the xhi/xlo field docs
+        xhi[j], xlo[j] = ScaledLegendre.split_two_float(NF, Float64(cos_colat[j]))
+    end
 
     on_gpu = architecture isa Architectures.GPU
 
@@ -188,7 +198,8 @@ function RecomputedLegendre(
     sectoral_hi_d = on_architecture(architecture, sectoral_hi)
     sectoral_lo_d = on_architecture(architecture, sectoral_lo)
     sectoral_scale_d = on_architecture(architecture, sectoral_scale)
-    x_d = on_architecture(architecture, x)
+    xhi_d = on_architecture(architecture, xhi)
+    xlo_d = on_architecture(architecture, xlo)
     tile_d = on_architecture(architecture, tile)
 
     return RecomputedLegendre{
@@ -197,7 +208,7 @@ function RecomputedLegendre(
         lmax,
         αhi_d, αlo_d, βhi_d, βlo_d,
         sectoral_hi_d, sectoral_lo_d, sectoral_scale_d,
-        x_d, ring, tile_d, tile_orders,
+        xhi_d, xlo_d, ring, tile_d, tile_orders,
     )
 end
 

--- a/SpeedyTransforms/src/legendre_polynomials.jl
+++ b/SpeedyTransforms/src/legendre_polynomials.jl
@@ -1,0 +1,213 @@
+"""Storage for the associated Legendre polynomials used by `SpectralTransform`, either
+precomputed once and stored (`PrecomputedLegendre`, today's behaviour) or recomputed on the fly
+from the `ScaledLegendre` recursion (`RecomputedLegendre`), trading `O(nonzeros(spectrum) *
+nlat_half)` of memory for `O(nonzeros(spectrum) + nlat_half * mmax)` at the cost of running the
+recursion inside the transform. See `docs/dev/2026-09/recompute-legendre-polynomials.md` for the
+full design. `SpectralTransform` holds one `AbstractLegendrePolynomials` in its `legendre` field,
+chosen at construction time by the `recompute_legendre` keyword; every reader downstream goes
+through `legendre_ring!` (CPU, `legendre.jl`) or reads the `PrecomputedLegendre` fields directly
+(GPU, `legendre_ka.jl` — the GPU recomputed kernels are a later step)."""
+abstract type AbstractLegendrePolynomials{NF} end
+
+"""$(TYPEDSIGNATURES)
+Legendre polynomials precomputed once for every spherical harmonic `(l, m)` and latitude ring `j`
+(northern hemisphere only, by symmetry), exactly as `SpectralTransform` has always done. Fields
+$(TYPEDFIELDS)"""
+struct PrecomputedLegendre{NF, LowerTriangularArrayType, VectorType} <: AbstractLegendrePolynomials{NF}
+    "Legendre polynomials λ_l^m(cos(colat_j)), stored as (lm, j)"
+    polynomials::LowerTriangularArrayType
+    "Transposed copy (j, lm), flattened so it needs no type parameter of its own; index it as
+    [(lm - 1) * nlat_half + j]. Only the GPU inverse transform reads this layout (the forward
+    transform reads `polynomials` directly); empty on CPU."
+    polynomials_transposed::VectorType
+end
+
+Adapt.@adapt_structure PrecomputedLegendre
+
+function Architectures.on_architecture(arch::AbstractArchitecture, L::PrecomputedLegendre{NF}) where {NF}
+    polynomials = on_architecture(arch, L.polynomials)
+    polynomials_transposed = on_architecture(arch, L.polynomials_transposed)
+    return PrecomputedLegendre{NF, typeof(polynomials), typeof(polynomials_transposed)}(
+        polynomials, polynomials_transposed,
+    )
+end
+
+"""$(TYPEDSIGNATURES)
+Precompute the Legendre polynomials for `spectrum`/`grid` in number format `NF`, moved onto
+`architecture`. This is exactly the code `SpectralTransform`'s constructor used to run inline
+(moved here verbatim so the precomputed path stays bit-for-bit identical): loop over latitude
+rings `j`, run `AssociatedLegendrePolynomials.jl`'s `Legendre.λlm!` once per ring, and — on GPU
+only — keep a second, transposed copy for the inverse transform kernel (see the struct docs)."""
+function PrecomputedLegendre(
+        ::Type{NF}, spectrum::AbstractSpectrum, grid::AbstractGrid,
+        cos_colat::AbstractVector, architecture::AbstractArchitecture,
+    ) where {NF}
+    (; lmax, mmax) = spectrum                             # 1-based max degree l, order m
+    (; nlat_half) = grid
+
+    polynomials = zeros(LowerTriangularArray{NF}, spectrum, nlat_half)
+    polynomials_j = zeros(NF, lmax, mmax)                 # temporary for one latitude
+    for j in 1:nlat_half                                  # only one hemisphere due to symmetry
+        Legendre.λlm!(polynomials_j, lmax - 1, mmax - 1, cos_colat[j])   # precompute l, m 0-based
+        polynomials[:, j] = LowerTriangularArray(polynomials_j)         # store
+    end
+
+    # TRANSPOSED COPY OF THE LEGENDRE POLYNOMIALS FOR THE GPU INVERSE TRANSFORM, see the struct
+    # field. Costs as much memory again as the polynomials themselves, so only built on GPU.
+    polynomials_transposed = architecture isa Architectures.GPU ?
+        vec(permutedims(polynomials.data)) :
+        on_architecture(architecture, zeros(NF, 0))
+
+    return PrecomputedLegendre{NF, typeof(polynomials), typeof(polynomials_transposed)}(
+        polynomials, polynomials_transposed,
+    )
+end
+
+"""$(TYPEDSIGNATURES)
+Legendre polynomials recomputed on the fly from the `ScaledLegendre` recursion instead of stored.
+Holds only `O(nonzeros(spectrum) + nlat_half * mmax)` of coefficients/starting values rather than
+the `O(nonzeros(spectrum) * nlat_half)` full table. Fields $(TYPEDFIELDS)
+
+`ring` and `tile` are mutually-exclusive scratch buffers for the two architectures: the CPU path
+(`legendre_ring!` in `legendre.jl`) recomputes one whole ring (all columns, all orders) at a time
+into `ring`, while the GPU forward-transform path (step 3) recomputes one *tile* — a contiguous
+block of orders `m`, see `tile_orders` — at a time into `tile`. Only one of the two is ever
+non-empty for a given architecture."""
+struct RecomputedLegendre{NF, VectorType, MatrixType, IntMatrixType, RingType} <: AbstractLegendrePolynomials{NF}
+    "1-based max degree l of the spectrum this was built for; needed to recover each order's
+    column length (lmax - m + 1) since it is not otherwise stored on this struct."
+    lmax::Int
+    "Recursion coefficients α, β (double-single hi/lo pairs), length nonzeros(spectrum) + 2,
+    indexed by the running lm index, see `ScaledLegendre.recursion_coefficients`."
+    αhi::VectorType
+    αlo::VectorType
+    βhi::VectorType
+    βlo::VectorType
+    "Sectoral (diagonal, l == m) starting values λ_m^m(cos_colat[j]) and their extended-exponent
+    scale, (nlat_half, mmax), see `ScaledLegendre.sectoral_modes`."
+    sectoral_hi::MatrixType
+    sectoral_lo::MatrixType
+    sectoral_scale::IntMatrixType
+    "cos(colat), length nlat_half, in number format NF."
+    x::VectorType
+    "CPU-only scratch: one recomputed ring (all columns) at a time, length nonzeros(spectrum) on
+    CPU, length 0 on GPU."
+    ring::RingType
+    "GPU-only scratch for the forward transform (step 3): one tile (block of orders) at a time,
+    (nnz_tile, nlat_half); length 0 on CPU."
+    tile::MatrixType
+    "Blocks of orders m that partition 1:mmax for the tiled GPU forward transform, host side
+    (plain Vector, never moved to the device); empty on CPU. Each block is a contiguous range of
+    orders and therefore also a contiguous range of the running lm index (columns are stored
+    order-by-order in the lower-triangular layout), so every coefficient lm belongs to exactly one
+    block and the tiled forward transform writes each coefficient exactly once."
+    tile_orders::Vector{UnitRange{Int}}
+end
+
+Adapt.@adapt_structure RecomputedLegendre
+
+function Architectures.on_architecture(arch::AbstractArchitecture, L::RecomputedLegendre{NF}) where {NF}
+    αhi = on_architecture(arch, L.αhi)
+    αlo = on_architecture(arch, L.αlo)
+    βhi = on_architecture(arch, L.βhi)
+    βlo = on_architecture(arch, L.βlo)
+    sectoral_hi = on_architecture(arch, L.sectoral_hi)
+    sectoral_lo = on_architecture(arch, L.sectoral_lo)
+    sectoral_scale = on_architecture(arch, L.sectoral_scale)
+    x = on_architecture(arch, L.x)
+    tile = on_architecture(arch, L.tile)
+    return RecomputedLegendre{NF, typeof(αhi), typeof(sectoral_hi), typeof(sectoral_scale), typeof(L.ring)}(
+        L.lmax, αhi, αlo, βhi, βlo, sectoral_hi, sectoral_lo, sectoral_scale, x, L.ring, tile, L.tile_orders,
+    )
+end
+
+"""$(TYPEDSIGNATURES)
+Partition the orders `1:mmax` of a spectrum with `lmax` degrees into consecutive blocks ("tiles")
+for the GPU forward transform, such that each block's total column count (summed `lmax - m + 1`
+over the orders `m` in the block) times `nlat_half * sizeof(NF)` bytes stays under `tile_budget`,
+with at least one order per block (so a single very wide order is never split). Blocks are
+contiguous ranges of `m`, and therefore also contiguous ranges of the running `lm` index (see
+`RecomputedLegendre`'s `tile_orders` field docs) — that is what lets the tiled forward transform
+write every coefficient exactly once, with no accumulation across tiles."""
+function tile_order_blocks(lmax::Integer, mmax::Integer, nlat_half::Integer, ::Type{NF}, tile_budget::Integer) where {NF}
+    max_cols = max(1, tile_budget ÷ (nlat_half * sizeof(NF)))   # max total lm-rows per tile
+    blocks = UnitRange{Int}[]
+    m_start = 1
+    cols = 0
+    for m in 1:mmax
+        column_length = lmax - m + 1
+        if cols > 0 && cols + column_length > max_cols
+            push!(blocks, m_start:(m - 1))
+            m_start = m
+            cols = 0
+        end
+        cols += column_length
+    end
+    push!(blocks, m_start:mmax)
+    return blocks
+end
+
+"""$(TYPEDSIGNATURES)
+Build a `RecomputedLegendre` for `spectrum`/`grid` in number format `NF`, moved onto
+`architecture`. The recursion coefficients and sectoral starting values are always built on the
+CPU (in `Float64`, only split into the `NF` double-single representation at the end, see
+`ScaledLegendre`) and then transferred with `on_architecture`. `tile_budget` (bytes, default 32
+MB) sizes the GPU forward-transform scratch `tile`, see `tile_order_blocks`; unused on CPU."""
+function RecomputedLegendre(
+        ::Type{NF}, spectrum::AbstractSpectrum, grid::AbstractGrid,
+        cos_colat::AbstractVector, architecture::AbstractArchitecture;
+        tile_budget::Integer = 32_000_000,
+    ) where {NF}
+    (; lmax, mmax) = spectrum                              # 1-based max degree l, order m
+    (; nlat_half) = grid
+    n = LowerTriangularArrays.nonzeros(spectrum)
+
+    # recursion coefficients and sectoral starting values, always computed in Float64 on the CPU
+    # and only split into the NF double-single representation at the end, see ScaledLegendre.
+    αhi, αlo, βhi, βlo = ScaledLegendre.recursion_coefficients(NF, lmax, mmax)
+    sectoral_hi, sectoral_lo, sectoral_scale = ScaledLegendre.sectoral_modes(NF, cos_colat, mmax)
+    x = NF.(cos_colat)
+
+    on_gpu = architecture isa Architectures.GPU
+
+    # `ring` (CPU) and `tile` (GPU) are mutually exclusive scratch buffers, see the struct docs.
+    ring = zeros(NF, on_gpu ? 0 : n)
+    if on_gpu
+        tile_orders = tile_order_blocks(lmax, mmax, nlat_half, NF, tile_budget)
+        max_block_columns = maximum(sum(lmax - m + 1 for m in block) for block in tile_orders)
+        tile = zeros(NF, max_block_columns, nlat_half)
+    else
+        tile_orders = UnitRange{Int}[]
+        tile = zeros(NF, 0, 0)
+    end
+
+    αhi_d = on_architecture(architecture, αhi)
+    αlo_d = on_architecture(architecture, αlo)
+    βhi_d = on_architecture(architecture, βhi)
+    βlo_d = on_architecture(architecture, βlo)
+    sectoral_hi_d = on_architecture(architecture, sectoral_hi)
+    sectoral_lo_d = on_architecture(architecture, sectoral_lo)
+    sectoral_scale_d = on_architecture(architecture, sectoral_scale)
+    x_d = on_architecture(architecture, x)
+    tile_d = on_architecture(architecture, tile)
+
+    return RecomputedLegendre{
+        NF, typeof(αhi_d), typeof(sectoral_hi_d), typeof(sectoral_scale_d), typeof(ring),
+    }(
+        lmax,
+        αhi_d, αlo_d, βhi_d, βlo_d,
+        sectoral_hi_d, sectoral_lo_d, sectoral_scale_d,
+        x_d, ring, tile_d, tile_orders,
+    )
+end
+
+"""$(TYPEDSIGNATURES)
+`Base.summarysize`-based memory footprint of an `AbstractLegendrePolynomials`, in bytes, summing
+every array field (the plain-`Int`/`Vector{UnitRange{Int}}` bookkeeping fields are negligible next
+to the coefficient/polynomial arrays and are included via `summarysize` for simplicity)."""
+legendre_memory_size(L::AbstractLegendrePolynomials) = Base.summarysize(L)
+
+"""$(TYPEDSIGNATURES)
+Short label for the mode an `AbstractLegendrePolynomials` was built in, used by `show`."""
+legendre_mode(::PrecomputedLegendre) = "precomputed"
+legendre_mode(::RecomputedLegendre) = "recomputed"

--- a/SpeedyTransforms/src/scaled_legendre.jl
+++ b/SpeedyTransforms/src/scaled_legendre.jl
@@ -30,8 +30,8 @@ using DocStringExtensions
 export coeff_μ, coeff_α, coeff_β, coeff_ν,
     two_prod, two_sum, quick_two_sum, df_mul, df_add, df_mul_f,
     scale_shift, rescale_shift,
-    recursion_coefficients, sectoral_modes,
-    legendre_column!, legendre_recursion_step
+    recursion_coefficients, sectoral_modes, split_two_float,
+    legendre_column!, legendre_recursion_step, legendre_advance, legendre_value
 
 # ============================================================================================
 # RECURSION COEFFICIENTS (spherical-harmonic normalisation), 0-based degree l and order m.
@@ -328,80 +328,119 @@ doc), where the surrounding loop becomes a `while`/unrolled loop over threads in
 end
 
 """$(TYPEDSIGNATURES)
-Reference/CPU implementation of one Legendre column recursion (fixed order `m`, running over
-degree `l`), writing the *true* (unscaled) polynomial values into `out[1:ncolumn]`. Dispatches its
-arithmetic on `eltype(out)`: double-single (`Float32` hi/lo pairs, via `legendre_recursion_step`)
-for `Float32` output, plain `Float64` arithmetic for `Float64` output — carrying the coefficients
-and the running state in `Float32` alone is what produces the ~1e-2 errors documented in the
-design doc, so this is not an optional refinement.
+The true (unscaled) value of a running recursion state held as the pair `(ph, pl)`. Trivial, but
+named so that CPU loops and GPU kernels read the state the same way regardless of whether the pair
+is a genuine double-single split (`Float32`) or a value plus an always-zero low part (`Float64`)."""
+@inline legendre_value(ph::NF, pl::NF) where {NF} = ph + pl
 
-Arguments: `x` the evaluation point `cos(colat)` (as `Float64`, split internally); `αhi, αlo, βhi,
-βlo` the coefficient tables from `recursion_coefficients`; `lm_offset` the running index just
-before this column's first entry (so degree `l = m` is written to `out[1]`, and coefficient lookup
-for step `q` is `lm_offset + q + 1`, i.e. the coefficient belonging to the *next* value produced);
-`ncolumn` the number of degrees in this column (`lmax - m + 1`); `sectoral_hi, sectoral_lo, scale`
-the starting `λ_m^m` double-single pair and its extended-exponent scale from `sectoral_modes`.
+"""$(TYPEDSIGNATURES)
+Advance the scaled column recursion by one degree `l`, in `Float32` double-single arithmetic.
+Takes the recursion coefficients at this step as double-single pairs `(αh, αl)`, `(βh, βl)`, the
+evaluation point `(xh, xl)`, the running state `(p1h, p1l)` = `λ_{l-1}^m`, `(p2h, p2l)` =
+`λ_{l-2}^m` and the extended-exponent scale `s`; returns the shifted-along state
+`(p1h, p1l, p2h, p2l, s)` with the new `λ_l^m` in `p1` and the rescaling of `scale_shift` applied
+if the mantissa has grown back past `1` while `s > 0`.
+
+This is the single place the recursion's arithmetic is written down: `legendre_column!` below and
+the GPU kernels in `legendre_ka.jl` both step through a column with it, so the recomputed CPU and
+GPU transforms produce bit-identical polynomials. `@inline`, branch-free apart from the rescale
+test, and allocation-free, so it inlines into kernel registers."""
+@inline function legendre_advance(
+        αh::Float32, αl::Float32, βh::Float32, βl::Float32,
+        xh::Float32, xl::Float32,
+        p1h::Float32, p1l::Float32, p2h::Float32, p2l::Float32, s::Integer,
+    )
+    ph, pl = legendre_recursion_step(αh, αl, βh, βl, xh, xl, p1h, p1l, p2h, p2l)
+    p2h, p2l = p1h, p1l
+    p1h, p1l = ph, pl
+    if s > 0 && abs(p1h) > 1.0f0                       # rescale: exact, both running values and s
+        SMALL = rescale_shift(Float32)
+        p1h *= SMALL
+        p1l *= SMALL
+        p2h *= SMALL
+        p2l *= SMALL
+        s -= oneunit(s)
+    end
+    return p1h, p1l, p2h, p2l, s
+end
+
+"""$(TYPEDSIGNATURES)
+Advance the scaled column recursion by one degree `l` in plain `Float64`. Same interface as the
+`Float32` double-single method above so callers stay number-format agnostic; the low parts are
+exactly zero throughout (`split_two_float` produces `lo == 0` for `Float64`) and are carried only
+to keep the signature uniform. `Float64` needs no double-single arithmetic: the whole point of that
+machinery is to recover `Float64`-like accuracy from `Float32` hardware."""
+@inline function legendre_advance(
+        αh::Float64, αl::Float64, βh::Float64, βl::Float64,
+        xh::Float64, xl::Float64,
+        p1h::Float64, p1l::Float64, p2h::Float64, p2l::Float64, s::Integer,
+    )
+    p = (αh + αl) * (xh + xl) * p1h - (βh + βl) * p2h
+    p2h = p1h
+    p1h = p
+    if s > 0 && abs(p1h) > 1.0
+        SMALL = rescale_shift(Float64)
+        p1h *= SMALL
+        p2h *= SMALL
+        s -= oneunit(s)
+    end
+    return p1h, zero(Float64), p2h, zero(Float64), s
+end
+
+"""$(TYPEDSIGNATURES)
+Run one Legendre column recursion (fixed order `m`, running over degree `l`), writing the *true*
+(unscaled) polynomial values into `out[1:ncolumn]`. Used by the CPU transform (`legendre_ring!` in
+`legendre.jl`) and as the reference the GPU kernels are checked against; the arithmetic itself
+lives in `legendre_advance`, so all three agree by construction.
+
+Arguments: `(xh, xl)` the evaluation point `cos(colat)` as a double-single pair (the `x::Real`
+method below splits a scalar for you); `αhi, αlo, βhi, βlo` the coefficient tables from
+`recursion_coefficients`; `lm_offset` the running index just before this column's first entry (so
+degree `l = m` is written to `out[1]`, and the coefficient lookup at step `q` is `lm_offset + q +
+1`, i.e. the coefficient belonging to the *next* value produced — which is why
+`recursion_coefficients` pads its tables); `ncolumn` the number of degrees in this column
+(`lmax - m + 1`); `sectoral_hi, sectoral_lo, scale` the starting `λ_m^m` double-single pair and its
+extended-exponent scale from `sectoral_modes`.
 
 Writes zero wherever `scale` has not yet reached `0`: per the `scale_shift` invariant, that means
-the true value is below `Float32` epsilon relative to the `O(1)` values that appear later in the
-same column, so it is indistinguishable from zero at this working precision anyway."""
+the true value is below `eps(NF)` relative to the `O(1)` values that appear later in the same
+column, so it is indistinguishable from zero at this working precision anyway."""
 function legendre_column!(
-        out::AbstractVector{Float32}, x::Real,
-        αhi::AbstractVector{Float32}, αlo::AbstractVector{Float32},
-        βhi::AbstractVector{Float32}, βlo::AbstractVector{Float32},
+        out::AbstractVector{NF}, xh::NF, xl::NF,
+        αhi::AbstractVector{NF}, αlo::AbstractVector{NF},
+        βhi::AbstractVector{NF}, βlo::AbstractVector{NF},
         lm_offset::Integer, ncolumn::Integer,
-        sectoral_hi::Float32, sectoral_lo::Float32, scale::Integer,
-    )
-    x64 = Float64(x)
-    xh = Float32(x64)
-    xl = Float32(x64 - Float64(xh))
+        sectoral_hi::NF, sectoral_lo::NF, scale::Integer,
+    ) where {NF}
     p1h, p1l = sectoral_hi, sectoral_lo               # λ_{l-1}^m, starting at the sectoral mode
-    p2h, p2l = 0.0f0, 0.0f0                            # λ_{l-2}^m ≡ 0 above the sectoral mode
-    s = Int(scale)
-    SMALL = rescale_shift(Float32)
+    p2h, p2l = zero(NF), zero(NF)                      # λ_{l-2}^m ≡ 0 above the sectoral mode
+    s = Int32(scale)
     @inbounds for q in 1:ncolumn
-        out[q] = s == 0 ? p1h + p1l : 0.0f0
+        out[q] = s == 0 ? legendre_value(p1h, p1l) : zero(NF)
         i = lm_offset + q + 1
-        ph, pl = legendre_recursion_step(αhi[i], αlo[i], βhi[i], βlo[i], xh, xl, p1h, p1l, p2h, p2l)
-        p2h, p2l = p1h, p1l
-        p1h, p1l = ph, pl
-        if s > 0 && abs(p1h) > 1.0f0                   # rescale: exact, both running values and s
-            p1h *= SMALL
-            p1l *= SMALL
-            p2h *= SMALL
-            p2l *= SMALL
-            s -= 1
-        end
+        p1h, p1l, p2h, p2l, s = legendre_advance(
+            αhi[i], αlo[i], βhi[i], βlo[i], xh, xl, p1h, p1l, p2h, p2l, s,
+        )
     end
     return out
 end
 
+"""$(TYPEDSIGNATURES)
+`legendre_column!` for a single (not yet split) evaluation point `x`. Splits `x` into an `NF`
+double-single pair through `Float64` first: `cos(colat)` rounded to `Float32` alone carries a
+relative error of `eps(Float32)` into every value of the column, which the double-single recursion
+would otherwise have no way to recover from."""
 function legendre_column!(
-        out::AbstractVector{Float64}, x::Real,
-        αhi::AbstractVector{Float64}, αlo::AbstractVector{Float64},
-        βhi::AbstractVector{Float64}, βlo::AbstractVector{Float64},
+        out::AbstractVector{NF}, x::Real,
+        αhi::AbstractVector{NF}, αlo::AbstractVector{NF},
+        βhi::AbstractVector{NF}, βlo::AbstractVector{NF},
         lm_offset::Integer, ncolumn::Integer,
-        sectoral_hi::Float64, sectoral_lo::Float64, scale::Integer,
+        sectoral_hi::NF, sectoral_lo::NF, scale::Integer,
+    ) where {NF}
+    xh, xl = split_two_float(NF, Float64(x))
+    return legendre_column!(
+        out, xh, xl, αhi, αlo, βhi, βlo, lm_offset, ncolumn, sectoral_hi, sectoral_lo, scale,
     )
-    x64 = Float64(x)
-    p1 = sectoral_hi + sectoral_lo                     # lo is exactly 0 for Float64, kept for a
-    p2 = 0.0                                            # uniform interface with the Float32 method
-    s = Int(scale)
-    SMALL = rescale_shift(Float64)
-    @inbounds for q in 1:ncolumn
-        out[q] = s == 0 ? p1 : 0.0
-        i = lm_offset + q + 1
-        a = αhi[i] + αlo[i]
-        b = βhi[i] + βlo[i]
-        p = a * x64 * p1 - b * p2
-        p2, p1 = p1, p
-        if s > 0 && abs(p1) > 1.0
-            p1 *= SMALL
-            p2 *= SMALL
-            s -= 1
-        end
-    end
-    return out
 end
 
 end # module

--- a/SpeedyTransforms/src/scaled_legendre.jl
+++ b/SpeedyTransforms/src/scaled_legendre.jl
@@ -1,0 +1,407 @@
+"""Self-contained building blocks for recomputing associated Legendre polynomials on the fly
+instead of precomputing and storing them.
+
+The precomputed table `legendre_polynomials[lm, j]` used by `SpectralTransform` has
+`O(nonzeros(spectrum) * nlat_half) = O(T^3)` entries, so its memory grows with the cube of the
+truncation `T` while every other array in the transform grows with the square. Recomputing the
+polynomials inside the transform kernels replaces that table with `O(T^2)` of recursion
+coefficients, at the cost of running the recursion itself in the number format of the transform
+(`Float32` on GPU), which is numerically delicate. This module provides exactly the arithmetic
+needed to do that safely: recursion coefficients in the spherical-harmonic normalisation,
+double-single ("two-float") arithmetic to recover close to `Float64` accuracy from `Float32`
+storage, and an extended-exponent scaling scheme so the recursion does not underflow near the
+poles.
+
+The coefficient forms (the "well-conditioned" `α`, `β`, `μ` below) are Justin Willmert's, from his
+Legendre.jl / AssociatedLegendrePolynomials.jl blog series on numerically stable recursions for
+associated Legendre polynomials (linked from `docs/src/spectral_transform.md`), and are ported
+from `AssociatedLegendrePolynomials.jl`'s `src/norm_sphere.jl`
+(https://github.com/jmert/AssociatedLegendrePolynomials.jl).
+
+This module is deliberately self-contained: no GPU imports and no dependency on RingGrids or
+LowerTriangularArrays for the core math, so it can be reasoned about and tested on its own. See
+`docs/dev/2026-09/recompute-legendre-polynomials.md` for the full design and the numerical
+prototype that validated this approach.
+"""
+module ScaledLegendre
+
+using DocStringExtensions
+
+export coeff_μ, coeff_α, coeff_β, coeff_ν,
+    two_prod, two_sum, quick_two_sum, df_mul, df_add, df_mul_f,
+    scale_shift, rescale_shift,
+    recursion_coefficients, sectoral_modes,
+    legendre_column!, legendre_recursion_step
+
+# ============================================================================================
+# RECURSION COEFFICIENTS (spherical-harmonic normalisation), 0-based degree l and order m.
+# Ported from AssociatedLegendrePolynomials.jl's src/norm_sphere.jl (Justin Willmert), which
+# derives these "well-conditioned" forms in the accompanying Legendre.jl blog series to avoid
+# the catastrophic cancellation of the textbook formulas when l and m are both large. Always
+# evaluated in Float64, even when the recursion itself later runs in Float32: rounding these to
+# Float32 before use costs as much accuracy as running the whole recursion in Float32, since the
+# coefficients multiply an O(1) polynomial value every step (see the design doc's accuracy table).
+# ============================================================================================
+
+"""$(TYPEDSIGNATURES)
+Coefficient of the sectoral (diagonal, l == m) recursion
+`λ_m^m = -μ_m sin(θ) λ_{m-1}^{m-1}`, 0-based `l` denoting the *target* order `m` of that step.
+Written as `1 + 1/(2l + sqrt(2l(2l+1)))` rather than the textbook `sqrt((2l+1)/(2l))` so that no
+cancellation occurs when the two terms under the square root are added; both forms agree to
+machine precision but this one is stable to evaluate directly in `Float32` as well as `Float64`."""
+coeff_μ(::Type{T}, l::Integer) where {T} = (xT = convert(T, 2l); one(T) + inv(xT + sqrt(muladd(xT, xT, xT))))
+
+"""$(TYPEDSIGNATURES)
+Coefficient of `x λ_{l-1}^m` in the two-term recursion `λ_l^m = α_l^m x λ_{l-1}^m - β_l^m λ_{l-2}^m`
+(0-based degree `l`, order `m`). Willmert's well-conditioned form,
+`sqrt[(2l+1)(4(l-1)^2-1) / ((2l-3)(l^2-m^2))]`, factored to avoid overflow/cancellation for large
+`l`. Satisfies `coeff_α(l, m) == coeff_ν(l)` exactly for `l == m + 1` (the one-term sectoral-to-
+first-off-diagonal step), which is what lets a single branch-free recursion cover a whole column
+with `λ_{m-1}^m ≡ 0`, see `legendre_column!`."""
+function coeff_α(::Type{T}, l::Integer, m::Integer) where {T}
+    lT, mT = convert(T, l), convert(T, m)
+    fac1 = (2lT + 1) / ((2lT - 3) * (lT^2 - mT^2))
+    fac2 = 4 * (lT - 1)^2 - 1
+    return sqrt(fac1 * fac2)
+end
+
+"""$(TYPEDSIGNATURES)
+Coefficient of `λ_{l-2}^m` in the two-term recursion `λ_l^m = α_l^m x λ_{l-1}^m - β_l^m λ_{l-2}^m`
+(0-based degree `l`, order `m`). Willmert's well-conditioned form,
+`sqrt[(2l+1)((l-1)^2-m^2) / ((2l-3)(l^2-m^2))]`. Satisfies `coeff_β(l, m) == 0` exactly for
+`l == m + 1`, so the two-term recursion degenerates to the correct one-term sectoral-to-first-off-
+diagonal step without a branch. Also satisfies `coeff_β(l, m) ≈ coeff_α(l, m) / coeff_α(l - 1, m)`
+for `l > m + 1` (verified numerically in the tests); that identity is not used here but is noted
+in the design doc as a possible way to drop `β` from the stored coefficients in the future."""
+function coeff_β(::Type{T}, l::Integer, m::Integer) where {T}
+    lT, mT = convert(T, l), convert(T, m)
+    fac1 = (2lT + 1) / ((2lT - 3) * (lT^2 - mT^2))
+    fac2 = (lT - 1)^2 - mT^2
+    return sqrt(fac1 * fac2)
+end
+
+"""$(TYPEDSIGNATURES)
+Coefficient of the one-term recursion `λ_{m+1}^m = ν_{m+1} x λ_m^m` from the sectoral mode to the
+first off-diagonal, 0-based degree `l`. Equal to `coeff_α(l, l - 1)`; provided separately because
+that identity is exactly what makes the general two-term recursion below valid at the top of every
+column, and it is cheaper to state directly than to evaluate `coeff_α` at the boundary."""
+coeff_ν(::Type{T}, l::Integer) where {T} = sqrt(convert(T, 2l + 1))
+
+# ============================================================================================
+# LOWER-TRIANGULAR INDEXING
+# Local copy of LowerTriangularArrays.lm2i's convention (1-based l, m; running index increases
+# down a column first) so this module has no dependency on LowerTriangularArrays. Must be kept
+# in sync with that definition by construction/tests, not by sharing code, since the whole point
+# of this module is to be usable without pulling in the rest of the package.
+# ============================================================================================
+
+"""$(TYPEDSIGNATURES)
+Running index into the lower-triangular storage layout for 1-based degree `l`, order `m`, and
+number of degrees `lmax`. Matches `LowerTriangularArrays.lm2i`'s convention exactly (same formula,
+kept as a local copy so this module stays free of a LowerTriangularArrays dependency)."""
+@inline lm2i(l::Integer, m::Integer, lmax::Integer) = l + (m - 1) * lmax - m * (m - 1) ÷ 2
+
+"""$(TYPEDSIGNATURES)
+Number of nonzero (on-or-below-diagonal) entries of a lower-triangular spectrum with `lmax`
+degrees and `mmax` orders. Matches `LowerTriangularArrays.nonzeros(lmax, mmax)`."""
+@inline count_nonzeros(lmax::Integer, mmax::Integer) = lmax * mmax - (mmax - 1) * mmax ÷ 2
+
+# ============================================================================================
+# DOUBLE-SINGLE ("TWO-FLOAT") ARITHMETIC ON Float32 PAIRS
+# Represents a real number as an unevaluated sum hi + lo of two Float32s (|lo| much-less-than
+# |hi|), giving close to Float64 accuracy (~48 bits of mantissa) from Float32 hardware. All
+# routines are @inline, FMA-based and branch-free (no allocation, no error paths), so they are
+# safe to call from GPU kernels. They take and return plain Float32 tuples/values rather than a
+# wrapping struct for the same reason: this is meant to inline into kernel registers, not to
+# allocate a boxed number. Standard algorithms (Dekker 1971 / Shewchuk 1997), specialised to use
+# `fma` instead of a Veltkamp split since target hardware has a fused multiply-add.
+# ============================================================================================
+
+"""$(TYPEDSIGNATURES)
+Error-free product `a*b = hi + lo` in `Float32`: `hi` is the correctly rounded product, `lo` is
+the exact rounding error, computed as `fma(a, b, -hi)` (exact because `hi` is the Float32 nearest
+to the true product, so `a*b - hi` is representable and the fused multiply-add computes it without
+an intermediate rounding step)."""
+@inline function two_prod(a::Float32, b::Float32)
+    p = a * b
+    return p, fma(a, b, -p)
+end
+
+"""$(TYPEDSIGNATURES)
+Error-free sum `a+b = hi + lo` in `Float32` for general `a`, `b` (unlike `quick_two_sum`, does not
+require `|a| >= |b|`). Knuth/Møller's two-sum algorithm: 6 flops, no comparisons needed to decide
+which operand is larger, so it is branch-free on top of being exact."""
+@inline function two_sum(a::Float32, b::Float32)
+    s = a + b
+    bb = s - a
+    return s, (a - (s - bb)) + (b - bb)
+end
+
+"""$(TYPEDSIGNATURES)
+Error-free sum `a+b = hi + lo` in `Float32`, assuming `|a| >= |b|` (Dekker's quick-two-sum, 3
+flops instead of `two_sum`'s 6). Used where that ordering is already guaranteed by construction,
+e.g. combining a double-single leading term with a small correction."""
+@inline function quick_two_sum(a::Float32, b::Float32)
+    s = a + b
+    return s, b - (s - a)
+end
+
+"""$(TYPEDSIGNATURES)
+Double-single times plain `Float32`: `(ah, al) * b`, returned as a new double-single `(hi, lo)`."""
+@inline function df_mul_f(ah::Float32, al::Float32, b::Float32)
+    p, e = two_prod(ah, b)
+    e = fma(al, b, e)
+    return quick_two_sum(p, e)
+end
+
+"""$(TYPEDSIGNATURES)
+Double-single times double-single: `(ah, al) * (bh, bl)`, returned as a new double-single
+`(hi, lo)`. Drops the `al*bl` cross term (it is below `Float32` eps relative to the other three
+products), which is the standard double-single multiplication truncation."""
+@inline function df_mul(ah::Float32, al::Float32, bh::Float32, bl::Float32)
+    p, e = two_prod(ah, bh)
+    e = fma(ah, bl, e)
+    e = fma(al, bh, e)
+    return quick_two_sum(p, e)
+end
+
+"""$(TYPEDSIGNATURES)
+Double-single plus double-single: `(ah, al) + (bh, bl)`, returned as a new double-single
+`(hi, lo)`. The low-order correction `al + bl` is added as plain `Float32` (its own rounding error
+is below the precision the result can represent), then folded back in with a final
+`quick_two_sum`."""
+@inline function df_add(ah::Float32, al::Float32, bh::Float32, bl::Float32)
+    s, e = two_sum(ah, bh)
+    e += al + bl
+    return quick_two_sum(s, e)
+end
+
+# ============================================================================================
+# EXTENDED-EXPONENT SCALING
+# λ_m^m ~ sin(θ)^m underflows Float32 (and Float64) range near the poles at high m, long before
+# λ_l^m has decayed to a value that is actually negligible (it grows back to O(1) once
+# l ≳ m/sin(θ)). Representing the running recursion state as p * 2^(-scale_shift(NF)*s) with an
+# integer s tracked alongside it lets the recursion carry values through that underflow region
+# without ever flushing to zero, using only exact power-of-two rescalings (no transcendentals, no
+# rounding of the mantissa).
+# ============================================================================================
+
+"""$(TYPEDSIGNATURES)
+Exponent step, in bits, of one unit of the extended-exponent scale factor `s` in number format
+`NF`: the true value of a scaled running state is `p * 2^(-scale_shift(NF) * s)`, with the
+invariant `|p| <= 1` whenever `s > 0`. That invariant means anything still carrying `s > 0` has
+true magnitude below `2^-scale_shift(NF)`, so it is safe to treat as exactly zero for output
+purposes. Two constraints fix the value, and the shift has to sit between them:
+
+- it must be **large enough** that `2^-scale_shift(NF)` is below `eps(NF)` relative to the `O(1)`
+  values that appear later in the same column, so that flushing those values to zero loses
+  nothing `NF` could represent anyway. Hence at least `precision(NF)` bits.
+- it must be **small enough** that a running mantissa just under the rescale threshold of `1`
+  still has headroom above `floatmin(NF)` after one more step down in `s`, so that the mantissa
+  itself can never underflow between rescalings however many recursion steps pass before the next
+  `|p| > 1` trigger.
+
+`precision(NF) + 8` satisfies the first with margin and is capped at a third of the exponent range
+for the second. This gives 32 bits for `Float32` (2.3e-10 neglected, 94 bits of headroom above
+`2^-126`) and 61 for `Float64` (4.3e-19 neglected, far under `eps(Float64)`). Formats with a very
+narrow exponent range relative to their mantissa — `Float16` in particular — cannot satisfy both
+at once and are not supported by the recomputed transform."""
+scale_shift(::Type{NF}) where {NF <: AbstractFloat} =
+    min(precision(NF) + 8, -exponent(floatmin(NF)) ÷ 3)
+
+# spell the two supported formats out so the shift is a literal inside GPU kernels
+scale_shift(::Type{Float32}) = 32
+scale_shift(::Type{Float64}) = 61
+
+"""$(TYPEDSIGNATURES)
+The rescaling factor `2^(-scale_shift(NF))` in number format `NF`, i.e. what a running recursion
+state `p` is multiplied by (together with decrementing its scale `s`) whenever `|p|` grows back
+past `1` while `s > 0`. Exact in any binary floating-point format since it is a power of two."""
+rescale_shift(::Type{NF}) where {NF} = NF(ldexp(1.0, -scale_shift(NF)))
+
+# ============================================================================================
+# SPLITTING A Float64 COEFFICIENT INTO A NUMBER-FORMAT hi/lo PAIR
+# ============================================================================================
+
+"""$(TYPEDSIGNATURES)
+Split a `Float64` value `v` into an `NF` double-single pair `(hi, lo)` with `hi = NF(v)` and
+`lo = NF(v - Float64(hi))` the exactly-representable remainder. For `NF == Float64` this makes
+`hi == v` exactly and `lo == 0`: the pair degenerates to a single value but the interface stays
+uniform across `NF`, so callers do not need to special-case `Float64`."""
+@inline function split_two_float(::Type{NF}, v::Float64) where {NF}
+    hi = NF(v)
+    lo = NF(v - Float64(hi))
+    return hi, lo
+end
+
+# ============================================================================================
+# HOST-SIDE BUILDERS
+# ============================================================================================
+
+"""$(TYPEDSIGNATURES)
+Build the `α`, `β` recursion coefficient tables for a lower-triangular spectrum with `lmax`
+degrees and `mmax` orders, split into number-format `NF` double-single pairs. Returns
+`(αhi, αlo, βhi, βlo)`, four `Vector{NF}` of length `count_nonzeros(lmax, mmax) + 2`: the running
+index `lm` (`LowerTriangularArrays.lm2i` convention, 1-based `l`, `m`) addresses them directly,
+and the `+ 2` zero-padding at the end lets a column recursion take one step past the end of the
+last column (`m == mmax`, `l == lmax`) without a bounds check, since the write of that
+one-past-the-end value is always discarded. Diagonal entries (`l == m`, the sectoral modes
+themselves) are left zero and are never read: the recursion starts from the precomputed sectoral
+value instead, see `sectoral_modes`. Coefficients are evaluated in `Float64` (`coeff_α`,
+`coeff_β`), so accuracy does not depend on `NF`; only the final split does."""
+function recursion_coefficients(::Type{NF}, lmax::Integer, mmax::Integer) where {NF}
+    n = count_nonzeros(lmax, mmax)
+    αhi, αlo = zeros(NF, n + 2), zeros(NF, n + 2)
+    βhi, βlo = zeros(NF, n + 2), zeros(NF, n + 2)
+    for m in 1:mmax, l in m:lmax
+        l == m && continue                              # diagonal: unused, keep zero
+        i = lm2i(l, m, lmax)
+        a = coeff_α(Float64, l - 1, m - 1)               # 0-based degree/order in the coefficient
+        b = coeff_β(Float64, l - 1, m - 1)               # formulas, 1-based in the lm2i index
+        αhi[i], αlo[i] = split_two_float(NF, a)
+        βhi[i], βlo[i] = split_two_float(NF, b)
+    end
+    return αhi, αlo, βhi, βlo
+end
+
+"""$(TYPEDSIGNATURES)
+Build the sectoral (diagonal, `l == m`) starting values `λ_m^m(cos_colat[j])` for every ring `j`
+and order `m`, with the extended-exponent scaling of `scale_shift(NF)` applied. Returns
+`(hi, lo, scale)`: `hi`, `lo` are `(nlat_half, mmax)` `Matrix{NF}` double-single pairs and `scale`
+is the matching `Matrix{Int16}` of scale factors `s` (`Int16` because even at T1023 the largest
+scale needed is of order a few hundred, far under the `Int16` range). All three are laid out with
+`j` (ring) as the fastest (first) dimension rather than `m` (order), even though the recursion
+below runs one ring at a time: on the GPU, neighbouring threads process neighbouring rings at the
+same order, so laying rings out contiguously in memory turns those reads into coalesced accesses
+instead of strided ones. The `μ` recursion that produces the sectoral values is run once per ring
+in `Float64` (so its own accuracy does not depend on `NF`) and only split into an `NF`
+double-single pair at the end."""
+function sectoral_modes(::Type{NF}, cos_colat::AbstractVector, mmax::Integer) where {NF}
+    nlat_half = length(cos_colat)
+    hi = zeros(NF, nlat_half, mmax)
+    lo = zeros(NF, nlat_half, mmax)
+    scale = zeros(Int16, nlat_half, mmax)
+    SMALL = ldexp(1.0, -scale_shift(NF))
+    BIG = ldexp(1.0, scale_shift(NF))
+    for j in 1:nlat_half
+        x = Float64(cos_colat[j])
+        y = sqrt(max(0.0, 1 - x^2))                       # sin(colat), clamped against roundoff
+        p = inv(sqrt(4 * Float64(π)))                      # λ_0^0
+        s = 0
+        hi[j, 1], lo[j, 1] = split_two_float(NF, p)
+        scale[j, 1] = 0
+        for m in 1:(mmax - 1)                              # 0-based target order m, μ_m: (m-1,m-1) -> (m,m)
+            p = -coeff_μ(Float64, m) * y * p
+            while p != 0 && abs(p) < SMALL
+                p *= BIG
+                s += 1
+            end
+            hi[j, m + 1], lo[j, m + 1] = split_two_float(NF, p)
+            scale[j, m + 1] = Int16(s)
+        end
+    end
+    return hi, lo, scale
+end
+
+# ============================================================================================
+# COLUMN RECURSION
+# ============================================================================================
+
+"""$(TYPEDSIGNATURES)
+One step of the double-single column recursion: given the recursion coefficient at this step as
+double-single pairs `(αh, αl)`, `(βh, βl)`, the evaluation point as a double-single pair
+`(xh, xl)`, and the running state `(p1h, p1l)` (the current value, `λ_{l-1}^m`) and
+`(p2h, p2l)` (the previous value, `λ_{l-2}^m`), returns the new value `λ_l^m = α x λ_{l-1}^m -
+β λ_{l-2}^m` as a double-single pair. `@inline`d and allocation-free so it inlines into registers;
+this is the piece meant to be reused verbatim inside the GPU recursion kernels (see the design
+doc), where the surrounding loop becomes a `while`/unrolled loop over threads instead of the plain
+`for` loop `legendre_column!` uses on the CPU."""
+@inline function legendre_recursion_step(
+        αh::Float32, αl::Float32, βh::Float32, βl::Float32,
+        xh::Float32, xl::Float32,
+        p1h::Float32, p1l::Float32, p2h::Float32, p2l::Float32,
+    )
+    ah, al = df_mul(αh, αl, xh, xl)          # α*x
+    th, tl = df_mul(ah, al, p1h, p1l)        # α*x*λ_{l-1}^m
+    uh, ul = df_mul(βh, βl, p2h, p2l)        # β*λ_{l-2}^m
+    return df_add(th, tl, -uh, -ul)
+end
+
+"""$(TYPEDSIGNATURES)
+Reference/CPU implementation of one Legendre column recursion (fixed order `m`, running over
+degree `l`), writing the *true* (unscaled) polynomial values into `out[1:ncolumn]`. Dispatches its
+arithmetic on `eltype(out)`: double-single (`Float32` hi/lo pairs, via `legendre_recursion_step`)
+for `Float32` output, plain `Float64` arithmetic for `Float64` output — carrying the coefficients
+and the running state in `Float32` alone is what produces the ~1e-2 errors documented in the
+design doc, so this is not an optional refinement.
+
+Arguments: `x` the evaluation point `cos(colat)` (as `Float64`, split internally); `αhi, αlo, βhi,
+βlo` the coefficient tables from `recursion_coefficients`; `lm_offset` the running index just
+before this column's first entry (so degree `l = m` is written to `out[1]`, and coefficient lookup
+for step `q` is `lm_offset + q + 1`, i.e. the coefficient belonging to the *next* value produced);
+`ncolumn` the number of degrees in this column (`lmax - m + 1`); `sectoral_hi, sectoral_lo, scale`
+the starting `λ_m^m` double-single pair and its extended-exponent scale from `sectoral_modes`.
+
+Writes zero wherever `scale` has not yet reached `0`: per the `scale_shift` invariant, that means
+the true value is below `Float32` epsilon relative to the `O(1)` values that appear later in the
+same column, so it is indistinguishable from zero at this working precision anyway."""
+function legendre_column!(
+        out::AbstractVector{Float32}, x::Real,
+        αhi::AbstractVector{Float32}, αlo::AbstractVector{Float32},
+        βhi::AbstractVector{Float32}, βlo::AbstractVector{Float32},
+        lm_offset::Integer, ncolumn::Integer,
+        sectoral_hi::Float32, sectoral_lo::Float32, scale::Integer,
+    )
+    x64 = Float64(x)
+    xh = Float32(x64)
+    xl = Float32(x64 - Float64(xh))
+    p1h, p1l = sectoral_hi, sectoral_lo               # λ_{l-1}^m, starting at the sectoral mode
+    p2h, p2l = 0.0f0, 0.0f0                            # λ_{l-2}^m ≡ 0 above the sectoral mode
+    s = Int(scale)
+    SMALL = rescale_shift(Float32)
+    @inbounds for q in 1:ncolumn
+        out[q] = s == 0 ? p1h + p1l : 0.0f0
+        i = lm_offset + q + 1
+        ph, pl = legendre_recursion_step(αhi[i], αlo[i], βhi[i], βlo[i], xh, xl, p1h, p1l, p2h, p2l)
+        p2h, p2l = p1h, p1l
+        p1h, p1l = ph, pl
+        if s > 0 && abs(p1h) > 1.0f0                   # rescale: exact, both running values and s
+            p1h *= SMALL
+            p1l *= SMALL
+            p2h *= SMALL
+            p2l *= SMALL
+            s -= 1
+        end
+    end
+    return out
+end
+
+function legendre_column!(
+        out::AbstractVector{Float64}, x::Real,
+        αhi::AbstractVector{Float64}, αlo::AbstractVector{Float64},
+        βhi::AbstractVector{Float64}, βlo::AbstractVector{Float64},
+        lm_offset::Integer, ncolumn::Integer,
+        sectoral_hi::Float64, sectoral_lo::Float64, scale::Integer,
+    )
+    x64 = Float64(x)
+    p1 = sectoral_hi + sectoral_lo                     # lo is exactly 0 for Float64, kept for a
+    p2 = 0.0                                            # uniform interface with the Float32 method
+    s = Int(scale)
+    SMALL = rescale_shift(Float64)
+    @inbounds for q in 1:ncolumn
+        out[q] = s == 0 ? p1 : 0.0
+        i = lm_offset + q + 1
+        a = αhi[i] + αlo[i]
+        b = βhi[i] + βlo[i]
+        p = a * x64 * p1 - b * p2
+        p2, p1 = p1, p
+        if s > 0 && abs(p1) > 1.0
+            p1 *= SMALL
+            p2 *= SMALL
+            s -= 1
+        end
+    end
+    return out
+end
+
+end # module

--- a/SpeedyTransforms/src/show.jl
+++ b/SpeedyTransforms/src/show.jl
@@ -19,10 +19,9 @@ function Base.show(io::IO, S::SpectralTransform{NF, AR, AT}) where {NF, AR, AT}
     Grid = nonparametric_type(grid)
 
     # add information about size of Legendre polynomials and scratch memory
-    # (including the transposed copy the GPU inverse transform reads, empty on CPU)
-    polysize_str = prettymemory(
-        Base.summarysize(S.legendre_polynomials) + sizeof(S.legendre_polynomials_transposed)
-    )
+    # (precomputed: includes the transposed copy the GPU inverse transform reads, empty on CPU;
+    # recomputed: the much smaller recursion coefficients/sectoral starting values, see legendre_polynomials.jl)
+    polysize_str = prettymemory(legendre_memory_size(S.legendre)) * " ($(legendre_mode(S.legendre)))"
     memorysize_str = prettymemory(
         sizeof(S.scratch_memory.north) +      # add all scratch_memories
             sizeof(S.scratch_memory.south) +

--- a/SpeedyTransforms/src/spectral_transform.jl
+++ b/SpeedyTransforms/src/spectral_transform.jl
@@ -17,7 +17,7 @@ struct SpectralTransform{
         VectorType,                 # <: ArrayType{NF, 1},
         ArrayTypeIntMatrix,         # <: ArrayType{Int32, 2}
         MatrixComplexType,          # <: ArrayType{Complex{NF}, 2},
-        LowerTriangularArrayType,   # <: LowerTriangularArray{NF, 2, ArrayType{NF}, ...},
+        LegendrePolynomialsType,    # <: AbstractLegendrePolynomials{NF}, precomputed or recomputed
         ScratchType,                # <: ScratchMemory{ArrayComplexType, VectorComplexType},
         GradientType,               # <: Gradients struct
         RFFTSerialType,             # <: Vector{<:AbstractFFTs.Plan}  (K=1, 1-D forward plans)
@@ -65,15 +65,13 @@ struct SpectralTransform{
     rfft_plans_batched::RFFTBatchedType  # grid → spectral (forward), K>1 per-ring 2-D plans, keyed by K
     brfft_plans_batched::BRFFTBatchedType # spectral → grid (inverse), K>1 per-ring 2-D plans, keyed by K
 
-    # LEGENDRE POLYNOMIALS, for all latitudes, precomputed
-    legendre_polynomials::LowerTriangularArrayType
-    # ... and transposed to (latitude ring, harmonic), flattened so that it needs no type
-    # parameter of its own; index it as [(lm - 1) * nlat_half + j].
-    # The GPU transforms read the polynomials along opposite axes -- the inverse has
-    # neighbouring threads on neighbouring rings, the forward on neighbouring harmonics -- and no
-    # single layout is coalesced for both, so the GPU keeps this second copy.
-    # Empty on CPU, which only uses the layout above.
-    legendre_polynomials_transposed::VectorType
+    # LEGENDRE POLYNOMIALS, for all latitudes, either precomputed and stored (`PrecomputedLegendre`,
+    # today's default) or recomputed on the fly from the ScaledLegendre recursion
+    # (`RecomputedLegendre`, `recompute_legendre = true`), see legendre_polynomials.jl. Every
+    # reader downstream goes through `legendre_ring!` (CPU, legendre.jl) or reads the
+    # `PrecomputedLegendre` fields directly (GPU, legendre_ka.jl -- the GPU recomputed kernels are
+    # a later step).
+    legendre::LegendrePolynomialsType
 
     # SCRATCH MEMORY FOR FOURIER NOT YET LEGENDRE TRANSFORMED AND VICE VERSA
     # state is undetermined, only read after writing to it
@@ -128,7 +126,15 @@ $(TYPEDSIGNATURES)
 Generator function for a SpectralTransform struct. With `NF` the number format,
 `Grid` the grid type `<:AbstractGrid` and spectral truncation `lmax, mmax` this function sets up
 necessary constants for the spetral transform. Also plans the Fourier transforms, retrieves the colatitudes,
-and preallocates the Legendre polynomials and quadrature weights."""
+and preallocates the Legendre polynomials and quadrature weights.
+
+`recompute_legendre = false` (the default) precomputes and stores the Legendre polynomials as
+today; `recompute_legendre = true` instead recomputes them on the fly from recursion coefficients
+and starting values that are `O(nonzeros(spectrum) + nlat_half * mmax)` rather than
+`O(nonzeros(spectrum) * nlat_half)`, trading memory for a recursion inside the transform (see
+`docs/dev/2026-09/recompute-legendre-polynomials.md`). On GPU the recomputed path currently only
+covers construction, not the transform kernels themselves (a later step) — using it there throws
+an `ArgumentError`."""
 function SpectralTransform(
         spectrum::AbstractSpectrum,                     # Spectral truncation
         grid::AbstractGrid;                             # grid used and resolution, e.g. FullGaussianGrid
@@ -137,6 +143,7 @@ function SpectralTransform(
         transform_batch::AbstractVector{<:Integer} = Int[1, nlayers],                   # list of batch sizes K to pre-plan FFTs for (independent of scratch size)
         LegendreShortcut::Type{<:AbstractLegendreShortcut} = LegendreShortcutLinear,    # shorten Legendre loop over order m
         gpu_graphs::Bool = default_gpu_graphs(spectrum.architecture),               # use GPU-graphs accelerated Fourier path (CUDA, AMDGPU); backend-dependent default
+        recompute_legendre::Bool = false,                                          # recompute Legendre polynomials on the fly instead of precomputing/storing them
     )
     # planned_K controls which Ks get pre-built FFT plans. K=1 is always planned (it is the
     # per-layer fallback used by `_fourier_serial!`).
@@ -177,19 +184,11 @@ function SpectralTransform(
     lon1s = [lons[rings[j].start] for j in 1:nlat_half]     # pick lons at first index for each ring
     lon_offsets = [cispi(m * lon1 / π) for m in 0:(mmax - 1), lon1 in lon1s]
 
-    # PRECOMPUTE LEGENDRE POLYNOMIALS
-    legendre_polynomials = zeros(LowerTriangularArray{NF}, spectrum, nlat_half)
-    legendre_polynomials_j = zeros(NF, lmax, mmax)          # temporary for one latitude
-    for j in 1:nlat_half                                    # only one hemisphere due to symmetry
-        Legendre.λlm!(legendre_polynomials_j, lmax - 1, mmax - 1, cos_colat[j])     # precompute l, m 0-based
-        legendre_polynomials[:, j] = LowerTriangularArray(legendre_polynomials_j)   # store
-    end
-
-    # TRANSPOSED COPY OF THE LEGENDRE POLYNOMIALS FOR THE GPU INVERSE TRANSFORM, see the struct
-    # field. Costs as much memory again as the polynomials themselves, so only built on GPU.
-    legendre_polynomials_transposed = architecture isa Architectures.GPU ?
-        vec(permutedims(legendre_polynomials.data)) :
-        on_architecture(architecture, zeros(NF, 0))
+    # LEGENDRE POLYNOMIALS, precomputed and stored or recomputed on the fly, see
+    # legendre_polynomials.jl. `false` (the default) reproduces today's behaviour bit-for-bit.
+    legendre = recompute_legendre ?
+        RecomputedLegendre(NF, spectrum, grid, cos_colat, architecture) :
+        PrecomputedLegendre(NF, spectrum, grid, cos_colat, architecture)
 
     # SCRATCH MEMORY FOR FOURIER NOT YET LEGENDRE TRANSFORMED AND VICE VERSA
     # CPU always chunks unplanned K down to the largest planned batch, so scratch only needs
@@ -287,7 +286,7 @@ function SpectralTransform(
         array_type(architecture, NF, 1),
         array_type(architecture, Int32, 2),
         array_type(architecture, Complex{NF}, 2),
-        typeof(legendre_polynomials),
+        typeof(legendre),
         typeof(scratch_memory),
         typeof(gradients),
         typeof(rfft_plan_serial),
@@ -304,8 +303,7 @@ function SpectralTransform(
         norm_sphere,
         rfft_plan_serial, brfft_plan_serial,
         rfft_plans_batched, brfft_plans_batched,
-        legendre_polynomials,
-        legendre_polynomials_transposed,
+        legendre,
         scratch_memory,
         jm_index_size, jm_indices, lm_indices,
         solid_angles,

--- a/SpeedyTransforms/test/recompute_legendre.jl
+++ b/SpeedyTransforms/test/recompute_legendre.jl
@@ -55,12 +55,11 @@ end
     @test mem_r < mem_p / 2   # measured ~4x smaller at T63, leave margin
 end
 
-@testset "recompute_legendre: RecomputedLegendre on GPU throws (step 3 not implemented)" begin
-    # PrecomputedLegendre stays the only GPU-supported mode until step 3; simulate a GPU
-    # architecture without a real backend by checking the dispatch guard directly through the
-    # type system: SpectralTransform{NF, <:Architectures.GPU} is what legendre_ka.jl dispatches
-    # on, and the guard throws before touching any GPU-only array, so this is safe to check with
-    # `isa` on the constructed struct without a working GPU backend.
+@testset "recompute_legendre: CPU RecomputedLegendre allocates the ring scratch, not the GPU tile" begin
+    # `ring` (CPU) and `tile` (GPU) are mutually exclusive scratch buffers, see the struct docs:
+    # the CPU path recomputes one whole ring at a time into `ring`, the GPU forward transform one
+    # tile of orders at a time into `tile`. Checked here on CPU, where only `ring` may be present;
+    # the GPU side needs a backend and lives in the GPU test suite.
     arch = SpeedyTransforms.Architectures.CPU()
     truncation = 15
     Grid = FullGaussianGrid
@@ -73,6 +72,10 @@ end
     @test length(Sr.legendre.ring) == LowerTriangularArrays.nonzeros(spectrum)
     @test isempty(Sr.legendre.tile)
     @test isempty(Sr.legendre.tile_orders)
+    # cos(colat) is kept as a double-single pair, see the xhi/xlo field docs: `xhi` rounds it to
+    # Float32 and `xlo` carries the remainder, so |xlo| stays below eps(Float32) * |xhi|
+    @test length(Sr.legendre.xhi) == length(Sr.legendre.xlo) == nlat_half
+    @test all(abs.(Sr.legendre.xlo) .<= eps(Float32) .* abs.(Sr.legendre.xhi))
 end
 
 @testset "recompute_legendre: tile_order_blocks partitions 1:mmax exactly once, contiguously" begin

--- a/SpeedyTransforms/test/recompute_legendre.jl
+++ b/SpeedyTransforms/test/recompute_legendre.jl
@@ -1,0 +1,94 @@
+# Tests for step 2 of the recompute-on-the-fly Legendre polynomials feature (see
+# docs/dev/2026-09/recompute-legendre-polynomials.md): `SpectralTransform`'s `recompute_legendre`
+# keyword, `PrecomputedLegendre`/`RecomputedLegendre`, and the CPU `legendre_ring!` path. GPU
+# kernels for the recomputed path are step 3 and not implemented here; on GPU
+# `recompute_legendre = true` must throw, tested below via a CPU-only fake using `S.legendre` (no
+# GPU/JLArrays dependency needed for that part since the check is architecture-agnostic on the
+# `RecomputedLegendre` type, only gated on `S isa SpectralTransform{NF, <:Architectures.GPU}`).
+
+# tolerances measured empirically (see PR discussion): a plain `Float32` recursion in the
+# transform gives ~1e-6 relative error against the `Float64`-precomputed reference (rounded to
+# Float32 on write), `Float64` recomputation is indistinguishable from precomputation (~1e-15).
+# Set just above the measured worst case so a real regression (e.g. losing the double-single
+# arithmetic, ~1e-2 per the design doc) trips these tests.
+const RECOMPUTE_RTOL = Dict(Float32 => 1.0e-5, Float64 => 1.0e-11)
+
+@testset "recompute_legendre: grid -> spectral -> grid agrees with precomputed" begin
+    for NF in (Float32, Float64)
+        for truncation in (15, 31)
+            for Grid in (FullGaussianGrid, OctahedralGaussianGrid)
+                arch = SpeedyTransforms.Architectures.CPU()
+                spectrum = Spectrum(truncation, truncation; architecture = arch)
+                nlat_half = SpeedyTransforms.get_nlat_half(truncation, SpeedyTransforms.default_dealiasing(Grid))
+                grid = Grid(nlat_half, arch)
+
+                Sp = SpectralTransform(spectrum, grid; NF, recompute_legendre = false)
+                Sr = SpectralTransform(spectrum, grid; NF, recompute_legendre = true)
+
+                field = rand(NF, grid, 2)
+                coeffs_p = transform(field, Sp)
+                coeffs_r = transform(field, Sr)
+                field_p = transform(coeffs_p, Sp)
+                field_r = transform(coeffs_r, Sr)
+
+                rtol = RECOMPUTE_RTOL[NF]
+                @test coeffs_r.data ≈ coeffs_p.data rtol = rtol
+                @test field_r.data ≈ field_p.data rtol = rtol
+            end
+        end
+    end
+end
+
+@testset "recompute_legendre: memory footprint much smaller than precomputed" begin
+    arch = SpeedyTransforms.Architectures.CPU()
+    truncation = 63
+    spectrum = Spectrum(truncation, truncation; architecture = arch)
+    Grid = FullGaussianGrid
+    nlat_half = SpeedyTransforms.get_nlat_half(truncation, SpeedyTransforms.default_dealiasing(Grid))
+    grid = Grid(nlat_half, arch)
+
+    Sp = SpectralTransform(spectrum, grid; NF = Float32, recompute_legendre = false)
+    Sr = SpectralTransform(spectrum, grid; NF = Float32, recompute_legendre = true)
+
+    mem_p = SpeedyTransforms.legendre_memory_size(Sp.legendre)
+    mem_r = SpeedyTransforms.legendre_memory_size(Sr.legendre)
+    @test mem_r < mem_p / 2   # measured ~4x smaller at T63, leave margin
+end
+
+@testset "recompute_legendre: RecomputedLegendre on GPU throws (step 3 not implemented)" begin
+    # PrecomputedLegendre stays the only GPU-supported mode until step 3; simulate a GPU
+    # architecture without a real backend by checking the dispatch guard directly through the
+    # type system: SpectralTransform{NF, <:Architectures.GPU} is what legendre_ka.jl dispatches
+    # on, and the guard throws before touching any GPU-only array, so this is safe to check with
+    # `isa` on the constructed struct without a working GPU backend.
+    arch = SpeedyTransforms.Architectures.CPU()
+    truncation = 15
+    Grid = FullGaussianGrid
+    spectrum = Spectrum(truncation, truncation; architecture = arch)
+    nlat_half = SpeedyTransforms.get_nlat_half(truncation, SpeedyTransforms.default_dealiasing(Grid))
+    grid = Grid(nlat_half, arch)
+    Sr = SpectralTransform(spectrum, grid; NF = Float32, recompute_legendre = true)
+    @test Sr.legendre isa SpeedyTransforms.RecomputedLegendre
+    @test Sr.legendre.ring isa Vector{Float32}
+    @test length(Sr.legendre.ring) == LowerTriangularArrays.nonzeros(spectrum)
+    @test isempty(Sr.legendre.tile)
+    @test isempty(Sr.legendre.tile_orders)
+end
+
+@testset "recompute_legendre: tile_order_blocks partitions 1:mmax exactly once, contiguously" begin
+    for (lmax, mmax, nlat_half) in ((16, 16, 8), (129, 128, 65), (64, 5, 20))
+        for NF in (Float32, Float64)
+            for tile_budget in (1000, 32_000_000)
+                blocks = SpeedyTransforms.tile_order_blocks(lmax, mmax, nlat_half, NF, tile_budget)
+                @test !isempty(blocks)
+                @test all(!isempty, blocks)                       # at least one order per block
+                covered = vcat(collect.(blocks)...)
+                @test covered == 1:mmax                            # exact cover, in order, no gaps/overlap
+                # contiguous: consecutive blocks abut
+                for i in 2:length(blocks)
+                    @test first(blocks[i]) == last(blocks[i - 1]) + 1
+                end
+            end
+        end
+    end
+end

--- a/SpeedyTransforms/test/runtests.jl
+++ b/SpeedyTransforms/test/runtests.jl
@@ -4,7 +4,9 @@ using LowerTriangularArrays
 using JET
 using Test
 
+include("scaled_legendre.jl")
 include("spectral_transform.jl")
+include("recompute_legendre.jl")
 include("type_name_length.jl")
 include("dispatch.jl")
 include("spectral_gradients.jl")

--- a/SpeedyTransforms/test/scaled_legendre.jl
+++ b/SpeedyTransforms/test/scaled_legendre.jl
@@ -1,0 +1,112 @@
+# Tests for SpeedyTransforms.ScaledLegendre only (step 1 of the recompute-on-the-fly Legendre
+# polynomials feature, see docs/dev/2026-09/recompute-legendre-polynomials.md). No
+# `SpectralTransform` integration here yet, that is a separate step; these tests exercise the
+# module's own math against AssociatedLegendrePolynomials.jl's Float64 reference.
+
+const SL = SpeedyTransforms.ScaledLegendre
+const Legendre = SpeedyTransforms.Legendre
+
+# equally spaced colatitudes standing in for a Gaussian ring set (as in the numerical prototype),
+# always includes a ring close to the pole via the extra argument below
+gaussian_colat(nlat_half) = [(j - 0.5) * π / (2nlat_half) for j in 1:nlat_half]
+
+"Float64 reference lower-triangular table of λ_l^m(cos(colat[j])), via AssociatedLegendrePolynomials."
+function reference_legendre(lmax, mmax, cos_colat)
+    nlat_half = length(cos_colat)
+    n = SL.count_nonzeros(lmax, mmax)
+    Λ = zeros(Float64, n, nlat_half)
+    Λj = zeros(Float64, lmax, mmax)
+    for j in 1:nlat_half
+        Legendre.λlm!(Λj, lmax - 1, mmax - 1, cos_colat[j])
+        for m in 1:mmax, l in m:lmax
+            Λ[SL.lm2i(l, m, lmax), j] = Λj[l, m]
+        end
+    end
+    return Λ
+end
+
+"Recompute the full triangle with ScaledLegendre in number format NF, for comparison against reference_legendre."
+function recomputed_legendre(::Type{NF}, lmax, mmax, cos_colat) where {NF}
+    nlat_half = length(cos_colat)
+    n = SL.count_nonzeros(lmax, mmax)
+    αhi, αlo, βhi, βlo = SL.recursion_coefficients(NF, lmax, mmax)
+    sechi, seclo, scale = SL.sectoral_modes(NF, cos_colat, mmax)
+    Λ = zeros(NF, n, nlat_half)
+    col = zeros(NF, lmax)
+    for j in 1:nlat_half, m in 1:mmax
+        ncolumn = lmax - m + 1
+        lm_offset = SL.lm2i(m, m, lmax) - 1
+        SL.legendre_column!(
+            view(col, 1:ncolumn), cos_colat[j], αhi, αlo, βhi, βlo, lm_offset, ncolumn,
+            sechi[j, m], seclo[j, m], scale[j, m],
+        )
+        Λ[(lm_offset + 1):(lm_offset + ncolumn), j] .= col[1:ncolumn]
+    end
+    return Λ
+end
+
+@testset "ScaledLegendre: coefficient identities" begin
+    # the one-term sectoral -> first-off-diagonal step is the same two-term recursion with
+    # α(m+1, m) == ν(m+1) and β(m+1, m) == 0 (0-based l, m); this is what makes a single
+    # branch-free recursion valid for the whole column, see legendre_column!
+    for m in 0:60
+        l = m + 1
+        @test SL.coeff_α(Float64, l, m) ≈ SL.coeff_ν(Float64, l)
+        @test SL.coeff_β(Float64, l, m) == 0
+    end
+
+    # β(l,m) ≈ α(l,m) / α(l-1,m) for l > m+1 (noted in the design doc as a possible future
+    # simplification, verified numerically here)
+    for m in 0:10:60, l in (m + 2):5:(m + 80)
+        αl = SL.coeff_α(Float64, l, m)
+        αlm1 = SL.coeff_α(Float64, l - 1, m)
+        βl = SL.coeff_β(Float64, l, m)
+        @test βl ≈ αl / αlm1 rtol = 1e-10
+    end
+end
+
+@testset "ScaledLegendre: legendre_column! vs AssociatedLegendrePolynomials" begin
+    for trunc in (31, 63)
+        lmax = mmax = trunc + 1
+        nlat_half = trunc + 1
+        colat = vcat(gaussian_colat(nlat_half), deg2rad(0.05))  # + one ring very close to the pole
+        cos_colat = cos.(colat)
+
+        ref = reference_legendre(lmax, mmax, cos_colat)
+
+        for NF in (Float32, Float64)
+            rec = recomputed_legendre(NF, lmax, mmax, cos_colat)
+            err = maximum(abs.(Float64.(rec) .- ref))
+            @test isfinite(err)
+            if NF == Float32
+                @test err < 2e-6
+            else
+                # `scale_shift(Float64) == 61` puts the flush-to-zero threshold at
+                # 2^-61 ≈ 4.3e-19, well below eps(Float64), so the error floor here is the
+                # recursion's own roundoff (which grows like eps*lmax^2 near the poles),
+                # not the extended-exponent scaling.
+                @test err < 1e-12
+            end
+        end
+    end
+end
+
+@testset "ScaledLegendre: extreme underflow near the pole" begin
+    # a ring extremely close to the pole (~0.05°) at high order m: the sectoral mode underflows
+    # long before the recursion has produced anything, so this exercises the extended-exponent
+    # scaling's ability to carry the recursion through the underflow region without flushing to
+    # zero and without ever overflowing/NaN-ing along the way
+    trunc = 255
+    lmax = mmax = trunc + 1
+    cos_colat = [cos(deg2rad(0.05))]
+
+    ref = reference_legendre(lmax, mmax, cos_colat)
+
+    for NF in (Float32, Float64)
+        rec = recomputed_legendre(NF, lmax, mmax, cos_colat)
+        @test all(isfinite, rec)
+        err = maximum(abs.(Float64.(rec) .- ref))
+        @test isfinite(err)
+        @test err < (NF == Float32 ? 2e-6 : 3e-10)
+    end
+end

--- a/docs/dev/2026-09/recompute-legendre-polynomials.md
+++ b/docs/dev/2026-09/recompute-legendre-polynomials.md
@@ -1,11 +1,12 @@
 # Recompute the Legendre polynomials on the fly
 
 > Status: **in progress**, opened as a draft for discussion. The design is validated numerically
-> (see the accuracy table below); the `ScaledLegendre` module and its tests are done, the
-> `SpectralTransform` integration and the CPU recompute path are drafted, and the GPU recursion
-> kernels (section 4 and 5) are **not implemented yet** — `recompute_legendre = true` on a GPU
-> architecture currently throws. The full `SpeedyTransforms` test suite has not been run against
-> this branch yet.
+> (see the accuracy table below); the `ScaledLegendre` module and its tests are done, and the
+> `SpectralTransform` integration, the CPU recompute path and both GPU recursion kernels (sections
+> 4 and 5) are written. Not yet verified: the full `SpeedyTransforms` test suite has not been run
+> against this branch, and the GPU kernels have **never been run on a GPU** — no backend was
+> available in the session that wrote them, so they are known to compile as ordinary Julia and
+> nothing more.
 
 Date of initial draft: 2026-09-01
 
@@ -35,6 +36,20 @@ Base revision: c3f443af8c22aca1506ea2ec0ff553278a03c4d5
 - 2026-09-01: initial draft, after a numerical prototype on CPU established that plain `Float32`
   recursion is unusable, that extended-exponent scaling alone is not enough, and that
   double-single (`Float32` pair) arithmetic reaches the accuracy of the current precomputation.
+- 2026-09-01: GPU kernels (sections 4 and 5) implemented. Three changes to the plan along the way:
+  - The recursion arithmetic was factored into a single `ScaledLegendre.legendre_advance`, which
+    both `legendre_column!` (CPU) and the two GPU kernels now step through. The plan had them as
+    separate transcriptions of the same recurrence; sharing one `@inline` step makes the CPU and
+    GPU polynomials bit-identical by construction rather than by review.
+  - `RecomputedLegendre`'s `x` field became the pair `xhi`/`xlo`. Storing `cos(colat)` as a single
+    `Float32` injects a relative error of `eps(Float32)` at *every* recursion step, which is
+    exactly the error the double-single arithmetic exists to avoid — the prototype had used a
+    `Float64` evaluation point and the first draft of the struct silently dropped that.
+  - The forward transform reuses `forward_legendre_kernel!` with a new trailing `lm_offset`
+    argument (`0` for the precomputed path) rather than getting a kernel of its own, so the tile
+    and the precomputed table are read through identical indexing. The tile therefore keeps the
+    `(lm, j)` layout: that makes the recompute kernel's writes strided, which is the right trade
+    since the tile is written once per transform but read once per layer.
 
 ## Problem description
 

--- a/docs/dev/2026-09/recompute-legendre-polynomials.md
+++ b/docs/dev/2026-09/recompute-legendre-polynomials.md
@@ -1,0 +1,337 @@
+# Recompute the Legendre polynomials on the fly
+
+> Status: **in progress**, opened as a draft for discussion. The design is validated numerically
+> (see the accuracy table below); the `ScaledLegendre` module and its tests are done, the
+> `SpectralTransform` integration and the CPU recompute path are drafted, and the GPU recursion
+> kernels (section 4 and 5) are **not implemented yet** — `recompute_legendre = true` on a GPU
+> architecture currently throws. The full `SpeedyTransforms` test suite has not been run against
+> this branch yet.
+
+Date of initial draft: 2026-09-01
+
+Base revision: c3f443af8c22aca1506ea2ec0ff553278a03c4d5
+
+## Originating prompt
+
+> We currently precompute the Legendre polynomials in SpeedyWeather but I would like you to
+> explore options to recompute them on the fly. The Legendre polynomials are big at higher
+> resolution and scale badly in terms of required memory. We currently use
+> AssociatedLegendrePolynomials.jl to precompute them, have a look at that code whether
+> computing them on the fly on the GPU would be feasible. There's several problems we need to be
+> aware of. On the GPU we'd ideally compute the polynomials in float32 but lower precision can
+> easily be a problem here because of the recursion relation to compute them, see Justin
+> Willmert's blogposts that are linked in the docs. In the end the recursion relation creates
+> intermediate values that are really small before growing again. I'm wondering whether parts of
+> it could be computed in log-space, or the sectoral modes (on the diagonal) could be precomputed
+> in higher precision but all others in float32 ... I want you to be creative. If you find
+> changes to AssociatedLegendrePolynomials necessary, then create a module in SpeedyTransforms.
+> Don't do any SpeedyWeather unit testing or docs, just write some code that could efficiently
+> compute the polynomials on the GPU, and draft how that can be integrated into
+> SpeedyTransforms.jl's interface so that we have a simple precompute/recompute flag. Then create
+> a draft pull request, plan with opus, execute with Sonnet
+
+## Revision log
+
+- 2026-09-01: initial draft, after a numerical prototype on CPU established that plain `Float32`
+  recursion is unusable, that extended-exponent scaling alone is not enough, and that
+  double-single (`Float32` pair) arithmetic reaches the accuracy of the current precomputation.
+
+## Problem description
+
+`SpectralTransform` precomputes the associated Legendre polynomials
+``\lambda_\ell^m(\cos\theta_j)`` for every spherical harmonic ``(\ell, m)`` and every latitude
+ring ``j`` of the northern hemisphere. That array has
+
+```
+nonzeros(spectrum) * nlat_half  ≈  (T²/2) * T  =  O(T³)
+```
+
+entries, so its memory grows with the *cube* of the truncation while every other array in the
+transform grows with the square. Measured for a square spectrum with `nlat_half = T+1` in
+`Float32`:
+
+| truncation | precomputed polynomials |
+|-----------:|------------------------:|
+| T31        | 0.07 MB                 |
+| T127       | 4.2 MB                  |
+| T255       | 34 MB                   |
+| T511       | 269 MB                  |
+| T1023      | ~2.1 GB                 |
+
+On GPU there is a second copy (`legendre_polynomials_transposed`, needed because the forward and
+inverse kernels want opposite layouts), so the real figure is twice that. At T1023 that is more
+than 4 GB of a GPU's memory spent on a table that is pure function of ``(\ell, m, j)``, before a
+single prognostic variable has been allocated. This is what caps the resolution we can reach on
+a single GPU.
+
+Recomputing the polynomials inside the transform kernels would replace that `O(T³)` table with
+`O(T²)` of recursion coefficients. The obstacle is numerical: the recursion is run in the number
+format of the transform, which on GPU we want to be `Float32`.
+
+## Background
+
+### The recursion
+
+SpeedyWeather uses the spherical-harmonic normalisation ``\lambda_\ell^m`` provided by
+[AssociatedLegendrePolynomials.jl](https://github.com/jmert/AssociatedLegendrePolynomials.jl)
+(`Legendre.λlm!`), documented in Justin Willmert's blog series linked from
+`docs/src/spectral_transform.md`. Three recurrences are used:
+
+```math
+\lambda_0^0 = \frac{1}{\sqrt{4\pi}}, \qquad
+\lambda_m^m = -\mu_m \sqrt{1-x^2}\, \lambda_{m-1}^{m-1}, \qquad
+\lambda_\ell^m = \alpha_\ell^m x \lambda_{\ell-1}^m - \beta_\ell^m \lambda_{\ell-2}^m
+```
+
+with ``x = \cos\theta``. The coefficients (Willmert's well-conditioned forms, reproduced in the
+new module) are
+
+```math
+\mu_\ell = 1 + \left[2\ell + \sqrt{2\ell(2\ell+1)}\right]^{-1}, \quad
+\alpha_\ell^m = \sqrt{\frac{4\ell^2-1}{\ell^2-m^2}}, \quad
+\beta_\ell^m = \sqrt{\frac{(2\ell+1)\left[(\ell-1)^2-m^2\right]}{(2\ell-3)(\ell^2-m^2)}}
+```
+
+Two facts make this a good fit for our GPU kernels:
+
+1. The one-term recurrence for ``\ell = m+1``, ``\lambda_{m+1}^m = \nu_{m+1} x \lambda_m^m`` with
+   ``\nu_\ell = \sqrt{2\ell+1}``, is the *same* two-term recurrence with
+   ``\alpha_{m+1}^m = \nu_{m+1}`` and ``\beta_{m+1}^m = 0`` (verified analytically and
+   numerically). So a single branch-free recursion with ``\lambda_{m-1}^m \equiv 0`` covers the
+   whole column.
+2. The recursion marches *down a column of fixed order ``m``*, which is exactly the direction the
+   inverse Legendre kernel already walks: one thread per (ring ``j``, order ``m``, layer ``k``)
+   dotting a lower-triangular column against the coefficients. The polynomial can be produced in
+   registers as the dot product accumulates.
+
+### Why `Float32` fails, in two separate ways
+
+**(a) Range.** ``\lambda_m^m \sim (\sin\theta)^m``. On the ring closest to the pole of a T511
+full grid that is ``\sim 10^{-1500}``, far below the `Float32` (and `Float64`) minimum. Starting
+the recursion from a flushed zero gives zero for the whole column — but ``\lambda_\ell^m`` grows
+back to ``O(1)`` once ``\ell \gtrsim m/\sin\theta``, so real coefficients are silently lost. In
+`Float32` this bites early: at ``\theta = 30°`` the sectoral mode underflows at ``m \approx 126``
+while the column becomes ``O(1)`` again at ``\ell \approx 252``, i.e. already at T255. This is
+why the current code gets away with `Float32` *storage*: the values are produced by
+AssociatedLegendrePolynomials.jl in `Float64` (its work arrays promote against the `Float64`
+colatitudes) and only rounded on write.
+
+**(b) Accumulated round-off.** Near the poles at low ``m`` the two solutions of the
+three-term recurrence are nearly degenerate (the characteristic roots coalesce as ``x \to 1``),
+so injected round-off grows like ``\ell^2`` rather than ``\sqrt{\ell}``. With ``\epsilon_{32}``
+and ``\ell = 512`` that is ``\epsilon_{32}\ell^2/2 \approx 8\cdot10^{-3}`` — which is exactly
+what the prototype measures.
+
+### Prototype measurements
+
+Max ``|\lambda_\text{recomputed} - \lambda_\text{Float64}|`` over the whole triangle and all
+rings, square spectrum, `nlat_half = T+1`:
+
+| variant                                          | T127     | T255     | T511      |
+|--------------------------------------------------|---------:|---------:|----------:|
+| `Float32` recursion, no scaling (naive)          | 5.3e-4   | 1.9e-2   | **5.5e35** |
+| `Float32` recursion, extended-exponent scaling   | 5.3e-4   | 2.5e-3   | 9.5e-3    |
+| `Float64` recursion, `Float32` coefficients      | 4.4e-5   | 5.7e-4   | 5.0e-3    |
+| **double-single `Float32` (hi/lo pairs)**        | **2.0e-7** | **2.8e-7** | **4.0e-7** |
+| `Float64` recursion, `Float64` coefficients      | 2.0e-7   | 2.8e-7   | 4.0e-7    |
+| *current: `Float64` precompute rounded to `Float32`* | 1.2e-7 | 2.4e-7 | 2.4e-7 |
+
+Reading the table:
+
+- Scaling alone fixes the blow-up (5.5e35 → 9.5e-3) but not the accuracy.
+- Rounding the *coefficients* to `Float32` costs as much as `Float32` arithmetic does, so both
+  have to be carried in higher precision.
+- Double-single arithmetic is indistinguishable from a full `Float64` recursion and lands on the
+  `Float32` output-rounding floor, i.e. **as accurate as what we store today**. The residual
+  3.99e-7 at T511 is the `Float32` rounding of values of magnitude ``\sqrt{2\ell+1}/\sqrt{4\pi}
+  \approx 9``, plus the `Float32` sectoral start; storing the sectoral start as a hi/lo pair too
+  should bring it to ~1.2e-7.
+
+Double-single ("two-float") arithmetic represents a number as an unevaluated sum of two
+`Float32`s, giving ~48 bits of mantissa using only `Float32` FMAs. It costs roughly 30 `Float32`
+operations per recursion step against the 2 FMAs of a naive step — but it buys back a global
+memory load per step, and the Legendre kernels are strongly memory bound (currently ~1.5 flop
+per byte against a machine balance of ~13 on an A100), so the arithmetic is expected to be
+close to free. On the L4s available here `Float64` runs at 1/64 rate, so double-single is the
+only viable route to `Float64`-grade accuracy in the kernel.
+
+### Why not log space
+
+Log space is the right tool for the *sectoral* start, where the whole difficulty is dynamic
+range and the value is a product, and it is wrong for the ``\ell``-recursion, which subtracts.
+But an ``\exp`` of an argument of magnitude ``\sim m\ln\sin\theta \sim -10^3`` needs the argument
+to ~1e-11 absolute to give `Float32`-accurate output, which is itself a double-single
+computation. The extended-exponent representation below is the same idea in base ``2^{32}``,
+computed exactly once on the host in `Float64`, and needs no transcendentals in the kernel.
+
+## Summary of changes
+
+### 1. New module `SpeedyTransforms.ScaledLegendre` (`src/scaled_legendre.jl`)
+
+Self-contained, no GPU or SpeedyWeather dependencies, so it can be tested and reasoned about on
+its own. It replaces our use of AssociatedLegendrePolynomials.jl inside the transform (that
+package stays a dependency for now, as the reference in tests).
+
+*Recursion coefficients.* `coeff_μ`, `coeff_α`, `coeff_β`, `coeff_ν` for the spherical-harmonic
+normalisation, in the well-conditioned forms above, always evaluated in `Float64`.
+
+*Double-single arithmetic.* `two_prod`, `two_sum`, `quick_two_sum`, `df_mul`, `df_add` on
+`Float32` pairs, all `@inline` and FMA-based so they are GPU-safe (no branches, no allocations).
+
+*Extended-exponent scaling.* Constants and helpers for the representation
+
+```
+true value  =  p · 2^(-SHIFT·s),    SHIFT = 32,    s ≥ 0 integer
+invariant:  |p| ≤ 1 whenever s > 0
+```
+
+Rescaling rule inside the recursion: `if s > 0 && |p| > 1` then `p *= 2^-SHIFT` (exact, a power
+of two) for *both* running values and `s -= 1`. The invariant guarantees that anything with
+`s > 0` has a true magnitude below `2^-32 ≈ 2.3e-10`, i.e. below `Float32` eps relative to the
+`O(1)` values in the same column, so it can be treated as zero. Once `s == 0` the value is
+exact-as-stored and no further rescaling happens. `SHIFT = 32` leaves 94 bits of headroom above
+the `Float32` minimum normal, so the running values can never underflow.
+
+*Host-side builders.*
+
+- `recursion_coefficients(NF, spectrum) -> (αhi, αlo, βhi, βlo)`: four vectors of length
+  `nonzeros(spectrum) + 2`, indexed by the same `lm` running index as the polynomials
+  themselves, zero-padded at the end so a kernel may run one recursion step past the end of a
+  column without a bounds check. Computed in `Float64` and split into hi/lo `Float32` pairs.
+  Diagonal entries are zero (unused).
+- `sectoral_modes(NF, cos_colat, mmax) -> (hi, lo, scale)`: `(nlat_half, mmax)` arrays, `j`
+  fastest so that neighbouring GPU threads (neighbouring rings at the same order) read
+  contiguous memory. The ``\mu`` recursion is run once per ring in `Float64` with the scaling
+  above, then split into a hi/lo pair; `scale` is `Int16` (the largest scale at T1023 is ~330).
+- `legendre_column!(out, x, coefficients, lm_offset, ncol, sectoral, scale)`: reference
+  implementation of the column recursion, used by the CPU path and by tests.
+
+### 2. `AbstractLegendrePolynomials` and the `recompute` flag
+
+```julia
+abstract type AbstractLegendrePolynomials{NF} end
+
+struct PrecomputedLegendre{NF, LTA, V} <: AbstractLegendrePolynomials{NF}
+    polynomials::LTA                # (lm, j), as today
+    polynomials_transposed::V       # flattened (j, lm), GPU only, empty on CPU
+end
+
+struct RecomputedLegendre{NF, V, M, MI, S} <: AbstractLegendrePolynomials{NF}
+    αhi::V; αlo::V; βhi::V; βlo::V  # length nonzeros+2
+    sectoral_hi::M                  # (nlat_half, mmax)
+    sectoral_lo::M
+    sectoral_scale::MI              # (nlat_half, mmax), Int16
+    x::V                            # cos(colat), length nlat_half
+    tile::S                         # scratch buffer for the forward transform, see below
+    tile_orders::Vector{UnitRange{Int}}   # order blocks, host side
+end
+```
+
+`SpectralTransform` loses its `legendre_polynomials` and `legendre_polynomials_transposed`
+fields and gains a single `legendre::LegendrePolynomialsType` field (one type parameter replaces
+one, since `LowerTriangularArrayType` was only there for the polynomials). The constructor gains
+
+```julia
+SpectralTransform(spectrum, grid; recompute_legendre::Bool = false, kwargs...)
+```
+
+`false` keeps today's behaviour bit-for-bit. Everything downstream reaches the polynomials
+through the two `_legendre!` methods only, so the blast radius is `legendre.jl`,
+`legendre_ka.jl`, `spectral_transform.jl` and `show.jl` (the only other reader, for the memory
+report — which should now print the recompute footprint and the mode).
+
+### 3. CPU path (`legendre.jl`)
+
+Both CPU `_legendre!` methods already loop over rings `j` on the outside and take a
+`view(legendre_polynomials.data, lm:lm_end, j)` on the inside. Introduce
+
+```julia
+legendre_ring!(scratch, legendre::AbstractLegendrePolynomials, j) -> AbstractVector
+```
+
+which returns a `view` into the precomputed array for `PrecomputedLegendre`, and for
+`RecomputedLegendre` fills a `nonzeros(spectrum)`-long scratch vector with all columns for ring
+`j` and returns it. Hoisted to the top of the `j` loop it is amortised over every order `m` and
+every layer `k`, so the CPU cost is one recursion pass per ring per transform. The inner loops
+are unchanged apart from indexing the returned vector.
+
+On CPU the recursion runs in `Float64` when `NF == Float64` and in double-single otherwise, so
+CPU and GPU agree.
+
+### 4. GPU inverse transform — true on the fly, no buffer at all
+
+`inverse_legendre_kernel!` already has one thread per (`j`, `m`, `k`) walking a column. Replace
+the polynomial load with the recursion carried in registers:
+
+```
+p1 = (sectoral_hi[j,m], sectoral_lo[j,m]);  p2 = 0;  s = sectoral_scale[j,m]
+
+phase 1 — climb out of the underflow region, no accumulation:
+    while s > 0 and q < ncol:  advance one step, rescale
+
+phase 2 — hot loop, no branches, two steps per iteration to keep the
+          existing even/odd (north/south symmetry) split:
+    a = Σ over even positions,  b = Σ over odd positions
+    (even, odd) = isodd(q_first) ? (a, b) : (b, a)
+```
+
+If phase 1 never reaches `s == 0` the whole column is negligible and the thread writes zeros —
+which is the correct answer, and is what the current `Float64` precompute effectively produces
+too.
+
+`α`, `β` are read by `lm`, which is *identical for every thread in a warp* (a warp holds
+consecutive rows of `jm_indices`, i.e. neighbouring rings at the same order), so those loads
+broadcast and hit cache; the per-thread memory traffic of the inverse Legendre transform drops
+to essentially zero. `legendre_polynomials_transposed` disappears entirely in this mode.
+
+### 5. GPU forward transform — recompute in tiles over the order `m`
+
+The forward kernel is parallelised over the output coefficients (one thread per `lm`, summing
+over rings), which is orthogonal to the recursion direction, so it cannot recompute in
+registers. Instead, tile over **blocks of orders `m`**:
+
+- A block of orders is a *contiguous* `lm` range in the lower-triangular layout, so no index
+  table needs restructuring: `lm_indices` and `jm_indices` are used exactly as they are.
+- Each coefficient belongs to exactly one block, so each is written exactly once — no
+  accumulation across tiles, no `fill!`, and the result is bit-identical regardless of tile size.
+- `tile::Matrix` of size `(nnz_tile, nlat_half)` where `nnz_tile` is chosen from a memory budget
+  (default 32 MB, so ~20 orders per tile at T1023). A recompute kernel with one thread per
+  (`m`, `j`) fills it; the existing `forward_legendre_kernel!` then runs over the block's `lm`
+  range with a new `lm_offset` argument (`0` for the precomputed path, so no cost there).
+- The recompute cost is per *transform call*, not per layer, so it is amortised over `nlayers`.
+
+## Testing and verification
+
+Per the prompt, no SpeedyWeather-level unit tests or docs in this PR. What goes in:
+
+- `SpeedyTransforms/test/scaled_legendre.jl`: the recursion against `Legendre.λlm!` in `Float64`
+  over several truncations and both a full and a reduced grid; the extreme-underflow rings
+  explicitly; and `transform!` round-trips with `recompute_legendre = true` against
+  `recompute_legendre = false` for both `Float32` and `Float64`.
+- A standalone script under `SpeedyTransforms/benchmark/` (not part of the test suite) that
+  reproduces the accuracy table above and times forward/inverse transforms in both modes on CPU
+  and, if a GPU backend is loaded, on GPU.
+
+## Documentation changes
+
+None in this PR beyond docstrings, per the prompt.
+
+## Known limitations
+
+- The inverse kernel repeats the recursion for every layer `k`, since `k` is a thread dimension.
+  For large batches it would be better to give each thread a block of layers and amortise the
+  recursion; deferred (see Future work).
+- The sectoral table is `O(nlat_half · mmax)`, i.e. still `O(T²)` — small next to the `O(T³)` it
+  replaces, but it could be dropped entirely by recursing in `m` inside the kernel at roughly
+  2× the arithmetic.
+- Reduced grids with aggressive Legendre shortcuts get less benefit from the tiled forward
+  transform, since the tile is sized for the full ring set.
+- `MatrixSpectralTransform` is untouched and always precomputes.
+
+## Future work
+
+- Layer-blocked inverse kernel (amortise the recursion over several `k` per thread).
+- `Int16`/packed sectoral storage, and dropping `β` in favour of
+  ``\beta_\ell^m = \alpha_\ell^m / \alpha_{\ell-1}^m`` (verified identity) if coefficient memory
+  ever matters.
+- Making `recompute_legendre` the default above a resolution threshold once benchmarked.


### PR DESCRIPTION
Draft — opening early for discussion on the approach before the GPU kernels land.

## Why

`SpectralTransform` precomputes `legendre_polynomials[lm, j]`, which has
`nonzeros(spectrum) * nlat_half = O(T³)` entries — it grows with the *cube* of the truncation
while every other array in the transform grows with the square:

| truncation | precomputed (Float32) |
|-----------:|----------------------:|
| T127       | 4.2 MB                |
| T255       | 34 MB                 |
| T511       | 269 MB                |
| T1023      | ~2.1 GB               |

On GPU there is a second, transposed copy (the forward and inverse kernels want opposite
layouts), so double that. This is what caps the resolution we can reach on a single GPU.

Recomputing the polynomials inside the kernels replaces that table with `O(T²)` of recursion
coefficients — ~3 MB instead of 269 MB at T511.

## The numerical problem, and what actually works

The obstacle is that on GPU we want to run the recursion in `Float32`. Two separate things break:

**Range.** `λ_m^m ~ sin(θ)^m` underflows near the poles long before `λ_l^m` has decayed to
something genuinely negligible — it grows back to `O(1)` once `l ≳ m/sin(θ)`. In `Float32` this
bites at T255 already. (The current code gets away with `Float32` *storage* because
AssociatedLegendrePolynomials.jl produces the values in `Float64` and we only round on write.)

**Accumulated round-off.** Near the poles at low order the two solutions of the three-term
recurrence nearly coalesce as `x → 1`, so injected round-off grows like `eps·l²`, not `sqrt(l)`.

I prototyped the variants against a `Float64` `Legendre.λlm!` reference — max absolute error
over the whole triangle and all rings, square spectrum:

| variant | T127 | T255 | T511 |
|---|---:|---:|---:|
| `Float32` recursion, no scaling | 5.3e-4 | 1.9e-2 | **5.5e35** |
| `Float32` recursion + extended-exponent scaling | 5.3e-4 | 2.5e-3 | 9.5e-3 |
| `Float64` recursion, `Float32` coefficients | 4.4e-5 | 5.7e-4 | 5.0e-3 |
| **double-single `Float32` (hi/lo pairs)** | **2.0e-7** | **2.8e-7** | **4.0e-7** |
| `Float64` recursion, `Float64` coefficients | 2.0e-7 | 2.8e-7 | 4.0e-7 |
| *current: `Float64` precompute rounded to `Float32`* | 1.2e-7 | 2.4e-7 | 2.4e-7 |

So: scaling alone fixes the blow-up but not the accuracy; rounding the *coefficients* to
`Float32` costs as much as `Float32` arithmetic does, so both need higher precision; and
double-single ("two-float") arithmetic is indistinguishable from a full `Float64` recursion and
lands on the same `Float32` rounding floor as the table we store today.

`Float64` in the kernel would be the simpler answer but is a non-starter on the GPUs this
targets (1/64 rate on an L4). Double-single buys the accuracy back using only `Float32` FMAs —
and it trades ~30 flops per recursion step for a *removed global load* per step, in kernels that
are strongly memory bound (~1.5 flop/byte against a machine balance of ~13), so it should be
close to free or better.

On the sectoral modes specifically: they are precomputed on the host in `Float64` and stored as
`(hi, lo, scale)` with the extended-exponent scaling, which is `O(nlat_half · mmax) = O(T²)`.
That is the "log space" idea in base `2^32`, computed exactly once and needing no transcendentals
in the kernel.

## What is in this PR

- **`SpeedyTransforms.ScaledLegendre`** (`src/scaled_legendre.jl`, new module as suggested):
  recursion coefficients in the spherical-harmonic normalisation (ported from
  AssociatedLegendrePolynomials.jl's `norm_sphere.jl`, credited), double-single `Float32`
  arithmetic, the extended-exponent scaling, and the column recursion. Self-contained and
  separately tested against `Legendre.λlm!`.
- **`PrecomputedLegendre` / `RecomputedLegendre`** behind `AbstractLegendrePolynomials`, and a
  `recompute_legendre::Bool = false` keyword on `SpectralTransform`. `false` keeps today's path
  bit-for-bit; `SpectralTransform` swaps its two polynomial fields for one `legendre` field.
- **CPU recompute path**: one recursion pass per ring, hoisted to the top of the `j` loop so it
  is amortised over every order and every layer. The inner loops are unchanged.
- `docs/dev/2026-09/recompute-legendre-polynomials.md` with the full design, including the GPU
  kernel design that is not yet implemented.

Two nice structural facts that make this fit our kernels:

1. `α(m+1, m) == ν(m+1)` and `β(m+1, m) == 0` exactly, so a single branch-free recursion with
   `λ_{m-1}^m ≡ 0` covers a whole column with no special case at the top.
2. The recursion marches down a column of fixed order `m`, which is exactly the direction the
   inverse Legendre kernel already walks — so the inverse can recompute in registers with no
   buffer at all, and `α`/`β` are identical across a warp (same order, neighbouring rings), so
   those loads broadcast.

## Not done yet

- **GPU kernels** (sections 4 and 5 of the plan doc). `recompute_legendre = true` on a GPU
  architecture currently throws. The design is written up: on-the-fly in registers for the
  inverse, and for the forward — whose parallelisation over output coefficients is orthogonal to
  the recursion — recompute in tiles over blocks of orders `m`, which are contiguous `lm` ranges
  so no index table changes and every coefficient is still written exactly once.
- **The full `SpeedyTransforms` test suite has not been run against this branch.** The
  `ScaledLegendre` module tests pass (Float32 accuracy 1.2e-7 at T127, 2.4e-7 at T255, matching
  the prototype); the integration tests are drafted but unverified. Opening as a draft to agree
  on the approach first.
- No benchmarks yet, so the "close to free" claim above is an estimate from arithmetic intensity,
  not a measurement.

## Questions for review

- Is swapping `legendre_polynomials` + `legendre_polynomials_transposed` for a single
  `legendre::AbstractLegendrePolynomials` field the interface you want, or would you rather keep
  the field names and dispatch some other way?
- Should `recompute_legendre` eventually default to `true` above some resolution, or stay opt-in?
- The CPU path keeps a per-ring scratch vector inside `RecomputedLegendre`, which is mutable
  shared state — fine as the transform is not threaded over rings today, but worth a look given
  the care taken elsewhere for Enzyme const-activity.
