### PR TITLE
Optional snow accumulation on sea ice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Optional snow accumulation on sea ice affecting albedo and surface flux insulation, enabled with `SnowModel(..., sea_ice_snow=true)` [#1245](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1245)
+- Optional snow accumulation on sea ice affecting albedo and surface flux insulation, enabled with `SnowModel(..., sea_ice_snow=true)` [#1245](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1246)
 - Several problems Enzyme compat with 1.12 fixed, but no full end-to-end differentiability yet [#1163](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1163)
 - Add `HEALPixOutput`, a Zarr output writer that writes onto a `HEALPixGrid` keeping the horizontal dimension flat [#1238](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1238)
 - GitHub Actions github-script v9 [#1241](https://github.com/SpeedyWeather/SpeedyWeather.jl/issues/1241)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Optional snow accumulation on sea ice affecting albedo and surface flux insulation, enabled with `SnowModel(..., sea_ice_snow=true)` [#1245](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1246)
+- Optional snow accumulation on sea ice affecting albedo and surface flux insulation, enabled with `SnowModel(..., sea_ice_snow=true)` [#1246](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1246)
 - Several problems Enzyme compat with 1.12 fixed, but no full end-to-end differentiability yet [#1163](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1163)
 - Add `HEALPixOutput`, a Zarr output writer that writes onto a `HEALPixGrid` keeping the horizontal dimension flat [#1238](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1238)
 - GitHub Actions github-script v9 [#1241](https://github.com/SpeedyWeather/SpeedyWeather.jl/issues/1241)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Optional snow accumulation on sea ice affecting albedo and surface flux insulation, enabled with `SnowModel(..., sea_ice_snow=true)` [#1245](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1245)
 - Several problems Enzyme compat with 1.12 fixed, but no full end-to-end differentiability yet [#1163](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1163)
 - Add `HEALPixOutput`, a Zarr output writer that writes onto a `HEALPixGrid` keeping the horizontal dimension flat [#1238](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1238)
 - GitHub Actions github-script v9 [#1241](https://github.com/SpeedyWeather/SpeedyWeather.jl/issues/1241)

--- a/SpeedyWeather/Project.toml
+++ b/SpeedyWeather/Project.toml
@@ -1,7 +1,7 @@
 name = "SpeedyWeather"
 uuid = "9e226e20-d153-4fed-8a5b-493def4f21a9"
 authors = ["SpeedyWeather contributors"]
-version = "0.22.1+DEV"
+version = "0.23.0-DEV"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/SpeedyWeather/src/parameterizations/albedo.jl
+++ b/SpeedyWeather/src/parameterizations/albedo.jl
@@ -172,32 +172,7 @@ end
 
 @propagate_inbounds albedo!(ij, albedo, vars, scheme::AlbedoClimatology, model) = (albedo[ij] = scheme.albedo[ij])
 
-# OceanSeaIceAlbedo
-export OceanSeaIceAlbedo
-
-"""Albedo that scales linearly between ocean and ice albedo depending on sea ice concentration.
-Fields are $(TYPEDFIELDS)"""
-@parameterized @kwdef struct OceanSeaIceAlbedo{NF} <: AbstractAlbedo
-    "[OPTION] Albedo over open ocean [1]"
-    @param albedo_ocean::NF = 0.06 (bounds = 0 .. 1,)
-
-    "[OPTION] Albedo over sea ice at concentration=1 [1]"
-    @param albedo_ice::NF = 0.6 (bounds = 0 .. 1,)
-end
-
-Adapt.@adapt_structure OceanSeaIceAlbedo
-OceanSeaIceAlbedo(SG::SpectralGrid; kwargs...) = OceanSeaIceAlbedo{SG.NF}(; kwargs...)
-initialize!(::OceanSeaIceAlbedo, ::PrimitiveEquation) = nothing
-
-@propagate_inbounds function albedo!(ij, albedo, vars, scheme::OceanSeaIceAlbedo, model)
-    (; albedo_ocean, albedo_ice) = scheme
-    NF = eltype(albedo)
-    ℵ = haskey(vars.prognostic.ocean, :sea_ice_concentration) ? vars.prognostic.ocean.sea_ice_concentration[ij] : zero(NF)
-
-    # set ocean albedo linearly between ocean and ice depending on sea ice concentration
-    return albedo[ij] = albedo_ocean + ℵ * (albedo_ice - albedo_ocean)
-end
-
+# snow cover schemes, shared by the ocean (snow on sea ice) and land albedos below
 abstract type AbstractSnowCover end
 
 export LinearSnowCover, SaturatingSnowCover
@@ -214,6 +189,57 @@ Adapt.@adapt_structure SaturatingSnowCover
 
 """$(TYPEDSIGNATURES) Snow cover fraction for the saturating scheme."""
 @inline (::SaturatingSnowCover)(snow_depth, scale) = snow_depth / (snow_depth + scale)
+
+# OceanSeaIceAlbedo
+export OceanSeaIceAlbedo
+
+"""Albedo that scales linearly between ocean and ice albedo depending on sea ice concentration,
+with an additional contribution from snow lying on the sea ice (see `SnowModel`'s `sea_ice_snow`).
+Fields are $(TYPEDFIELDS)"""
+@parameterized @kwdef struct OceanSeaIceAlbedo{NF, Scheme <: AbstractSnowCover} <: AbstractAlbedo
+    "[OPTION] Albedo over open ocean [1]"
+    @param albedo_ocean::NF = 0.06 (bounds = 0 .. 1,)
+
+    "[OPTION] Albedo over sea ice at concentration=1 [1]"
+    @param albedo_ice::NF = 0.6 (bounds = 0 .. 1,)
+
+    "[OPTION] Albedo of snow on sea ice [1], additive to sea ice"
+    @param albedo_snow::NF = 0.4 (bounds = 0 .. 1,)
+
+    "[OPTION] Conversion from snow depth to snow cover [m]"
+    @param snow_depth_scale::NF = 0.05 (bounds = Positive,)
+
+    "[OPTION] Snow cover-albedo scheme"
+    @param snow_cover::Scheme = SaturatingSnowCover() (group = :snow_cover,)
+end
+
+Adapt.@adapt_structure OceanSeaIceAlbedo
+OceanSeaIceAlbedo(SG::SpectralGrid; snow_cover = SaturatingSnowCover(), kwargs...) =
+    OceanSeaIceAlbedo{SG.NF, typeof(snow_cover)}(; snow_cover, kwargs...)
+initialize!(::OceanSeaIceAlbedo, ::PrimitiveEquation) = nothing
+
+@propagate_inbounds function albedo!(ij, albedo, vars, scheme::OceanSeaIceAlbedo, model)
+    (; albedo_ocean, albedo_ice) = scheme
+    NF = eltype(albedo)
+    ℵ = haskey(vars.prognostic.ocean, :sea_ice_concentration) ? vars.prognostic.ocean.sea_ice_concentration[ij] : zero(NF)
+
+    # set ocean albedo linearly between ocean and ice depending on sea ice concentration
+    albedo[ij] = albedo_ocean + ℵ * (albedo_ice - albedo_ocean)
+
+    # add snow lying on the sea ice, weighted by the ice fraction it sits on so that it
+    # vanishes over open ocean. Snow depth is stored as a depth per sea ice area.
+    if haskey(vars.prognostic.ocean, :snow_depth)
+        (; albedo_snow, snow_depth_scale) = scheme
+        snow_depth = vars.prognostic.ocean.snow_depth[ij]
+
+        # compute snow-cover fraction using the chosen scheme, as over land
+        snow_cover = scheme.snow_cover(snow_depth, snow_depth_scale)
+
+        # clamp to 1 so that albedo_ice + albedo_snow > 1 cannot give an unphysical albedo
+        albedo[ij] = min(albedo[ij] + ℵ * snow_cover * albedo_snow, one(NF))
+    end
+    return nothing
+end
 
 # LandSnowAlbedo
 export LandSnowAlbedo

--- a/SpeedyWeather/src/parameterizations/land/snow.jl
+++ b/SpeedyWeather/src/parameterizations/land/snow.jl
@@ -8,6 +8,11 @@ Single-column snow bucket model in equivalent liquid water depth. Snow accumulat
 from the diagnosed precipitation, melts once the top soil layer exceeds
 `melting_threshold`, and is capped at `snow_depth_cap` to limit infinite snow/ice accumulation
 over perennial ice caps and glaciers.
+
+Optionally (`sea_ice_snow = true`) a second snow bucket accumulates over sea ice, where it
+raises the surface albedo and insulates the surface heat and humidity fluxes. That bucket melts
+with the surface air temperature above `melting_threshold` and is removed entirely once the sea
+ice concentration drops below `sea_ice_threshold`, i.e. the snow disappears with the ice.
 $(TYPEDFIELDS)"""
 @parameterized @kwdef struct SnowModel{NF} <: AbstractSnow
     "[OPTION] Temperature threshold for snow melting [K]"
@@ -15,6 +20,15 @@ $(TYPEDFIELDS)"""
 
     "[OPTION] Permanent snow/ice depth cap in equivalent liquid water depth [m]"
     snow_depth_cap::NF = 10
+
+    "[OPTION] Accumulate snow on sea ice, affecting albedo and surface fluxes"
+    sea_ice_snow::Bool = false
+
+    "[OPTION] Melt rate of snow on sea ice per degree above the melting threshold [m/s/K]"
+    @param sea_ice_melt_factor::NF = 1.0e-7 (bounds = Nonnegative,)
+
+    "[OPTION] Sea ice concentration below which snow on sea ice is removed entirely [1]"
+    @param sea_ice_threshold::NF = 0.01 (bounds = 0 .. 1,)
 end
 
 Adapt.@adapt_structure SnowModel
@@ -22,11 +36,18 @@ Adapt.@adapt_structure SnowModel
 # generator function
 SnowModel(SG::SpectralGrid, geometry::LandGeometryOrNothing = nothing; kwargs...) = SnowModel{SG.NF}(; kwargs...)
 
-function variables(::SnowModel)
-    return (
+function variables(snow::SnowModel)
+    vars = (
         PrognosticVariable(:snow_depth, Grid2D(), namespace = :land, units = "m", desc = "Snow depth in equivalent liquid water height"),
         PrognosticVariable(:soil_temperature, LandXYZ(), namespace = :land, units = "K", desc = "Soil temperature"),
         ParameterizationVariable(:snow_melt_rate, Grid2D(), namespace = :land, units = "kg/m²/s", desc = "Snow melt rate"),
+    )
+
+    # only allocate the snow on sea ice bucket if that effect is enabled
+    snow.sea_ice_snow || return vars
+    return (
+        vars...,
+        PrognosticVariable(:snow_depth, Grid2D(), namespace = :ocean, units = "m", desc = "Snow depth on sea ice in equivalent liquid water height"),
     )
 end
 
@@ -34,8 +55,12 @@ end
 initialize!(snow::SnowModel, model::PrimitiveEquation) = nothing
 
 # set initial conditions for snow depth in initial conditions
-initialize!(vars::Variables, snow::SnowModel, model::PrimitiveEquation) =
+function initialize!(vars::Variables, snow::SnowModel, model::PrimitiveEquation)
     set!(vars.prognostic.land, model.geometry, snow_depth = 0)
+    snow.sea_ice_snow && haskey(vars.prognostic.ocean, :snow_depth) &&
+        fill!(vars.prognostic.ocean.snow_depth, 0)
+    return nothing
+end
 
 function timestep!(
         vars::Variables,
@@ -72,7 +97,75 @@ function timestep!(
         snow_depth, soil_temperature, snow_melt_rate, snow_fall_rate, land_fraction,
         params,
     )
+
+    # snow on sea ice, only if enabled and there is sea ice to accumulate it on
+    snow.sea_ice_snow && sea_ice_snow_timestep!(vars, snow, snow_fall_rate, model)
     return nothing
+end
+
+"""$(TYPEDSIGNATURES)
+Time step the snow bucket on sea ice, a no-op unless both the snow on sea ice variable and a
+sea ice concentration are available."""
+function sea_ice_snow_timestep!(
+        vars::Variables,
+        snow::SnowModel,
+        snow_fall_rate,
+        model::PrimitiveEquation,
+    )
+    haskey(vars.prognostic.ocean, :snow_depth) || return nothing
+    haskey(vars.prognostic.ocean, :sea_ice_concentration) || return nothing
+
+    (; Δt) = model.time_stepping                            # time step [s]
+    (; land_fraction) = model.land_sea_mask
+    snow_depth = vars.prognostic.ocean.snow_depth           # per sea ice area [m]
+
+    # sea ice concentration at the current prognostic step, hence lagged by one sea ice update
+    ℵ = get_prognostic_step(vars.prognostic.ocean.sea_ice_concentration, model.time_stepping, model.sea_ice)
+
+    # surface air temperature drives the melt, no surface energy budget over sea ice available
+    (; surface_air_temperature) = vars.parameterizations
+    (; melting_threshold, snow_depth_cap, sea_ice_melt_factor, sea_ice_threshold) = snow
+
+    params = (; melting_threshold, snow_depth_cap, sea_ice_melt_factor, sea_ice_threshold, Δt)
+
+    launch!(
+        architecture(snow_depth), LinearWorkOrder, size(snow_depth), sea_ice_snow_kernel!,
+        snow_depth, ℵ, surface_air_temperature, snow_fall_rate, land_fraction,
+        params,
+    )
+    return nothing
+end
+
+@kernel inbounds = true function sea_ice_snow_kernel!(
+        snow_depth, ℵ, surface_air_temperature, snow_fall_rate, land_fraction,
+        params,
+    )
+    ij = @index(Global, Linear)             # every grid point ij
+
+    if land_fraction[ij] < 1                # at least partially ocean
+
+        (; melting_threshold, snow_depth_cap, sea_ice_melt_factor, sea_ice_threshold, Δt) = params
+
+        # snow depth is a depth per sea ice area, so accumulation is not weighted by concentration
+        # Term 1: snow fall rate from precipitation schemes [m/s]
+        snow_fall = snow_fall_rate[ij]
+
+        # Term 2: melt rate above the melting threshold [m/s], a degree-day-style melt as there is
+        # no prognostic sea ice surface temperature to close a surface energy budget with
+        T = surface_air_temperature[ij]
+        δT_melt = isfinite(T) ? max(T - melting_threshold, 0) : zero(T)
+        melt_rate = sea_ice_melt_factor * δT_melt
+
+        # don't melt more snow than there is, so the bucket cannot go negative
+        melt_rate = min(snow_depth[ij] / Δt, melt_rate)
+
+        # Euler forward time step, floored at 0 depth and capped as over land
+        snow_depth_forward = min(max(snow_depth[ij] + Δt * (snow_fall - melt_rate), 0), snow_depth_cap)
+
+        # snow disappears with the sea ice it sits on. Mass is not conserved here, the melt water
+        # is dropped rather than added to an ocean freshwater budget, which the model doesn't track
+        snow_depth[ij] = ifelse(ℵ[ij] < sea_ice_threshold, zero(snow_depth_forward), snow_depth_forward)
+    end
 end
 
 @kernel inbounds = true function land_snow_kernel!(

--- a/SpeedyWeather/src/parameterizations/surface_fluxes/heat.jl
+++ b/SpeedyWeather/src/parameterizations/surface_fluxes/heat.jl
@@ -59,6 +59,9 @@ with drag coefficients. Fields are $(TYPEDFIELDS)"""
 
     "[OPTION] Sea ice insulating surface heat fluxes [1]"
     @param sea_ice_insulation::NF = 0.01 (bounds = Positive,)
+
+    "[OPTION] Snow insulation depth [m], e-folding depth controlling how snow on sea ice insulates surface heat fluxes"
+    @param snow_insulation_depth::NF = 0.05 (bounds = Positive,)
 end
 
 Adapt.@adapt_structure SurfaceOceanHeatFlux
@@ -94,6 +97,12 @@ variables(::SurfaceOceanHeatFlux) = (
 
     # sea ice insulation: more sea ice ⇒ smaller flux (ℵ / ℵ₀ scaling)
     flux_ocean /= 1 + sea_ice_concentration / heat_flux.sea_ice_insulation
+
+    # snow on sea ice insulates further, weighted by the ice fraction it lies on so that it
+    # vanishes over open ocean. Snow depth is stored as a depth per sea ice area.
+    snow_depth_ocean = haskey(vars.prognostic.ocean, :snow_depth) ?
+        vars.prognostic.ocean.snow_depth[ij] : zero(ρ)
+    flux_ocean /= 1 + sea_ice_concentration * snow_depth_ocean / heat_flux.snow_insulation_depth
 
     # store without weighting by land fraction for coupling [W/m²]
     vars.parameterizations.ocean.sensible_heat_flux[ij] = flux_ocean * cₚ  # to store ocean flux separately too

--- a/SpeedyWeather/src/parameterizations/surface_fluxes/humidity.jl
+++ b/SpeedyWeather/src/parameterizations/surface_fluxes/humidity.jl
@@ -59,6 +59,9 @@ export SurfaceOceanHumidityFlux
 
     "[OPTION] Sea ice insulating surface humidity fluxes [1]"
     @param sea_ice_insulation::NF = 0.01 (bounds = 0 .. 1,)
+
+    "[OPTION] Snow insulation depth [m], e-folding depth controlling how snow on sea ice insulates surface humidity fluxes"
+    @param snow_insulation_depth::NF = 0.05 (bounds = Positive,)
 end
 
 Adapt.@adapt_structure SurfaceOceanHumidityFlux
@@ -97,6 +100,12 @@ variables(::SurfaceOceanHumidityFlux) = (
 
     # sea ice insulation: more sea ice ⇒ smaller flux (ℵ / ℵ₀ scaling)
     flux_ocean /= 1 + sea_ice_concentration / humidity_flux.sea_ice_insulation
+
+    # snow on sea ice insulates further, weighted by the ice fraction it lies on so that it
+    # vanishes over open ocean. Snow depth is stored as a depth per sea ice area.
+    snow_depth_ocean = haskey(vars.prognostic.ocean, :snow_depth) ?
+        vars.prognostic.ocean.snow_depth[ij] : zero(SST[ij])
+    flux_ocean /= 1 + sea_ice_concentration * snow_depth_ocean / humidity_flux.snow_insulation_depth
 
     # store without weighting by land fraction for coupling
     vars.parameterizations.ocean.surface_humidity_flux[ij] = flux_ocean

--- a/SpeedyWeather/test/parameterizations/snow_on_sea_ice.jl
+++ b/SpeedyWeather/test/parameterizations/snow_on_sea_ice.jl
@@ -1,0 +1,183 @@
+@testset "Snow on sea ice: flag off is inert" begin
+    spectral_grid = SpectralGrid(truncation = 15, nlayers = 5)
+
+    # default is off, so no snow depth variable in the ocean namespace
+    model = PrimitiveWetModel(spectral_grid)
+    vars = Variables(model)
+    @test model.land.snow.sea_ice_snow == false
+    @test !haskey(vars.prognostic.ocean, :snow_depth)
+
+    # explicitly on: variable is allocated and initialized to zero
+    land = LandModel(spectral_grid, snow = SnowModel(spectral_grid, sea_ice_snow = true))
+    model = PrimitiveWetModel(spectral_grid; land)
+    simulation = initialize!(model)
+    @test haskey(simulation.variables.prognostic.ocean, :snow_depth)
+    @test all(iszero, simulation.variables.prognostic.ocean.snow_depth)
+end
+
+@testset "Snow on sea ice: accumulation, melt and cap" begin
+    spectral_grid = SpectralGrid(truncation = 15, nlayers = 5)
+    snow = SnowModel(spectral_grid, sea_ice_snow = true, melting_threshold = 275, snow_depth_cap = 0.5)
+    land = LandModel(spectral_grid; snow)
+    model = PrimitiveWetModel(spectral_grid; land)
+    simulation = initialize!(model)
+    vars = simulation.variables
+
+    (; Δt) = model.time_stepping
+    S = vars.prognostic.ocean.snow_depth
+    ℵ = vars.prognostic.ocean.sea_ice_concentration
+    snow_fall_rate = vars.parameterizations.snow_rate
+
+    # fully ice covered everywhere, so the land-sea mask is the only mask left
+    fill!(ℵ, 1)
+    ocean = model.land_sea_mask.land_fraction .< 1
+
+    # ACCUMULATION: constant snow fall, no melt (surface air temperature below threshold)
+    fill!(snow_fall_rate, 1.0e-5)
+    fill!(vars.parameterizations.surface_air_temperature, 250)
+    fill!(S, 0)
+
+    SpeedyWeather.sea_ice_snow_timestep!(vars, snow, snow_fall_rate, model)
+    @test all(S[ocean] .≈ 1.0e-5 * Δt)       # depth per ice area, not weighted by concentration
+
+    SpeedyWeather.sea_ice_snow_timestep!(vars, snow, snow_fall_rate, model)
+    @test all(S[ocean] .≈ 2.0e-5 * Δt)       # accumulates further
+
+    # MELT: no snow fall, surface air temperature above the melting threshold
+    fill!(snow_fall_rate, 0)
+    fill!(vars.parameterizations.surface_air_temperature, 285)
+    S_before = copy(S)
+    SpeedyWeather.sea_ice_snow_timestep!(vars, snow, snow_fall_rate, model)
+    @test all(S[ocean] .< S_before[ocean])   # monotonically decreasing
+    @test all(S .>= 0)                       # floored at zero
+
+    # melt to exhaustion never goes negative
+    for _ in 1:50
+        SpeedyWeather.sea_ice_snow_timestep!(vars, snow, snow_fall_rate, model)
+    end
+    @test all(S .>= 0)
+
+    # CAP: heavy snow fall, no melt, capped at snow_depth_cap
+    fill!(snow_fall_rate, 1)
+    fill!(vars.parameterizations.surface_air_temperature, 250)
+    for _ in 1:5
+        SpeedyWeather.sea_ice_snow_timestep!(vars, snow, snow_fall_rate, model)
+    end
+    @test maximum(S) <= snow.snow_depth_cap
+end
+
+@testset "Snow on sea ice: disappears with the sea ice" begin
+    spectral_grid = SpectralGrid(truncation = 15, nlayers = 5)
+    snow = SnowModel(spectral_grid, sea_ice_snow = true)
+    land = LandModel(spectral_grid; snow)
+    model = PrimitiveWetModel(spectral_grid; land)
+    simulation = initialize!(model)
+    vars = simulation.variables
+
+    S = vars.prognostic.ocean.snow_depth
+    ℵ = vars.prognostic.ocean.sea_ice_concentration
+    snow_fall_rate = vars.parameterizations.snow_rate
+
+    fill!(S, 0.2)                            # start from a nonzero snow cover on ice
+    fill!(snow_fall_rate, 0)
+    fill!(vars.parameterizations.surface_air_temperature, 250)   # no melt
+
+    fill!(ℵ, 1)                              # ice present: snow survives
+    SpeedyWeather.sea_ice_snow_timestep!(vars, snow, snow_fall_rate, model)
+    @test all(S[model.land_sea_mask.land_fraction .< 1] .≈ 0.2)
+
+    fill!(ℵ, 0)                              # ice gone: snow goes with it
+    SpeedyWeather.sea_ice_snow_timestep!(vars, snow, snow_fall_rate, model)
+    @test all(iszero, S[model.land_sea_mask.land_fraction .< 1])
+end
+
+@testset "Snow on sea ice: albedo response" begin
+    spectral_grid = SpectralGrid(truncation = 15, nlayers = 5)
+    albedo = OceanLandAlbedo(ocean = OceanSeaIceAlbedo(spectral_grid), land = LandSnowAlbedo(spectral_grid))
+    snow = SnowModel(spectral_grid, sea_ice_snow = true)
+    land = LandModel(spectral_grid; snow)
+    model = PrimitiveWetModel(spectral_grid; land, albedo)
+    simulation = initialize!(model)
+    vars = simulation.variables
+
+    scheme = model.albedo.ocean
+    a = vars.parameterizations.ocean.albedo
+    S = vars.prognostic.ocean.snow_depth
+    ℵ = vars.prognostic.ocean.sea_ice_concentration
+
+    ij = 1
+    fill!(ℵ, 1)                              # full ice cover
+    fill!(S, 0)
+    SpeedyWeather.albedo!(ij, a, vars, scheme, model)
+    albedo_no_snow = a[ij]
+
+    fill!(S, 0.2)                            # snow raises the albedo over ice
+    SpeedyWeather.albedo!(ij, a, vars, scheme, model)
+    @test a[ij] > albedo_no_snow
+    @test 0 <= a[ij] <= 1
+
+    fill!(ℵ, 0)                              # no ice: snow has no effect
+    SpeedyWeather.albedo!(ij, a, vars, scheme, model)
+    albedo_snow_no_ice = a[ij]
+    fill!(S, 0)
+    SpeedyWeather.albedo!(ij, a, vars, scheme, model)
+    @test a[ij] ≈ albedo_snow_no_ice
+    @test a[ij] ≈ scheme.albedo_ocean
+
+    # clamped to 1 even when albedo_ice + albedo_snow > 1
+    scheme2 = OceanSeaIceAlbedo(spectral_grid, albedo_ice = 0.9, albedo_snow = 0.9, snow_depth_scale = 0.01)
+    fill!(ℵ, 1)
+    fill!(S, 10)
+    SpeedyWeather.albedo!(ij, a, vars, scheme2, model)
+    @test a[ij] <= 1
+end
+
+@testset "Snow on sea ice: flux insulation" begin
+    spectral_grid = SpectralGrid(truncation = 15, nlayers = 5)
+    snow = SnowModel(spectral_grid, sea_ice_snow = true)
+    land = LandModel(spectral_grid; snow)
+    model = PrimitiveWetModel(spectral_grid; land)
+    simulation = initialize!(model)
+    vars = simulation.variables
+
+    # set the surface state the fluxes read from, not defined before the first time step
+    fill!(vars.parameterizations.surface_air_temperature, 280)
+    fill!(vars.parameterizations.surface_air_density, 1.2)
+    fill!(vars.parameterizations.surface_wind_speed, 10)
+    fill!(vars.parameterizations.surface_pressure, 1.0e5)
+    fill!(vars.parameterizations.boundary_layer_drag, 1.0e-3)
+    fill!(vars.grid.humidity, 0)
+
+    S = vars.prognostic.ocean.snow_depth
+    ℵ = vars.prognostic.ocean.sea_ice_concentration
+
+    # pick an ocean point with a defined sea surface temperature, over land the SST is NaN
+    SST = SpeedyWeather.get_prognostic_step(vars.prognostic.ocean.sea_surface_temperature, model.time_stepping, model.ocean)
+    ij = findfirst(ij -> model.land_sea_mask.land_fraction[ij] < 1 && isfinite(SST[ij]), eachindex(S))
+    @test ij !== nothing
+
+    @testset for (flux, field) in (
+            (model.surface_heat_flux.ocean, :sensible_heat_flux),
+            (model.surface_humidity_flux.ocean, :surface_humidity_flux),
+        )
+        f! = field == :sensible_heat_flux ? SpeedyWeather.surface_heat_flux! : SpeedyWeather.surface_humidity_flux!
+        out = getproperty(vars.parameterizations.ocean, field)
+
+        fill!(ℵ, 1)                          # full ice cover
+        fill!(S, 0)
+        f!(ij, vars, flux, model)
+        flux_no_snow = abs(out[ij])
+
+        fill!(S, 0.5)                        # snow insulates: smaller flux magnitude
+        f!(ij, vars, flux, model)
+        @test abs(out[ij]) < flux_no_snow
+
+        fill!(ℵ, 0)                          # no ice: snow has no effect
+        fill!(S, 0)
+        f!(ij, vars, flux, model)
+        flux_open_ocean = abs(out[ij])
+        fill!(S, 0.5)
+        f!(ij, vars, flux, model)
+        @test abs(out[ij]) ≈ flux_open_ocean
+    end
+end

--- a/docs/dev/2026-09/snow-on-sea-ice.md
+++ b/docs/dev/2026-09/snow-on-sea-ice.md
@@ -1,0 +1,229 @@
+# Snow on sea ice
+
+> Status: **planned**. Awaiting human sign-off before implementation.
+
+Date of initial draft: 2026-09-03
+
+Base revision: e7c569df
+
+## Originating prompt
+
+> Our SnowModel accumulates snow over land but not over the ocean where it would melt in the
+> water. But at the moment we don't account for snow landing on sea ice where it should have an
+> effect on albedo and flux insulation. When the sea ice melts the snow should disappear. Can you
+> make changes to the code to implement this with a flag in the snow model to enable/disable this
+> effect?
+
+Design decisions taken from a follow-up clarification with the user:
+
+- Snow depth over sea ice is stored **per unit ice area**, not as a grid-cell mean.
+- Snow disappears both **on sea ice retreat** and by **melting when the surface air temperature
+  exceeds the melting threshold**.
+- All three couplings are wired in: **albedo**, **sensible heat flux**, **humidity flux**.
+
+## Revision log
+
+- 2026-09-03: initial draft.
+
+## Problem description
+
+`SnowModel` (`SpeedyWeather/src/parameterizations/land/snow.jl`) only accumulates snow where
+`land_fraction[ij] > 0`; its kernel is guarded by that condition and its prognostic variable
+`snow_depth` lives in the `:land` namespace. Over the ocean, falling snow is implicitly assumed to
+melt on contact with the water, which is correct for open ocean but wrong over sea ice: in reality
+snow accumulates on the ice, where it substantially raises the surface albedo and insulates the
+surface turbulent fluxes. When the ice melts away, the snow it carried must go with it.
+
+The model already has all the surrounding machinery:
+
+- `ThermodynamicSeaIce` (`parameterizations/sea_ice.jl`) carries a prognostic sea ice concentration
+  `sea_ice_concentration` (ℵ) in the `:ocean` namespace.
+- `OceanSeaIceAlbedo` (`parameterizations/albedo.jl`) already blends ocean and ice albedo by ℵ, and
+  `LandSnowAlbedo` already has snow-cover schemes (`LinearSnowCover`, `SaturatingSnowCover`) that
+  map snow depth to a cover fraction.
+- `SurfaceOceanHeatFlux` / `SurfaceOceanHumidityFlux` already damp their fluxes by a
+  `sea_ice_insulation` factor, and their land counterparts already damp by a
+  `snow_insulation_depth` factor — the exact form we want to reuse over ice.
+
+What is missing is a snow reservoir over the ice and the wiring of that reservoir into these three
+consumers.
+
+## Background
+
+The land snow budget in `land_snow_kernel!` is a bucket in equivalent liquid water depth [m]:
+snow falls at `snow_rate` [m/s], melts at a rate limited by the energy available from the top soil
+layer being above `melting_threshold`, is floored at 0 and capped at `snow_depth_cap`. The excess
+melt that could not be drawn from the bucket is folded into `snow_melt_rate` for the soil moisture
+model.
+
+Over sea ice there is no prognostic ice surface temperature and no soil layer, so the land energy
+argument does not carry over. The available thermal driver is
+`vars.parameterizations.surface_air_temperature`, which is what this plan uses. This is
+deliberately a simple degree-day-style melt rather than a closed surface energy budget — see
+*Known limitations*.
+
+Note also that the two snow sinks act on different quantities. Melting removes snow mass. Ice
+retreat does not melt the snow *per unit ice area* — it removes the area that was carrying it.
+Because we store depth per ice area, retreat is represented by rescaling the reservoir so that the
+total snow mass `ℵ·S` is reduced in proportion to the lost ice area, which for a per-area depth `S`
+means `S` is unchanged by retreat alone but the mass it represents drops with ℵ automatically. To
+make the snow actually *disappear* when the ice does — as the prompt requires — we additionally
+zero the reservoir once ℵ falls below a small threshold. See *Summary of changes*, item 3.
+
+## Summary of changes
+
+### 1. Flag and parameters on `SnowModel`
+
+Add to `SnowModel{NF}` in `parameterizations/land/snow.jl`:
+
+```julia
+"[OPTION] Accumulate snow on sea ice, affecting albedo and surface fluxes"
+sea_ice_snow::Bool = false
+
+"[OPTION] Sea ice concentration below which snow on sea ice is removed entirely [1]"
+@param sea_ice_threshold::NF = 0.01 (bounds = 0 .. 1,)
+```
+
+`sea_ice_snow` defaults to `false` so existing setups are bit-for-bit unchanged. It is a plain
+`Bool` field, not a `@param`, since it is a structural switch rather than a calibratable number.
+`snow_depth_cap` and `melting_threshold` are shared with the land budget.
+
+### 2. New prognostic variable
+
+Extend `variables(snow::SnowModel)` to conditionally declare
+
+```julia
+PrognosticVariable(:snow_depth, Grid2D(), namespace = :ocean, units = "m",
+                   desc = "Snow depth on sea ice in equivalent liquid water height")
+```
+
+only when `snow.sea_ice_snow` is `true`, so the allocation is skipped when the feature is off.
+This makes `variables` depend on the flag's value, which is already the pattern used elsewhere for
+optional components. It lives in the `:ocean` namespace (accessed as
+`vars.prognostic.ocean.snow_depth`) because its lifecycle is tied to sea ice, not to land.
+`initialize!(vars, snow, model)` sets it to 0 alongside the land field.
+
+All consumers access it defensively via
+`haskey(vars.prognostic.ocean, :snow_depth)`, falling back to zero — matching how
+`sea_ice_concentration` is already accessed throughout. This means no consumer needs to know
+about the flag, and the feature degrades cleanly for models without sea ice.
+
+### 3. Sea ice snow budget
+
+Add `sea_ice_snow_kernel!` and launch it from `timestep!(vars, snow::SnowModel, model)` when
+`snow.sea_ice_snow` is true and both `sea_ice_concentration` and the ocean `snow_depth` are
+present. Per grid point, guarded by `land_fraction[ij] < 1` (at least partially ocean):
+
+1. **Accumulation.** `snow_rate[ij]` [m/s] falls on the ice. Because `S` is a per-ice-area depth,
+   accumulation is *not* weighted by ℵ.
+2. **Melt.** `δT = max(surface_air_temperature[ij] - melting_threshold, 0)`, giving a melt rate
+   `melt_rate = melt_factor * δT` with a new
+   `@param sea_ice_melt_factor::NF = 1e-7 (bounds = Nonnegative,)` [m/s/K] on `SnowModel`. As on
+   land, melt is limited to the snow actually available, `min(S/Δt, melt_rate)`, so the bucket
+   cannot go negative.
+3. **Removal on ice retreat.** After the Euler-forward step,
+   `S = ifelse(ℵ[ij] < sea_ice_threshold, 0, S)` — when the ice is gone, so is the snow. ℵ is read
+   at the current prognostic step via `get_prognostic_step(..., model.sea_ice)`.
+4. **Cap.** `S = min(S, snow_depth_cap)`, as on land.
+
+The melt water is *not* routed anywhere: over ocean it joins the ocean, which the model does not
+track as a freshwater budget. This is a genuine (small) mass-conservation gap, noted below.
+
+Ordering: `timestep!(vars, land.snow, model)` runs inside the land timestep, and the sea ice
+timestep runs separately in the main loop. The sea ice snow update reads ℵ from the current
+prognostic step, so it sees the ice state from the previous sea-ice update. This one-step lag is
+consistent with how other cross-component couplings in the model already work.
+
+### 4. Albedo coupling
+
+Give `OceanSeaIceAlbedo` the same snow fields `LandSnowAlbedo` has:
+
+```julia
+@param albedo_snow::NF = 0.4 (bounds = 0 .. 1,)
+@param snow_depth_scale::NF = 0.05 (bounds = Positive,)
+@param snow_cover::Scheme = SaturatingSnowCover() (group = :snow_cover,)
+```
+
+and in `albedo!` blend the snow contribution over the ice fraction only:
+
+```julia
+albedo[ij] = albedo_ocean + ℵ * (albedo_ice - albedo_ocean)
+# snow sits on the ice, so weight its contribution by the ice fraction
+albedo[ij] += ℵ * snow_cover * albedo_snow
+```
+
+with `snow_cover = snow_cover_scheme(snow_depth_ocean[ij], snow_depth_scale)`. The result is
+clamped to 1 so that `albedo_ice + albedo_snow > 1` cannot produce an unphysical albedo. This adds
+a type parameter `Scheme` to `OceanSeaIceAlbedo`, which is a breaking change to that struct's type
+signature (keyword construction is unaffected).
+
+### 5. Surface flux coupling
+
+Add `snow_insulation_depth::NF = 0.05` to `SurfaceOceanHeatFlux` and `SurfaceOceanHumidityFlux`,
+and apply it after the existing sea ice insulation:
+
+```julia
+flux_ocean /= 1 + sea_ice_concentration / heat_flux.sea_ice_insulation
+# snow on sea ice insulates further, weighted by the ice fraction it sits on
+flux_ocean /= 1 + sea_ice_concentration * snow_depth / heat_flux.snow_insulation_depth
+```
+
+The `sea_ice_concentration` weight is what makes this vanish over open ocean. The two divisions
+compose the same way the land scheme composes its own damping factors.
+
+## Testing and verification
+
+New file `SpeedyWeather/test/parameterizations/snow_on_sea_ice.jl`, kept short per the repo
+convention, covering:
+
+1. **Flag off is inert.** With `sea_ice_snow = false`, `vars.prognostic.ocean` has no
+   `snow_depth` key, and a short `PrimitiveWetModel` run reproduces the unmodified result exactly.
+2. **Accumulation.** With the flag on, prescribed ℵ = 1 and a prescribed `snow_rate`, snow depth
+   over ice grows by `snow_rate * Δt` per step and stays 0 over land-free open ocean.
+3. **Melt.** With surface air temperature above `melting_threshold` and no snowfall, snow depth
+   decreases monotonically and is floored at 0, never negative.
+4. **Disappearance on ice melt.** Starting from nonzero snow depth, setting ℵ to 0 zeroes the snow
+   depth on the next timestep.
+5. **Cap.** Snow depth never exceeds `snow_depth_cap`.
+6. **Albedo response.** `OceanSeaIceAlbedo` returns a strictly larger albedo with snow than
+   without at ℵ = 1, equal albedo at ℵ = 0, and stays within [0, 1] even for
+   `albedo_ice + albedo_snow > 1`.
+7. **Flux insulation.** `SurfaceOceanHeatFlux` and `SurfaceOceanHumidityFlux` magnitudes decrease
+   with snow depth at ℵ = 1 and are unchanged at ℵ = 0.
+
+Run with `--check-bounds=yes` per the repo convention. A short `PrimitiveWetModel` run with the
+flag enabled will also be checked for stability (no NaNs) on both `Float32` and `Float64`.
+
+GPU correctness is inherited from the kernel form — the new kernel uses only `ifelse`/`min`/`max`
+and no branching on data — but is not separately tested here.
+
+## Documentation changes
+
+- Docstrings on all new fields, following the existing `"[OPTION] ..."` convention.
+- The land/snow section of the documentation gains a short subsection on snow over sea ice,
+  documenting the flag, the budget, and the three couplings.
+- `CHANGELOG.md` entry under `## Unreleased`.
+- Version bump for `SpeedyWeather` (new public option and a changed struct signature on
+  `OceanSeaIceAlbedo`, so a minor bump with `-DEV`).
+
+## Known limitations
+
+- **No surface energy budget over ice.** Melt is a tuned degree-day function of surface air
+  temperature, not a closed energy balance. The `sea_ice_melt_factor` default of 1e-7 m/s/K is a
+  plausible order of magnitude, not a calibrated value.
+- **Melt water is not conserved.** Snow melting on sea ice is dropped rather than added to an
+  ocean freshwater budget, which the model does not currently track.
+- **Snow does not insulate the ice itself.** The insulation acts on the atmosphere-surface fluxes
+  only; it does not slow the `ThermodynamicSeaIce` growth/melt, so snow cannot yet preserve ice
+  through a warm season.
+- **No blowing snow, no snow-ice formation, no flooding** of thick snow depressing the ice below
+  sea level.
+- **One-step lag** between the sea ice update and the snow-on-ice update, as described above.
+
+## Future work
+
+- Couple snow insulation into the `ThermodynamicSeaIce` budget so snow cover feeds back on ice
+  survival.
+- Replace the degree-day melt with a surface energy balance once a prognostic ice surface
+  temperature exists.
+- Track snow-on-ice mass in a conservation diagnostic alongside the land snow budget.

--- a/docs/src/land.md
+++ b/docs/src/land.md
@@ -323,6 +323,49 @@ The total albedo is higher over already brighter areas (low vegetation cover)
 and lower over darker areas. This somewhat reflects that in forests the
 snow cover is broken up and snow lies in between trees.
 
+### Snow on sea ice
+
+By default snow only lies on land; over the ocean it is assumed to melt on contact with the water.
+That is right for open ocean but not over sea ice, where snow accumulates and substantially
+brightens and insulates the surface. Setting the `sea_ice_snow` flag enables a second snow bucket
+over sea ice
+
+```julia
+snow = SnowModel(spectral_grid, sea_ice_snow=true)
+land = LandModel(spectral_grid; snow)
+model = PrimitiveWetModel(spectral_grid; land)
+```
+
+which adds the prognostic variable `variables.prognostic.ocean.snow_depth`, again in equivalent
+liquid water height. It is a depth **per unit sea ice area**, not a grid-cell mean, so accumulation
+is not weighted by the sea ice concentration ``ℵ`` while all its effects below are. The budget is
+
+```math
+\frac{dS}{dt} = P - M, \qquad M = \min\left(\frac{S}{\Delta t},\ \text{sea\_ice\_melt\_factor} \cdot \max(T_s - \text{melting\_threshold},\ 0)\right)
+```
+
+with the snow fall rate ``P`` as over land and the surface air temperature ``T_s``. Unlike the land
+budget, the melt is a degree-day-style function of air temperature rather than a closed surface
+energy balance, because there is no prognostic sea ice surface temperature to build one from.
+The bucket is capped at `snow_depth_cap` as over land.
+
+When the sea ice retreats the snow it carried goes with it: once ``ℵ`` drops below
+`sea_ice_threshold` (0.01 by default) the bucket is emptied. The melt water is not routed into an
+ocean freshwater budget, which the model does not track, so this snow sink does not conserve mass.
+
+Snow on sea ice then feeds into three places, in each case weighted by ``ℵ`` so that the effect
+vanishes over open ocean:
+
+- `OceanSeaIceAlbedo` adds ``ℵ σₛ albedo_{snow}`` on top of the ocean/ice mixture, using the same
+  snow-cover schemes as over land, clamped so the total albedo cannot exceed 1.
+- `SurfaceOceanHeatFlux` damps the sensible heat flux by a further factor
+  ``1 + ℵ S / \text{snow\_insulation\_depth}``.
+- `SurfaceOceanHumidityFlux` damps the evaporative flux the same way.
+
+Note that snow does not currently insulate the sea ice *itself*: the insulation acts on the
+atmosphere-surface fluxes only and does not enter the [Sea ice](@ref) growth and melt budget, so
+snow cover cannot yet help ice survive a warm season.
+
 ## Albedo
 
 Albedo is the surface reflectivity to downward solar shortwave radiation.


### PR DESCRIPTION
## What this does

`SnowModel` currently accumulates snow only where `land_fraction > 0`; over the ocean falling snow is implicitly assumed to melt on contact with the water. That is right for open ocean but wrong over sea ice, where snow accumulates and substantially brightens and insulates the surface.

This PR adds an optional second snow bucket over sea ice, enabled with a flag:

```julia
snow = SnowModel(spectral_grid, sea_ice_snow=true)
land = LandModel(spectral_grid; snow)
model = PrimitiveWetModel(spectral_grid; land)
```

The flag defaults to `false`, and when off the new prognostic variable is not even allocated, so existing setups are unchanged.

### Snow budget

The new prognostic `variables.prognostic.ocean.snow_depth` is in equivalent liquid water height, stored as a depth **per unit sea ice area** rather than a grid-cell mean. Accumulation is therefore not weighted by the sea ice concentration ℵ, while all of its effects below are:

```
dS/dt = P - M,   M = min(S/Δt, sea_ice_melt_factor · max(Tₛ - melting_threshold, 0))
```

with the snow fall rate `P` as over land and the surface air temperature `Tₛ`. The bucket is capped at `snow_depth_cap` and floored at zero, and is emptied entirely once ℵ drops below `sea_ice_threshold` (0.01 by default) — so when the sea ice melts, the snow disappears with it.

### Couplings

Each is weighted by ℵ so the effect vanishes over open ocean:

- **`OceanSeaIceAlbedo`** gains `albedo_snow`, `snow_depth_scale` and `snow_cover`, reusing the existing `LinearSnowCover`/`SaturatingSnowCover` schemes, and adds `ℵ·σₛ·albedo_snow` on top of the ocean/ice mixture. Clamped so the total albedo cannot exceed 1 even when `albedo_ice + albedo_snow > 1`.
- **`SurfaceOceanHeatFlux`** and **`SurfaceOceanHumidityFlux`** each gain a `snow_insulation_depth`, damping the flux by a further factor `1 + ℵ·S/snow_insulation_depth`, mirroring the existing land snow insulation.

The `AbstractSnowCover` block moved up `albedo.jl` so the ocean albedo can reuse it; no behaviour change there.

## Limitations

Deliberately kept simple for a first version — worth being explicit about what this does *not* do:

- **No surface energy budget over sea ice.** There is no prognostic sea ice surface temperature to close one with, so melt is a degree-day-style function of surface air temperature. The `sea_ice_melt_factor` default of `1e-7` m/s/K is a plausible order of magnitude, **not a calibrated value**, and should be tuned before this is used for anything quantitative.
- **Melt water is not conserved.** Snow melting on sea ice is dropped rather than added to an ocean freshwater budget, which the model does not track. This snow sink therefore violates mass conservation, in the same spirit as the existing `snow_depth_cap` over land.
- **Snow does not insulate the sea ice itself.** The insulation acts on the atmosphere–surface turbulent fluxes only; it does not enter the `ThermodynamicSeaIce` growth/melt budget, so snow cover cannot yet help ice survive a warm season. This is probably the most important follow-up.
- **One-step lag.** The snow-on-ice update reads ℵ at the current prognostic step, so it sees the ice state from the previous sea ice update, consistent with other cross-component couplings in the model.
- **No blowing snow, no snow-ice formation, no flooding** of thick snow depressing the ice below sea level.

## Testing

New `SpeedyWeather/test/parameterizations/snow_on_sea_ice.jl`, 22 tests, all passing under `--check-bounds=yes`:

- flag off is inert (no `snow_depth` key in the ocean namespace, zero-initialized when on)
- accumulation is unweighted by ℵ and accumulates across steps
- melt is monotonic, floored at zero, and never goes negative when melting to exhaustion
- depth never exceeds `snow_depth_cap`
- snow is zeroed when ℵ drops to 0
- albedo increases with snow at ℵ=1, is unchanged at ℵ=0, and stays within [0, 1] when `albedo_ice + albedo_snow > 1`
- heat and humidity flux magnitudes decrease with snow depth at ℵ=1 and are unchanged at ℵ=0

Existing `albedo.jl`, `land.jl`, `surface_fluxes.jl` and `ocean_sea_ice.jl` all still pass. A 5-day `PrimitiveWetModel` run with the flag enabled is stable, with snow accumulating on 65 grid points and no NaNs.

## Notes

- Implementation plan in `docs/dev/2026-09/snow-on-sea-ice.md`.
- Docs section added to `docs/src/land.md`.
- `SpeedyWeather` version bumped to `0.23.0-DEV`: `OceanSeaIceAlbedo` gains a type parameter for the snow-cover scheme, which is breaking for its type signature (keyword construction is unaffected).
